### PR TITLE
supports the user doesn't set the sizing template in the CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ manager: generate code-fmt code-vet
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate code-fmt code-vet manifests
-	go run ./main.go
+	OPERATOR_NAME=ibm-common-service-operator go run ./main.go
 
 # Install CRDs into a cluster
 install: manifests kustomize

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -89,6 +89,10 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		} else {
 			newConfigs = deepMerge(instance.Object["spec"].(map[string]interface{})["services"].([]interface{}), size.Large)
 		}
+	default:
+		if instance.Object["spec"].(map[string]interface{})["services"] != nil {
+			newConfigs = instance.Object["spec"].(map[string]interface{})["services"].([]interface{})
+		}
 	}
 
 	err = r.updateOpcon(ctx, newConfigs)


### PR DESCRIPTION
If the user doesn't set `size`, the common service operator can merge the sizing configuration anyway