### PR TITLE
Add required RBAC for ibmcloud-cluster-ca-cert

### DIFF
--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.1/ibm-common-service-operator.v3.4.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.1/ibm-common-service-operator.v3.4.1.clusterserviceversion.yaml
@@ -302,6 +302,36 @@ metadata:
         kind: Role
         name: ibmcloud-cluster-info
         apiGroup: rbac.authorization.k8s.io
+
+      ---
+      kind: Role
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ibmcloud-cluster-ca-cert
+        namespace: kube-public
+      rules:
+        - apiGroups: [""]
+          resources: ["secrets"]
+          resourceNames: ["ibmcloud-cluster-ca-cert"]
+          verbs: ["get"]
+
+      ---
+      kind: RoleBinding
+      apiVersion: rbac.authorization.k8s.io/v1
+      metadata:
+        name: ibmcloud-cluster-ca-cert
+        namespace: kube-public
+      subjects:
+        - kind: Group
+          apiGroup: rbac.authorization.k8s.io
+          name: "system:authenticated"
+        - kind: Group
+          apiGroup: rbac.authorization.k8s.io
+          name: "system:unauthenticated"
+      roleRef:
+        kind: Role
+        name: ibmcloud-cluster-ca-cert
+        apiGroup: rbac.authorization.k8s.io
     repository: https://github.com/IBM/ibm-common-service-operator
     secretShareOperator: |-
       apiVersion: apiextensions.k8s.io/v1beta1


### PR DESCRIPTION
Secret ibmcloud-cluster-ca-cert will be copied to kube-public
namespace. But the required RBAC is missing. Add the RBAC so any
k8s user can access the info.