### PR TITLE
pick changes for common service 3.5.0

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -74,6 +74,8 @@ metadata:
         - name: ibm-healthcheck-operator
           spec:
             healthService: {}
+            mustgatherService: {}
+            mustgatherConfig: {}
         - name: ibm-commonui-operator
           spec:
             commonWebUI: {}
@@ -89,6 +91,7 @@ metadata:
         - name: ibm-auditlogging-operator
           spec:
             auditLogging: {}
+            operandBindInfo: {}
             operandRequest: {}
         - name: ibm-catalog-ui-operator
           spec:


### PR DESCRIPTION
This pr picks https://github.com/IBM/ibm-common-service-operator/pull/137 and https://github.com/IBM/ibm-common-service-operator/pull/129 to the IBM common service operator CSV 3.5.0