### PR TITLE
Enhance logic for delete old ODLM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ uninstall: ## Uninstall all that all performed in the $ make install
 
 run: ## Run against the configured Kubernetes cluster in ~/.kube/config
 	@echo ....... Start Operator locally with go run ......
-	WATCH_NAMESPACE=${NAMESPACE} go run ./cmd/manager/main.go
+	WATCH_NAMESPACE= go run ./cmd/manager/main.go -v=2 --zap-encoder=console
 
 code-dev:
 	go mod tidy

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/IBM/ibm-common-service-operator/pkg/controller"
 	"github.com/IBM/ibm-common-service-operator/version"
 
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
@@ -115,7 +116,14 @@ func main() {
 	klog.Info("Registering Components.")
 
 	// Setup Scheme for all resources
-	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
+	mgrScheme := mgr.GetScheme()
+	// Add cs operator apis to mgr scheme
+	if err := apis.AddToScheme(mgrScheme); err != nil {
+		klog.Error(err)
+		os.Exit(1)
+	}
+	// Add olmv1alpha1 apis to mgr sheme
+	if err := olmv1alpha1.AddToScheme(mgrScheme); err != nil {
 		klog.Error(err)
 		os.Exit(1)
 	}

--- a/pkg/bootstrap/init.go
+++ b/pkg/bootstrap/init.go
@@ -312,14 +312,14 @@ func deleteExistingODLM(r client.Reader, c client.Client) error {
 			},
 		}
 		if err := c.Delete(context.TODO(), csv); err != nil && !errors.IsNotFound(err) {
-			klog.Error("Failed to delete ODLM Cluster Service Versio in the ibm-common-services namespace")
+			klog.Error("Failed to delete ODLM Cluster Service Version in the ibm-common-services namespace")
 			return err
 		}
 	}
 
 	// Delete existing ODLM subscription
 	if err := c.Delete(context.TODO(), sub); err != nil && !errors.IsNotFound(err) {
-		klog.Error("Failed to delete ODLM Cluster Service Versio in the ibm-common-services namespace")
+		klog.Error("Failed to delete ODLM Cluster Service Version in the ibm-common-services namespace")
 		return err
 	}
 	return nil


### PR DESCRIPTION
Remove original hard code logic
Current logic:
1. Get ODLM subscription, if don't exist, exit delete method, if existing, continue step 2
2. Get the ODLM CSV name from the subscription of step 1 and delete the CSV
3. Delete ODLM subscription