### PR TITLE
push 3.4.3 to dev, 3.4.2 to beta and 3.4.1 to stable-v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 QUAY_REPO ?= quay.io/opencloudio
 IMAGE_NAME ?= common-service-operator
 OPERATOR_NAME ?= ibm-common-service-operator
-CSV_VERSION ?= 3.4.2
+CSV_VERSION ?= 3.4.3
 VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
 				git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 

--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.2/ibm-common-service-operator.v3.4.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.2/ibm-common-service-operator.v3.4.2.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    containerImage: quay.io/opencloudio/common-service-operator:latest
+    containerImage: quay.io/opencloudio/common-service-operator:3.4
     createdAt: "2020-04-06T11:28:16Z"
     csNamespace: |-
       apiVersion: v1
@@ -135,121 +135,121 @@ metadata:
         operators:
         - name: ibm-metering-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-metering-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-licensing-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-licensing-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-mongodb-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-mongodb-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-cert-manager-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-iam-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-iam-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-healthcheck-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-healthcheck-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-commonui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-commonui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-management-ingress-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-management-ingress-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-ingress-nginx-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-ingress-nginx-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-auditlogging-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-auditlogging-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-catalog-ui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-catalog-ui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-platform-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-platform-api-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-api-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-repo-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-repo-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-exporters-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-exporters-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-prometheusext-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-prometheusext-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-monitoring-grafana-operator
           namespace: ibm-common-services
           packageName: ibm-monitoring-grafana-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-elastic-stack-operator
           namespace: ibm-common-services
           packageName: ibm-elastic-stack-operator-app
@@ -267,7 +267,7 @@ metadata:
         annotations:
           version: "1"
       spec:
-        channel: dev
+        channel: beta
         installPlanApproval: Automatic
         name: operand-deployment-lifecycle-manager-app
         source: opencloud-operators
@@ -484,15 +484,22 @@ metadata:
                 - /tmp/ansible-operator/runner
                 - stdout
                 # Replace this with the built image name
-                image: "quay.io/opencloudio/ibm-secretshare-operator:v1.0"
+                image: "quay.io/opencloudio/ibm-secretshare-operator@sha256:e6587d27db30e269428e85c2a7a33892051248ffa18a73c7c750f6577a8fc484"
                 imagePullPolicy: "Always"
                 volumeMounts:
                 - mountPath: /tmp/ansible-operator/runner
                   name: runner
                   readOnly: true
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 200m
+                    memory: 200Mi
               - name: operator
                 # Replace this with the built image name
-                image: "quay.io/opencloudio/ibm-secretshare-operator:v1.0"
+                image: "quay.io/opencloudio/ibm-secretshare-operator@sha256:e6587d27db30e269428e85c2a7a33892051248ffa18a73c7c750f6577a8fc484"
                 imagePullPolicy: "Always"
                 volumeMounts:
                 - mountPath: /tmp/ansible-operator/runner
@@ -510,6 +517,13 @@ metadata:
                     value: "secretshare"
                   - name: ANSIBLE_GATHERING
                     value: explicit
+                resources:
+                  limits:
+                    cpu: 800m
+                    memory: 1024Mi
+                  requests:
+                    cpu: 200m
+                    memory: 200Mi
             volumes:
               - name: runner
                 emptyDir: {}
@@ -531,8 +545,26 @@ metadata:
         - secretname: ibmcloud-cluster-ca-cert
           sharewith:
           - namespace: kube-public
+        - secretname: icp-serviceid-apikey-secret
+          sharewith:
+          - namespace: kube-system
+        - secretname: platform-oidc-credentials
+          sharewith:
+          - namespace: kube-system
+        - secretname: icp-mongodb-admin
+          sharewith:
+          - namespace: kube-system
+        - secretname: icp-mongodb-client-cert
+          sharewith:
+          - namespace: kube-system
+        - secretname: cs-ca-certificate-secret
+          sharewith:
+          - namespace: kube-system
         # ConfigMaps to share for adopter compatibility to Common Services 3.2.4
         configmapshares:
