### PR TITLE
Check the old common services if installed

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -120,14 +120,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	klog.Info("checking old common services if installed.")
+	klog.Info("check Helm based IBM Common Services installation")
 	exist, err := check.CheckOriginalCs(mgr)
 	if err != nil {
 		klog.Error(err)
 		os.Exit(1)
 	}
 	if exist {
-		klog.Error("old common services has been installed, uninstall the old common services before install the new")
+		klog.Error("The Helm based IBM Common Services must be uninstalled before performing operator based installation")
 		os.Exit(1)
 	}
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -23,6 +23,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/IBM/ibm-common-service-operator/pkg/check"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -115,6 +117,17 @@ func main() {
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		klog.Error(err)
+		os.Exit(1)
+	}
+
+	klog.Info("checking old common services if installed.")
+	exist, err := check.CheckOriginalCs(mgr)
+	if err != nil {
+		klog.Error(err)
+		os.Exit(1)
+	}
+	if exist {
+		klog.Error("old common services has been installed, uninstall the old common services before install the new")
 		os.Exit(1)
 	}
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -121,7 +121,7 @@ func main() {
 	}
 
 	klog.Info("check Helm based IBM Common Services installation")
-	exist, err := check.CheckOriginalCs(mgr)
+	exist, err := check.OriginalCs(mgr)
 	if err != nil {
 		klog.Error(err)
 		os.Exit(1)

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-// CheckOriginalCs check the old version common services if installed
-func CheckOriginalCs(mgr manager.Manager) (exist bool, err error) {
+// OriginalCs check Helm based IBM Common Services installation
+func OriginalCs(mgr manager.Manager) (exist bool, err error) {
 	reader := mgr.GetAPIReader()
 	secret, err := getSecret(reader)
 	if err != nil {

--- a/pkg/check/check.go
+++ b/pkg/check/check.go
@@ -1,0 +1,63 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package check
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// CheckOriginalCs check the old version common services if installed
+func CheckOriginalCs(mgr manager.Manager) (exist bool, err error) {
+	reader := mgr.GetAPIReader()
+	secret, err := getSecret(reader)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Get the tiller secret annotations
+	annotations := secret.GetAnnotations()
+
+	if _, ok := annotations["ibm.com/iam-service.id"]; ok {
+		return true, nil
+	}
+	if _, ok := annotations["ibm.com/iam-service.api-key"]; ok {
+		return true, nil
+	}
+	if _, ok := annotations["ibm.com/iam-service.name"]; ok {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func getSecret(reader client.Reader) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	secretName := "tiller-secret"
+	secretNs := "kube-system"
+
+	err := reader.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: secretNs}, secret)
+	return secret, err
+}


### PR DESCRIPTION
Local test, if secret tiller-secret existing, and iam related annotation existing, exit with code 1.
```console
✗ make run
....... Start Operator locally with go run ......
WATCH_NAMESPACE=ibm-common-services go run ./cmd/manager/main.go
I0525 22:25:02.360505   98988 main.go:49] Operator Version: 3.4.1
I0525 22:25:02.360632   98988 main.go:50] Go Version: go1.14.3
I0525 22:25:02.360636   98988 main.go:51] Go OS/Arch: darwin/amd64
I0525 22:25:02.360640   98988 main.go:52] Version of operator-sdk: v0.16.0
I0525 22:25:06.208490   98988 main.go:115] Registering Components.
I0525 22:25:06.208567   98988 main.go:123] check Helm based IBM Common Services installation
E0525 22:25:06.455382   98988 main.go:130] The Helm based IBM Common Services must be uninstalled before performing operator based installation
exit status 1
make: *** [run] Error 1
```