### PR TITLE
Using dev channel for common-service and common-service-dev

### DIFF
--- a/build/resources/cs-operandconfig.yaml
+++ b/build/resources/cs-operandconfig.yaml
@@ -53,7 +53,6 @@ spec:
   - name: ibm-ingress-nginx-operator
     spec:
       nginxIngress: {}
-      operandRequest: {}
   - name: ibm-auditlogging-operator
     spec:
       auditLogging: {}

--- a/build/resources/cs-operandconfig.yaml
+++ b/build/resources/cs-operandconfig.yaml
@@ -38,6 +38,7 @@ spec:
       policydecision: {}
       secretwatcher: {}
       securityonboarding: {}
+      operandBindInfo: {}
       operandRequest: {}
   - name: ibm-healthcheck-operator
     spec:
@@ -45,6 +46,7 @@ spec:
   - name: ibm-commonui-operator
     spec:
       commonWebUI: {}
+      operandBindInfo: {}
       operandRequest: {}
   - name: ibm-management-ingress-operator
     spec:
@@ -88,6 +90,7 @@ spec:
   - name: ibm-elastic-stack-operator
     spec:
       elasticStack: {}
+
 ---
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig
@@ -102,12 +105,18 @@ spec:
     spec:
       metering: {}
       meteringUI: {}
+      meteringReportServer: {}
+      operandBindInfo: {}
+      operandRequest: {}
   - name: ibm-licensing-operator
     spec:
       IBMLicensing: {}
+      operandBindInfo: {}
+      operandRequest: {}
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}
+      operandRequest: {}
   - name: ibm-cert-manager-operator
     spec:
       certManager: {}
@@ -123,44 +132,55 @@ spec:
       policydecision: {}
       secretwatcher: {}
       securityonboarding: {}
+      operandBindInfo: {}
+      operandRequest: {}
   - name: ibm-healthcheck-operator
     spec:
       healthService: {}
   - name: ibm-commonui-operator
     spec:
       commonWebUI: {}
-      legacyHeader: {}
-      navconfiguration: {}
+      operandBindInfo: {}
+      operandRequest: {}
   - name: ibm-management-ingress-operator
     spec:
       managementIngress: {}
+      operandRequest: {}
   - name: ibm-ingress-nginx-operator
     spec:
       nginxIngress: {}
   - name: ibm-auditlogging-operator
     spec:
       auditLogging: {}
+      operandRequest: {}
   - name: ibm-catalog-ui-operator
     spec:
       catalogUI: {}
+      operandRequest: {}
   - name: ibm-platform-api-operator
     spec:
       platformApi: {}
+      operandRequest: {}
   - name: ibm-helm-api-operator
     spec:
       helmApi: {}
+      operandRequest: {}
   - name: ibm-helm-repo-operator
     spec:
       helmRepo: {}
+      operandRequest: {}
   - name: ibm-monitoring-exporters-operator
     spec:
       exporter: {}
+      operandRequest: {}
   - name: ibm-monitoring-prometheusext-operator
     spec:
       prometheusExt: {}
+      operandRequest: {}
   - name: ibm-monitoring-grafana-operator
     spec:
       grafana: {}
+      operandRequest: {}
   - name: ibm-elastic-stack-operator
     spec:
       elasticStack: {}

--- a/build/resources/cs-operandregistry.yaml
+++ b/build/resources/cs-operandregistry.yaml
@@ -131,7 +131,7 @@ spec:
     scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
---- 
+---
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
@@ -143,129 +143,125 @@ spec:
   operators:
   - name: ibm-metering-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-metering-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: The service used to meter workloads in a kubernetes cluster
   - name: ibm-licensing-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-licensing-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: The service used to management the license in a kubernetes cluster
   - name: ibm-mongodb-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-mongodb-operator-app
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: The service used to create mongodb in a kubernetes cluster
   - name: ibm-cert-manager-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-cert-manager-operator
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of cert-manager service.
   - name: ibm-iam-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-iam-operator
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of iam service.
   - name: ibm-healthcheck-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-healthcheck-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of health check service.
   - name: ibm-commonui-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-commonui-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: The service that services the login page, common header, LDAP, and Team resources pages
   - name: ibm-management-ingress-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-management-ingress-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of management ingress service.
   - name: ibm-ingress-nginx-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-ingress-nginx-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of ingress nginx service.
   - name: ibm-auditlogging-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-auditlogging-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of auditlogging service.
   - name: ibm-catalog-ui-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-catalog-ui-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of catalog UI service.
   - name: ibm-platform-api-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-platform-api-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of Platform API service.
   - name: ibm-helm-api-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-helm-api-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of Helm API service.
   - name: ibm-helm-repo-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-helm-repo-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator for managing deployment of Helm repository service.
   - name: ibm-monitoring-exporters-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-monitoring-exporters-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator to provision node-exporter, kube-state-metrics and collectd exporter with tls enabled.
   - name: ibm-monitoring-prometheusext-operator
     namespace: ibm-common-services
-    channel: stable-v1
+    channel: dev
     packageName: ibm-monitoring-prometheusext-operator-app
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-    description: Operator to deploy Prometheus and Alertmanager instances with RBAC enabled. It will also enable Multicloud monitoring.
-  - channel: stable-v1
-    description: Operator to deploy Grafana instances with RBAC enabled.
+  - channel: dev
     name: ibm-monitoring-grafana-operator
     namespace: ibm-common-services
     packageName: ibm-monitoring-grafana-operator-app
-    scope: private
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
-  - channel: stable-v1
-    description: Operator that installs and manages Elastic Stack logging service instances. 
+  - channel: dev
     name: ibm-elastic-stack-operator
     namespace: ibm-common-services
     packageName: ibm-elastic-stack-operator-app
-    scope: private
+    scope: public
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace


### PR DESCRIPTION
When I test today, I found there would be an issue if we keep both registry `common-service` and `common-service-dev` 

The OperandRequest in cs operators for supporting operator dependency, point to the OperandRegistry common-service, so when users install with the dev registry, it may cause some of the operators are deployed by dev channel and others use the stable channel.
For example. installing dev version MongoDB (from common-service-dev registry) but depends on stable version cert-manager (from common-service registry).

This PR updates the `common-service` registry to use `dev` channel as well to avoid the above conflict. 

I am wondering if we can leave one of the OperandRegiestry and OperandConfig. If users want to install the stable or dev channel, they need to manually update them and keep the name as common-service
For this release, We only keep one pair of the dev registry and config and named them as common-service. For the users who want to install the stable version, they should use the stable registry and config to replace the dev registry and config. I hope to use dev as default for this release is because this is the first release of the ibm common service operator, some of the features like (operandbindinfo and the dependency management) can’t be tested with the stable channel.

When we go GA, we convert the dev registry and config to the stable and in the following release, we use stable version as default and when users want to test, they need to add dev registry and config.



