### PR TITLE
Update operandconfig instance

### DIFF
--- a/pkg/bootstrap/constant.go
+++ b/pkg/bootstrap/constant.go
@@ -221,7 +221,6 @@ spec:
     spec:
       commonWebUI: {}
       legacyHeader: {}
-      navconfiguration: {}
   - name: ibm-management-ingress-operator
     spec:
       managementIngress: {}


### PR DESCRIPTION
This PR is to update `operandconfig` instance, remove `navconfiguration: {}` from ibm-commonui.