### PR TITLE
remove the unnecessary copies

### DIFF
--- a/build/resources/extra/secretshare_deploy.yaml
+++ b/build/resources/extra/secretshare_deploy.yaml
@@ -186,11 +186,6 @@ metadata:
 spec:
   # Secrets to share for adopter compatibility to Common Services 3.2.4
   secretshares:
-  - secretname: icp-management-ingress-tls-secret
-    sharewith:
-    - namespace: kube-system
-    - namespace: kube-system
-      name: route-tls-secret 
   - secretname: icp-metering-api-secret
     sharewith:
     - namespace: kube-system
@@ -201,17 +196,10 @@ spec:
     sharewith:
     - namespace: kube-public
   # ConfigMaps to share for adopter compatibility to Common Services 3.2.4
-  configmapshares: 
+  configmapshares:
   - configmapname: oauth-client-map
     sharewith:
     - namespace: services
   - configmapname: ibmcloud-cluster-info
     sharewith:
     - namespace: kube-public
-  - configmapname: common-web-ui-config
-    sharewith:
-    - namespace: kube-system
-  - configmapname: common-web-ui-log4js
-    sharewith:
-    - namespace: kube-system
-  


### PR DESCRIPTION
Got the message from @liqlin2015 that the `icp-management-ingress-tls-secret` does not need to be copied to `kube-system`.

Sync the secretshare PR: https://github.ibm.com/IBMPrivateCloud/secretshare/pull/2

/cc @mikekaczmarski @liqlin2015 