### PR TITLE
Add required RBAC for ibmcloud-cluster-ca-cert

### DIFF
--- a/build/resources/extra/rbac_cluster_info.yaml
+++ b/build/resources/extra/rbac_cluster_info.yaml
@@ -26,3 +26,33 @@ roleRef:
   kind: Role
   name: ibmcloud-cluster-info
   apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ibmcloud-cluster-ca-cert
+  namespace: kube-public
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["ibmcloud-cluster-ca-cert"]
+    verbs: ["get"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ibmcloud-cluster-ca-cert
+  namespace: kube-public
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: "system:authenticated"
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: "system:unauthenticated"
+roleRef:
+  kind: Role
+  name: ibmcloud-cluster-ca-cert
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -54,10 +54,10 @@ Then Click `OperandRegistry` and delete all the `OperandRegistry` instances.
 
     Click Projects and delete project `ibm-common-services`.
 
-- Remove the RBAC for `ibmcloud-cluster-info`
+- Remove RBAC created in kube-public namespace.
 
     Click `User Management` > `Role Bindings` and switch to `kube-public` namespace.
-    Search and delete all the `Role Bindings` with the name `ibmcloud-cluster-info`.
+    Search and delete all the `Role Bindings` with the name `ibmcloud-cluster-info` and `ibmcloud-cluster-ca-cert`.
 
     Click `User Management` > `Roles` and switch to `kube-public` namespace.
-    Search and delete the `Roles` with the name `ibmcloud-cluster-info`.
+    Search and delete the `Roles` with the name `ibmcloud-cluster-info` and `ibmcloud-cluster-ca-cert`.


### PR DESCRIPTION
Secret ibmcloud-cluster-ca-cert will be copied to kube-public
namespace. But the required RBAC is missing. Add the RBAC so any
k8s user can access the info.