### PR TITLE
Remove ibm-cloud-info cm from SecretShare CR

### DIFF
--- a/build/resources/extra/secretshare_deploy.yaml
+++ b/build/resources/extra/secretshare_deploy.yaml
@@ -205,9 +205,6 @@ spec:
   - configmapname: oauth-client-map
     sharewith:
     - namespace: services
-  - configmapname: ibm-cloud-info
-    sharewith:
-    - namespace: kube-system
   - configmapname: ibmcloud-cluster-info
     sharewith:
     - namespace: kube-public


### PR DESCRIPTION
Configmap ibm-cloud-info was added by accident or mistake. There
is no such configmap Common Services 3.2.4 in kube-system namespace.
Remove it from the list.