### PR TITLE
creating a separate registry and config for the dev channel

### DIFF
--- a/build/resources/cs-operandconfig.yaml
+++ b/build/resources/cs-operandconfig.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig
 metadata:
-  name: common-service
+  name: common-service-dev
   namespace: ibm-common-services
   annotations:
     version: "1"
@@ -86,6 +86,82 @@ spec:
     spec:
       grafana: {}
       operandRequest: {}
+  - name: ibm-elastic-stack-operator
+    spec:
+      elasticStack: {}
+---
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service
+  namespace: ibm-common-services
+  annotations:
+    version: "1"
+spec:
+  services:
+  - name: ibm-metering-operator
+    spec:
+      metering: {}
+      meteringUI: {}
+  - name: ibm-licensing-operator
+    spec:
+      IBMLicensing: {}
+  - name: ibm-mongodb-operator
+    spec:
+      mongoDB: {}
+  - name: ibm-cert-manager-operator
+    spec:
+      certManager: {}
+      issuer: {}
+      certificate: {}
+      clusterIssuer: {}
+  - name: ibm-iam-operator
+    spec:
+      authentication: {}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+  - name: ibm-healthcheck-operator
+    spec:
+      healthService: {}
+  - name: ibm-commonui-operator
+    spec:
+      commonWebUI: {}
+      legacyHeader: {}
+      navconfiguration: {}
+  - name: ibm-management-ingress-operator
+    spec:
+      managementIngress: {}
+  - name: ibm-ingress-nginx-operator
+    spec:
+      nginxIngress: {}
+  - name: ibm-auditlogging-operator
+    spec:
+      auditLogging: {}
+  - name: ibm-catalog-ui-operator
+    spec:
+      catalogUI: {}
+  - name: ibm-platform-api-operator
+    spec:
+      platformApi: {}
+  - name: ibm-helm-api-operator
+    spec:
+      helmApi: {}
+  - name: ibm-helm-repo-operator
+    spec:
+      helmRepo: {}
+  - name: ibm-monitoring-exporters-operator
+    spec:
+      exporter: {}
+  - name: ibm-monitoring-prometheusext-operator
+    spec:
+      prometheusExt: {}
+  - name: ibm-monitoring-grafana-operator
+    spec:
+      grafana: {}
   - name: ibm-elastic-stack-operator
     spec:
       elasticStack: {}

--- a/build/resources/cs-operandregistry.yaml
+++ b/build/resources/cs-operandregistry.yaml
@@ -1,7 +1,7 @@
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
-  name: common-service
+  name: common-service-dev
   namespace: ibm-common-services
   annotations:
     version: "1"
@@ -129,5 +129,143 @@ spec:
     namespace: ibm-common-services
     packageName: ibm-elastic-stack-operator-app
     scope: public
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+--- 
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: ibm-common-services
+  annotations:
+    version: "1"
+spec:
+  operators:
+  - name: ibm-metering-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-metering-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: The service used to meter workloads in a kubernetes cluster
+  - name: ibm-licensing-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-licensing-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: The service used to management the license in a kubernetes cluster
+  - name: ibm-mongodb-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-mongodb-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: The service used to create mongodb in a kubernetes cluster
+  - name: ibm-cert-manager-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-cert-manager-operator
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of cert-manager service.
+  - name: ibm-iam-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-iam-operator
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of iam service.
+  - name: ibm-healthcheck-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-healthcheck-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of health check service.
+  - name: ibm-commonui-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-commonui-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: The service that services the login page, common header, LDAP, and Team resources pages
+  - name: ibm-management-ingress-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-management-ingress-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of management ingress service.
+  - name: ibm-ingress-nginx-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-ingress-nginx-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of ingress nginx service.
+  - name: ibm-auditlogging-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-auditlogging-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of auditlogging service.
+  - name: ibm-catalog-ui-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-catalog-ui-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of catalog UI service.
+  - name: ibm-platform-api-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-platform-api-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of Platform API service.
+  - name: ibm-helm-api-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-helm-api-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of Helm API service.
+  - name: ibm-helm-repo-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-helm-repo-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator for managing deployment of Helm repository service.
+  - name: ibm-monitoring-exporters-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-monitoring-exporters-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator to provision node-exporter, kube-state-metrics and collectd exporter with tls enabled.
+  - name: ibm-monitoring-prometheusext-operator
+    namespace: ibm-common-services
+    channel: stable-v1
+    packageName: ibm-monitoring-prometheusext-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator to deploy Prometheus and Alertmanager instances with RBAC enabled. It will also enable Multicloud monitoring.
+  - channel: stable-v1
+    description: Operator to deploy Grafana instances with RBAC enabled.
+    name: ibm-monitoring-grafana-operator
+    namespace: ibm-common-services
+    packageName: ibm-monitoring-grafana-operator-app
+    scope: private
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+  - channel: stable-v1
+    description: Operator that installs and manages Elastic Stack logging service instances. 
+    name: ibm-elastic-stack-operator
+    namespace: ibm-common-services
+    packageName: ibm-elastic-stack-operator-app
+    scope: private
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace

--- a/docs/cloudpak-integration.md
+++ b/docs/cloudpak-integration.md
@@ -45,7 +45,7 @@ In CloudPak Operator CSV file, add following content.
 
 This can ensure when users install CloudPak Operator, the IBM Common Service Operator will be also installed by OLM.
 
-```
+```yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
@@ -81,12 +81,20 @@ metadata:
 spec:
   requests:
     - operands:
-        - name: ibm-cert-manager-operator
-        - name: ibm-metering-operator
         - name: ibm-licensing-operator
-      registry: common-service
+      registry: common-service-dev
       registryNamespace: ibm-common-services
 ```
+
+For development and testing purposes, ibm common service operator will develop two pairs of the `OperandRegistry` and `OperandConfig`.
+
+If users want to install the common services from the stable channel, they can set `registry: common-service` in the `OperandRequest`.
+
+If users want to install the common services from the dev channel, they should set `registry: common-service-dev` in the `OperandRequest`.
+
+**Note:** If `OperandRegistry` `common-service` is used, uses need to add the required services and all their dependencies into `OperandRequest`.
+
+**Note:** If If `OperandRegistry` `common-service-dev` is used, users just need to request the required services and ODLM and common service operators will manage the service dependency. `ibm-certmanager-operator` and  `ibm-mongodb-operator` are private operators in the dev channel. They can't be requested directly by users from other namespace from `ibm-common-service`. ODLM will generate them if other operators depend on them.
 
 CloudPaks can create this `OperandRequest` during [the CloudPak Operator start](https://github.com/IBM/ibm-common-service-operator/blob/master/cmd/manager/main.go#L121-L126), or have their own method to create this `OperandRequest`.
 

--- a/docs/cloudpak-integration.md
+++ b/docs/cloudpak-integration.md
@@ -86,15 +86,15 @@ spec:
       registryNamespace: ibm-common-services
 ```
 
-For development and testing purposes, ibm common service operator will develop two pairs of the `OperandRegistry` and `OperandConfig`.
+For development and testing purposes, ibm common service operator will deploy two pairs of the `OperandRegistry` and `OperandConfig`.
 
-If users want to install the common services from the stable channel, they can set `registry: common-service` in the `OperandRequest`.
+If you want to install the common services from the stable channel, you should set `registry: common-service` in the `OperandRequest`.
 
-If users want to install the common services from the dev channel, they should set `registry: common-service-dev` in the `OperandRequest`.
+If you want to install the common services from the dev channel, you should set `registry: common-service-dev` in the `OperandRequest`.
 
 **Note:** If `OperandRegistry` `common-service` is used, uses need to add the required services and all their dependencies into `OperandRequest`.
 
-**Note:** If If `OperandRegistry` `common-service-dev` is used, users just need to request the required services and ODLM and common service operators will manage the service dependency. `ibm-certmanager-operator` and  `ibm-mongodb-operator` are private operators in the dev channel. They can't be requested directly by users from other namespace from `ibm-common-service`. ODLM will generate them if other operators depend on them.
+**Note:** If If `OperandRegistry` `common-service-dev` is used, you just need to request the required services and ODLM and common service operators will manage the service dependency. `ibm-cert-manager-operator` and  `ibm-mongodb-operator` are private operators in the dev channel. They can't be requested directly from other namespaces except `ibm-common-service`. ODLM will generate them if other operators depend on them.
 
 CloudPaks can create this `OperandRequest` during [the CloudPak Operator start](https://github.com/IBM/ibm-common-service-operator/blob/master/cmd/manager/main.go#L121-L126), or have their own method to create this `OperandRequest`.
 


### PR DESCRIPTION
For development and testing purposes, ibm common service operator will deploy two pairs of the `OperandRegistry` and `OperandConfig`.
`common-service` uses the stable channel.
`common-service-dev` uses the dev channel.