### PR TITLE
replace the CR used for the audit-logging operator

### DIFF
--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -371,9 +371,8 @@ const Small = `
               cpu: "10m"
 - name: ibm-auditlogging-operator
   spec:
-    commonAudit:
+    auditLogging:
       spec:
-        replicas: 1
         fluentd:
           resources:
             requests:


### PR DESCRIPTION
Since`auditLogging` is the default CR for the audit-logging operator, I replace the `commonAudit`  to `auditLogging` according to information from @hbradfield.

/cc @hbradfield



