### PR TITLE
add operandbindinfo, and dependency request for IBM Licensing

### DIFF
--- a/pkg/bootstrap/constant.go
+++ b/pkg/bootstrap/constant.go
@@ -196,6 +196,8 @@ spec:
   - name: ibm-licensing-operator
     spec:
       IBMLicensing: {}
+      OperandBindInfo: {}
+      OperandRequest: {}
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}


### PR DESCRIPTION
This PR makes adding bindinfo and dependency request for IBM Licensing as default