+        - configmapname: platform-auth-idp
+          sharewith:
+          - namespace: kube-system
         - configmapname: oauth-client-map
           sharewith:
           - namespace: services
@@ -2107,7 +2139,7 @@ metadata:
             serviceAccountName: ibm-common-service-webhook
             containers:
               - name: ibm-common-service-webhook
-                image: quay.io/opencloudio/ibm-cs-webhook:latest
+                image: quay.io/opencloudio/ibm-cs-webhook@sha256:3e03c060166bb5df5afa206e7d32b664243d16931dea0545b01d06909bb60e96
                 command:
                 - ibm-common-service-webhook
                 imagePullPolicy: Always
@@ -2259,7 +2291,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: ibm-common-service-operator
-                image: quay.io/opencloudio/common-service-operator:latest
+                image: quay.io/opencloudio/common-service-operator@sha256:7e4d08a3d0cd26bae1184d72420d80cd2de157ef1dc69037006ffcf08e9c9a0b
                 imagePullPolicy: Always
                 name: ibm-common-service-operator
                 resources:

--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.3/ibm-common-service-operator.v3.4.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.3/ibm-common-service-operator.v3.4.3.clusterserviceversion.yaml
@@ -21,8 +21,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    containerImage: quay.io/opencloudio/common-service-operator:3.4
-    createdAt: "2020-04-06T11:28:16Z"
+    containerImage: quay.io/opencloudio/common-service-operator:latest
+    createdAt: "2020-06-05T17:08:59Z"
     csNamespace: |-
       apiVersion: v1
       kind: Namespace
@@ -135,121 +135,121 @@ metadata:
         operators:
         - name: ibm-metering-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-metering-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-licensing-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-licensing-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-mongodb-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-mongodb-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-cert-manager-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-iam-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-iam-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-healthcheck-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-healthcheck-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-commonui-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-commonui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-management-ingress-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-management-ingress-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-ingress-nginx-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-ingress-nginx-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-auditlogging-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-auditlogging-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-catalog-ui-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-catalog-ui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-platform-api-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-platform-api-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-api-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-helm-api-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-repo-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-helm-repo-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-exporters-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-monitoring-exporters-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-prometheusext-operator
           namespace: ibm-common-services
-          channel: stable-v1
+          channel: dev
           packageName: ibm-monitoring-prometheusext-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: stable-v1
+        - channel: dev
           name: ibm-monitoring-grafana-operator
           namespace: ibm-common-services
           packageName: ibm-monitoring-grafana-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: stable-v1
+        - channel: dev
           name: ibm-elastic-stack-operator
           namespace: ibm-common-services
           packageName: ibm-elastic-stack-operator-app
@@ -267,12 +267,12 @@ metadata:
         annotations:
           version: "1"
       spec:
-        channel: stable-v1
+        channel: dev
         installPlanApproval: Automatic
         name: operand-deployment-lifecycle-manager-app
         source: opencloud-operators
         sourceNamespace: openshift-marketplace
-    olm.skipRange: '>=3.3.0 <3.4.1'
+    olm.skipRange: '>=3.3.0 <3.4.3'
     rbac: |-
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
@@ -484,7 +484,7 @@ metadata:
                 - /tmp/ansible-operator/runner
                 - stdout
                 # Replace this with the built image name
-                image: "quay.io/opencloudio/ibm-secretshare-operator@sha256:e6587d27db30e269428e85c2a7a33892051248ffa18a73c7c750f6577a8fc484"
+                image: "quay.io/opencloudio/ibm-secretshare-operator:v1.0"
                 imagePullPolicy: "Always"
                 volumeMounts:
                 - mountPath: /tmp/ansible-operator/runner
@@ -499,7 +499,7 @@ metadata:
                     memory: 200Mi
               - name: operator
                 # Replace this with the built image name
