### PR TITLE
bump CSV 3.5.0 to the beta channel

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         services:
         - name: ibm-metering-operator
@@ -133,126 +133,126 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         operators:
         - name: ibm-metering-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-metering-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-licensing-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-licensing-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-mongodb-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-mongodb-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-cert-manager-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-iam-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-iam-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-healthcheck-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-healthcheck-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-commonui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-commonui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-management-ingress-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-management-ingress-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-ingress-nginx-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-ingress-nginx-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-auditlogging-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-auditlogging-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-catalog-ui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-catalog-ui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-platform-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-platform-api-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-api-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-repo-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-repo-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-exporters-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-exporters-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-prometheusext-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-prometheusext-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-monitoring-grafana-operator
           namespace: ibm-common-services
           packageName: ibm-monitoring-grafana-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-elastic-stack-operator
           namespace: ibm-common-services
           packageName: ibm-elastic-stack-operator-app
@@ -266,9 +266,9 @@ metadata:
         name: ibm-common-service-operator
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
-        channel: dev
+        channel: beta
         installPlanApproval: Automatic
         name: ibm-common-service-operator
         source: opencloud-operators
@@ -282,9 +282,9 @@ metadata:
         name: operand-deployment-lifecycle-manager-app
         namespace: openshift-operators
         annotations:
-          version: "5"
+          version: "6"
       spec:
-        channel: dev
+        channel: beta
         installPlanApproval: Automatic
         name: operand-deployment-lifecycle-manager-app
         source: opencloud-operators
@@ -494,7 +494,7 @@ metadata:
         name: secretshare
         namespace: ibm-common-services
         annotations:
-          version: "6"
+          version: "7"
       spec:
         replicas: 1
         selector:
@@ -2134,7 +2134,7 @@ metadata:
         name: ibm-common-service-webhook
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         replicas: 1
         selector:
@@ -2363,5 +2363,4 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.4.5
   version: 3.5.0

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         services:
         - name: ibm-metering-operator
@@ -116,126 +116,126 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         operators:
         - name: ibm-metering-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-metering-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-licensing-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-licensing-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-mongodb-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-mongodb-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-cert-manager-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-iam-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-iam-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-healthcheck-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-healthcheck-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-commonui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-commonui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-management-ingress-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-management-ingress-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-ingress-nginx-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-ingress-nginx-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-auditlogging-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-auditlogging-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-catalog-ui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-catalog-ui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-platform-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-platform-api-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-api-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-repo-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-repo-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-exporters-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-exporters-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-prometheusext-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-prometheusext-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-monitoring-grafana-operator
           namespace: ibm-common-services
           packageName: ibm-monitoring-grafana-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-elastic-stack-operator
           namespace: ibm-common-services
           packageName: ibm-elastic-stack-operator-app
@@ -249,9 +249,9 @@ metadata:
         name: ibm-common-service-operator
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
-        channel: dev
+        channel: beta
         installPlanApproval: Automatic
         name: ibm-common-service-operator
         source: opencloud-operators
@@ -265,9 +265,9 @@ metadata:
         name: operand-deployment-lifecycle-manager-app
         namespace: openshift-operators
         annotations:
-          version: "5"
+          version: "6"
       spec:
-        channel: dev
+        channel: beta
         installPlanApproval: Automatic
         name: operand-deployment-lifecycle-manager-app
         source: opencloud-operators
@@ -477,7 +477,7 @@ metadata:
         name: secretshare
         namespace: ibm-common-services
         annotations:
-          version: "6"
+          version: "7"
       spec:
         replicas: 1
         selector:
@@ -2117,7 +2117,7 @@ metadata:
         name: ibm-common-service-webhook
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         replicas: 1
         selector:

--- a/deploy/olm-catalog/ibm-common-service-operator/3.5.0/ibm-common-service-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.5.0/ibm-common-service-operator.v3.5.0.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         services:
         - name: ibm-metering-operator
@@ -133,126 +133,126 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         operators:
         - name: ibm-metering-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-metering-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-licensing-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-licensing-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-mongodb-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-mongodb-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-cert-manager-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-iam-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-iam-operator
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-healthcheck-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-healthcheck-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-commonui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-commonui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-management-ingress-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-management-ingress-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-ingress-nginx-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-ingress-nginx-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-auditlogging-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-auditlogging-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-catalog-ui-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-catalog-ui-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-platform-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-platform-api-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-api-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-api-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-helm-repo-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-helm-repo-operator-app
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-exporters-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-exporters-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-monitoring-prometheusext-operator
           namespace: ibm-common-services
-          channel: dev
+          channel: beta
           packageName: ibm-monitoring-prometheusext-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-monitoring-grafana-operator
           namespace: ibm-common-services
           packageName: ibm-monitoring-grafana-operator-app
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: dev
+        - channel: beta
           name: ibm-elastic-stack-operator
           namespace: ibm-common-services
           packageName: ibm-elastic-stack-operator-app
@@ -266,9 +266,9 @@ metadata:
         name: ibm-common-service-operator
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
-        channel: dev
+        channel: beta
         installPlanApproval: Automatic
         name: ibm-common-service-operator
         source: opencloud-operators
@@ -282,9 +282,9 @@ metadata:
         name: operand-deployment-lifecycle-manager-app
         namespace: openshift-operators
         annotations:
-          version: "5"
+          version: "6"
       spec:
-        channel: dev
+        channel: beta
         installPlanApproval: Automatic
         name: operand-deployment-lifecycle-manager-app
         source: opencloud-operators
@@ -494,7 +494,7 @@ metadata:
         name: secretshare
         namespace: ibm-common-services
         annotations:
-          version: "6"
+          version: "7"
       spec:
         replicas: 1
         selector:
@@ -2134,7 +2134,7 @@ metadata:
         name: ibm-common-service-webhook
         namespace: ibm-common-services
         annotations:
-          version: "5"
+          version: "6"
       spec:
         replicas: 1
         selector:
@@ -2363,5 +2363,5 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.4.5
+  replaces: ibm-common-service-operator.v3.4.3
   version: 3.5.0

--- a/deploy/olm-catalog/ibm-common-service-operator/ibm-common-service-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/ibm-common-service-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: ibm-common-service-operator.v3.4.4
+- currentCSV: ibm-common-service-operator.v3.5.0
   name: beta
 - currentCSV: ibm-common-service-operator.v3.5.0
   name: dev


### PR DESCRIPTION
Discussed with the CICD squad, no matter users use the `dev` and `beta` channel of the common service operator, the ibm-common-service-operator will generate the OperandRegistry with the `beta` channel.

/assign @Daniel-Fan 