### PR TITLE
use ubi as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.14.6 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -19,7 +19,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# FROM gcr.io/distroless/static:nonroot
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
 ARG VCS_REF
 ARG VCS_URL
 
@@ -37,6 +39,7 @@ LABEL org.label-schema.vendor="IBM" \
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER nonroot:nonroot
+# USER nonroot:nonroot
+USER 1001
 
 ENTRYPOINT ["/manager"]

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -2279,6 +2279,14 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 200Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
               serviceAccountName: ibm-common-service-operator-manager-role
               terminationGracePeriodSeconds: 10
       permissions:

--- a/deploy/olm-catalog/ibm-common-service-operator/3.5.0/ibm-common-service-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.5.0/ibm-common-service-operator.v3.5.0.clusterserviceversion.yaml
@@ -2279,6 +2279,14 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 200Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+                  runAsNonRoot: true
               serviceAccountName: ibm-common-service-operator-manager-role
               terminationGracePeriodSeconds: 10
       permissions:


### PR DESCRIPTION
- Using go 1.14.6 to solve vulnerabilities CVE-2020-15586 and CVE-2020-14039
- Using ubi as the base image