### PR TITLE
added yaml file for deployment secretshare_deploy.yaml

### DIFF
--- a/build/resources/extra/example-sa.yaml
+++ b/build/resources/extra/example-sa.yaml
@@ -1,6 +1,0 @@
-# TODO: remove this file
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: example-sa
-  namespace: ibm-common-services

--- a/build/resources/extra/secretshare_deploy.yaml
+++ b/build/resources/extra/secretshare_deploy.yaml
@@ -26,6 +26,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: secretshare
+  namespace: ibm-common-services
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -129,6 +130,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: secretshare
+  namespace: ibm-common-services
 spec:
   replicas: 1
   selector:

--- a/build/resources/extra/secretshare_deploy.yaml
+++ b/build/resources/extra/secretshare_deploy.yaml
@@ -1,0 +1,219 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: secretshares.ibmcpcs.ibm.com
+spec:
+  group: ibmcpcs.ibm.com
+  names:
+    kind: SecretShare
+    listKind: SecretShareList
+    plural: secretshares
+    singular: secretshare
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: secretshare
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: secretshare
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  - services
+  - services/finalizers
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - secretshare
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+  - get
+  - list
+  - watch
+  - apiGroups:
+  - ibmcpcs.ibm.com
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ibmcpcs.ibm.com
+  resources:
+  - secretshares
+  - secretshares/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: secretshare-ibm-common-services
+subjects:
+- kind: ServiceAccount
+  name: secretshare
+  namespace: ibm-common-services
+roleRef:
+  kind: ClusterRole
+  name: secretshare
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secretshare
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: secretshare
+  template:
+    metadata:
+      labels:
+        name: secretshare
+    spec:
+      serviceAccountName: secretshare
+      containers:
+        - name: ansible
+          command:
+          - /usr/local/bin/ao-logs
+          - /tmp/ansible-operator/runner
+          - stdout
+          # Replace this with the built image name
+          image: "stocktraderdemo/secretshare:v1.0"
+          imagePullPolicy: "Always"
+          volumeMounts:
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+            readOnly: true
+        - name: operator
+          # Replace this with the built image name
+          image: "stocktraderdemo/secretshare:v1.0"
+          imagePullPolicy: "Always"
+          volumeMounts:
+          - mountPath: /tmp/ansible-operator/runner
+            name: runner
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "secretshare"
+            - name: ANSIBLE_GATHERING
+              value: explicit
+      volumes:
+        - name: runner
+          emptyDir: {}
+---
+apiVersion: ibmcpcs.ibm.com/v1
+kind: SecretShare
+metadata:
+  name: common-services
+  namespace: ibm-common-services
+spec:
+  # Secrets to share for adopter compatibility to Common Services 3.2.4
+  secretshares:
+  - secretname: icp-management-ingress-tls-secret
+    sharewith:
+    - namespace: kube-system
+    - namespace: kube-system
+      name: route-tls-secret 
+  - secretname: icp-metering-api-secret
+    sharewith:
+    - namespace: kube-system
+  - secretname: oauth-client-secret
+    sharewith:
+    - namespace: services
+  - secretname: ibmcloud-cluster-ca-cert
+    sharewith:
+    - namespace: kube-public
+  # ConfigMaps to share for adopter compatibility to Common Services 3.2.4
+  configmapshares: 
+  - configmapname: oauth-client-map
+    sharewith:
+    - namespace: services
+  - configmapname: ibm-cloud-info
+    sharewith:
+    - namespace: kube-system
+  - configmapname: ibmcloud-cluster-info
+    sharewith:
+    - namespace: kube-public
+  - configmapname: common-web-ui-config
+    sharewith:
+    - namespace: kube-system
+  - configmapname: common-web-ui-log4js
+    sharewith:
+    - namespace: kube-system
+  


### PR DESCRIPTION
Added a yaml file that should be deployed in ibm-common-services to perform secret sharing for backward compatibility with 3.2.4.

This will be adjusted for the proper image registry - the current one is temmporary