### PR TITLE
bump version to 3.4.2 and push 3.4.1 to the beta channel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 QUAY_REPO ?= quay.io/opencloudio
 IMAGE_NAME ?= common-service-operator
 OPERATOR_NAME ?= ibm-common-service-operator
-CSV_VERSION ?= 3.4.1
+CSV_VERSION ?= 3.4.2
 VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
 				git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Red Hat OpenShift Container Platform 4.3 or newer installed on one of the follow
 
 ## Operator versions
 
- - 3.4.1
+ - 3.4.2
 
 ## Prerequisites
 

--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.1/ibm-common-service-operator.v3.4.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.1/ibm-common-service-operator.v3.4.1.clusterserviceversion.yaml
@@ -135,121 +135,121 @@ metadata:
         operators:
         - name: ibm-metering-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-metering-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-licensing-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-licensing-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-mongodb-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-mongodb-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-cert-manager-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-iam-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-iam-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-healthcheck-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-healthcheck-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-commonui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-commonui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-management-ingress-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-management-ingress-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-ingress-nginx-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-ingress-nginx-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-auditlogging-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-auditlogging-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-catalog-ui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-catalog-ui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-platform-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-platform-api-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-api-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-repo-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-repo-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-exporters-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-exporters-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-prometheusext-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-prometheusext-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-monitoring-grafana-operator
           namespace: ibm-common-services
           packageName: ibm-monitoring-grafana-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-elastic-stack-operator
           namespace: ibm-common-services
           packageName: ibm-elastic-stack-operator-app
@@ -267,7 +267,7 @@ metadata:
         annotations:
           version: "1"
       spec:
-        channel: dev
+        channel: beta
         installPlanApproval: Automatic
         name: operand-deployment-lifecycle-manager-app
         source: opencloud-operators

--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.1/ibm-common-service-operator.v3.4.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.1/ibm-common-service-operator.v3.4.1.clusterserviceversion.yaml
@@ -2292,7 +2292,7 @@ spec:
   - IBM
   - Cloud
   maintainers:
-  - email: supports@ibm.com
+  - email: support@ibm.com
     name: IBM Support
   maturity: alpha
   provider:

--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.2/ibm-common-service-operator.v3.4.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.2/ibm-common-service-operator.v3.4.2.clusterserviceversion.yaml
@@ -272,7 +272,7 @@ metadata:
         name: operand-deployment-lifecycle-manager-app
         source: opencloud-operators
         sourceNamespace: openshift-marketplace
-    olm.skipRange: '>=3.3.0 <3.4.0'
+    olm.skipRange: '>=3.3.0 <3.4.2'
     rbac: |-
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
@@ -484,7 +484,7 @@ metadata:
                 - /tmp/ansible-operator/runner
                 - stdout
                 # Replace this with the built image name
-                image: "quay.io/opencloudio/ibm-secretshare-operator@sha256:e6587d27db30e269428e85c2a7a33892051248ffa18a73c7c750f6577a8fc484"
+                image: "quay.io/opencloudio/ibm-secretshare-operator:v1.0"
                 imagePullPolicy: "Always"
                 volumeMounts:
                 - mountPath: /tmp/ansible-operator/runner
@@ -492,7 +492,7 @@ metadata:
                   readOnly: true
               - name: operator
                 # Replace this with the built image name
-                image: "quay.io/opencloudio/ibm-secretshare-operator@sha256:e6587d27db30e269428e85c2a7a33892051248ffa18a73c7c750f6577a8fc484"
+                image: "quay.io/opencloudio/ibm-secretshare-operator:v1.0"
                 imagePullPolicy: "Always"
                 volumeMounts:
                 - mountPath: /tmp/ansible-operator/runner
@@ -2107,7 +2107,7 @@ metadata:
             serviceAccountName: ibm-common-service-webhook
             containers:
               - name: ibm-common-service-webhook
-                image: quay.io/opencloudio/ibm-cs-webhook@sha256:3e03c060166bb5df5afa206e7d32b664243d16931dea0545b01d06909bb60e96
+                image: quay.io/opencloudio/ibm-cs-webhook:latest
                 command:
                 - ibm-common-service-webhook
                 imagePullPolicy: Always
@@ -2148,7 +2148,7 @@ metadata:
         name: ibm-common-service-webhook
         namespace: ibm-common-services
       spec: {}
-  name: ibm-common-service-operator.v3.4.1
+  name: ibm-common-service-operator.v3.4.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -2182,7 +2182,7 @@ spec:
 
     ## Operator versions
 
-     - 3.4.1
+     - 3.4.2
 
     ## Prerequisites
 
@@ -2259,7 +2259,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: ibm-common-service-operator
-                image: quay.io/opencloudio/common-service-operator@sha256:50826858364c41a308fa0259baa87b70431249ae8b2bad1664edd0b2d26ca0f9
+                image: quay.io/opencloudio/common-service-operator:latest
                 imagePullPolicy: Always
                 name: ibm-common-service-operator
                 resources:
@@ -2297,5 +2297,5 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.4.0
-  version: 3.4.1
+  replaces: ibm-common-service-operator.v3.4.1
+  version: 3.4.2

--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.2/ibm-common-service-operator.v3.4.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.2/ibm-common-service-operator.v3.4.2.clusterserviceversion.yaml
@@ -2292,7 +2292,7 @@ spec:
   - IBM
   - Cloud
   maintainers:
-  - email: supports@ibm.com
+  - email: support@ibm.com
     name: IBM Support
   maturity: alpha
   provider:

--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.2/operator.ibm.com_commonservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.2/operator.ibm.com_commonservices_crd.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/instance: "ibm-common-service-operator"
+    app.kubernetes.io/managed-by: "ibm-common-service-operator"
+    app.kubernetes.io/name: "ibm-common-service-operator"
+  name: commonservices.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: CommonService
+    listKind: CommonServiceList
+    plural: commonservices
+    singular: commonservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CommonService is the Schema for the commonservices API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CommonServiceSpec defines the desired state of CommonService
+          type: object
+        status:
+          description: CommonServiceStatus defines the observed state of CommonService
+          type: object
+      type: object
+  version: v3
+  versions:
+  - name: v3
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-common-service-operator/ibm-common-service-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/ibm-common-service-operator.package.yaml
@@ -1,7 +1,7 @@
 channels:
-- currentCSV: ibm-common-service-operator.v3.4.0
-  name: beta
 - currentCSV: ibm-common-service-operator.v3.4.1
+  name: beta
+- currentCSV: ibm-common-service-operator.v3.4.2
   name: dev
 - currentCSV: ibm-common-service-operator.v3.3.0
   name: stable-v1

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "3.4.1"
+	Version = "3.4.2"
 )


### PR DESCRIPTION
Update version to 3.4.2
The beta channel uses 3.4.1
The dev channel uses 3.4.2

Image digest:

- common-service-operator: https://quay.io/repository/opencloudio/common-service-operator/manifest/sha256:50826858364c41a308fa0259baa87b70431249ae8b2bad1664edd0b2d26ca0f9
- ibm-cs-webhook: https://quay.io/repository/opencloudio/ibm-cs-webhook/manifest/sha256:3e03c060166bb5df5afa206e7d32b664243d16931dea0545b01d06909bb60e96
- ibm-secretshare-operator: https://quay.io/repository/opencloudio/ibm-secretshare-operator/manifest/sha256:e6587d27db30e269428e85c2a7a33892051248ffa18a73c7c750f6577a8fc484