-                image: "quay.io/opencloudio/ibm-secretshare-operator@sha256:e6587d27db30e269428e85c2a7a33892051248ffa18a73c7c750f6577a8fc484"
+                image: "quay.io/opencloudio/ibm-secretshare-operator:v1.0"
                 imagePullPolicy: "Always"
                 volumeMounts:
                 - mountPath: /tmp/ansible-operator/runner
@@ -2139,7 +2139,7 @@ metadata:
             serviceAccountName: ibm-common-service-webhook
             containers:
               - name: ibm-common-service-webhook
-                image: quay.io/opencloudio/ibm-cs-webhook@sha256:3e03c060166bb5df5afa206e7d32b664243d16931dea0545b01d06909bb60e96
+                image: quay.io/opencloudio/ibm-cs-webhook:1.0.0
                 command:
                 - ibm-common-service-webhook
                 imagePullPolicy: Always
@@ -2180,7 +2180,7 @@ metadata:
         name: ibm-common-service-webhook
         namespace: ibm-common-services
       spec: {}
-  name: ibm-common-service-operator.v3.4.1
+  name: ibm-common-service-operator.v3.4.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -2214,7 +2214,7 @@ spec:
 
     ## Operator versions
 
-     - 3.4.1
+     - 3.4.3
 
     ## Prerequisites
 
@@ -2291,7 +2291,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: ibm-common-service-operator
-                image: quay.io/opencloudio/common-service-operator@sha256:7e4d08a3d0cd26bae1184d72420d80cd2de157ef1dc69037006ffcf08e9c9a0b
+                image: quay.io/opencloudio/common-service-operator:latest
                 imagePullPolicy: Always
                 name: ibm-common-service-operator
                 resources:
@@ -2329,5 +2329,5 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.4.0
-  version: 3.4.1
+  replaces: ibm-common-service-operator.v3.4.2
+  version: 3.4.3

--- a/deploy/olm-catalog/ibm-common-service-operator/3.4.3/operator.ibm.com_commonservices_crd.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.4.3/operator.ibm.com_commonservices_crd.yaml
@@ -1,0 +1,46 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/instance: "ibm-common-service-operator"
+    app.kubernetes.io/managed-by: "ibm-common-service-operator"
+    app.kubernetes.io/name: "ibm-common-service-operator"
+  name: commonservices.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: CommonService
+    listKind: CommonServiceList
+    plural: commonservices
+    singular: commonservice
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CommonService is the Schema for the commonservices API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CommonServiceSpec defines the desired state of CommonService
+          type: object
+        status:
+          description: CommonServiceStatus defines the observed state of CommonService
+          type: object
+      type: object
+  version: v3
+  versions:
+  - name: v3
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-common-service-operator/ibm-common-service-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/ibm-common-service-operator.package.yaml
@@ -1,9 +1,9 @@
 channels:
-- currentCSV: ibm-common-service-operator.v3.4.1
-  name: beta
 - currentCSV: ibm-common-service-operator.v3.4.2
+  name: beta
+- currentCSV: ibm-common-service-operator.v3.4.3
   name: dev
-- currentCSV: ibm-common-service-operator.v3.3.0
+- currentCSV: ibm-common-service-operator.v3.4.1
   name: stable-v1
 defaultChannel: beta
 packageName: ibm-common-service-operator

--- a/deploy/olm-catalog/ibm-common-service-operator/ibm-common-service-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/ibm-common-service-operator.package.yaml
@@ -5,5 +5,5 @@ channels:
   name: dev
 - currentCSV: ibm-common-service-operator.v3.4.1
   name: stable-v1
-defaultChannel: beta
+defaultChannel: stable-v1
 packageName: ibm-common-service-operator

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "3.4.2"
+	Version = "3.4.3"
 )


### PR DESCRIPTION
Push 3.4.3 to dev, the content is similar to the original 3.4.2.
Push 3.4.2 to beta, using the image digest used in 3.4.1 
Push 3.4.1 to stable-v1, using the stable-v1 channel to replace the beta channel

**Note:** We need to push the operator bundle into quay.io after other common service operators. 