### PR TITLE
update sizing based new unlimited usage test

### DIFF
--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -24,7 +24,7 @@ const Medium = `
         resources:
           limits:
             cpu: 35m
-            memory: 290Mi
+            memory: 350Mi
           requests:
             cpu: 30m
             memory: 230Mi
@@ -242,7 +242,7 @@ const Medium = `
         rdr:
           resources:
             limits:
-              cpu: 30m
+              cpu: 50m
               memory: 290Mi
             requests:
               cpu: 25m
@@ -425,7 +425,7 @@ const Medium = `
             cpu: 25m
             memory: 65Mi
           limits:
-            cpu: 120m
+            cpu: 150m
             memory: 130Mi
       dashboardConfig:
         resources:

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -58,10 +58,10 @@ const Medium = `
       replicas: 3
       resources:
         limits:
-          cpu: 1200m
+          cpu: 2000m
           memory: 2Gi
         requests:
-          cpu: 1200m
+          cpu: 2000m
           memory: 2Gi
 - name: ibm-iam-operator
   spec:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -32,7 +32,7 @@ const Small = `
         resources:
           limits:
             cpu: 80m
-            memory: 230Mi
+            memory: 400Mi
           requests:
             cpu: 50m
             memory: 175Mi
@@ -78,8 +78,8 @@ const Small = `
       authService:
         resources:
           limits:
-            cpu: 650m
-            memory: 555Mi
+            cpu: 700m
+            memory: 625Mi
           requests:
             cpu: 140m
             memory: 525Mi
@@ -95,7 +95,7 @@ const Small = `
         resources:
           limits:
             cpu: 200m
-            memory: 200Mi
+            memory: 525Mi
           requests:
             cpu: 50m
             memory: 120Mi
@@ -103,7 +103,7 @@ const Small = `
         resources:
           limits:
             cpu: 275m
-            memory: 195Mi
+            memory: 350Mi
           requests:
             cpu: 80m
             memory: 130Mi
@@ -129,7 +129,7 @@ const Small = `
         resources:
           limits:
             cpu: 100m
-            memory: 330Mi
+            memory: 600Mi
           requests:
             cpu: 50m
             memory: 160Mi
@@ -243,7 +243,7 @@ const Small = `
           resources:
             limits:
               cpu: 50m
-              memory: 200Mi
+              memory: 250Mi
             requests:
               cpu: 25m
               memory: 175Mi
@@ -274,8 +274,8 @@ const Small = `
           cpu: 100m
           memory: 220Mi
         limits:
-          cpu: 200m
-          memory: 250Mi
+          cpu: 220m
+          memory: 350Mi
     IBMLicenseServiceReporter:
       databaseContainer:
         resources:
@@ -302,7 +302,7 @@ const Small = `
           memory: 256Mi
           cpu: 150m
         limits:
-          memory: 256Mi
+          memory: 420Mi
           cpu: 150m
 - name: ibm-platform-api-operator
   spec:
@@ -426,7 +426,7 @@ const Small = `
             memory: 65Mi
           limits:
             cpu: 150m
-            memory: 75Mi
+            memory: 130Mi
       dashboardConfig:
         resources:
           requests:
@@ -442,7 +442,7 @@ const Small = `
             memory: 50Mi
           limits:
             cpu: 50m
-            memory: 50Mi
+            memory: 75Mi
 - name: ibm-monitoring-prometheusext-operator
   spec:
     prometheusExt:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -24,15 +24,15 @@ const Small = `
         resources:
           limits:
             cpu: 35m
-            memory: 290Mi
+            memory: 350Mi
           requests:
             cpu: 30m
             memory: 230Mi
       certManagerController:
         resources:
           limits:
-            cpu: 60m
-            memory: 400Mi
+            cpu: 80m
+            memory: 230Mi
           requests:
             cpu: 50m
             memory: 175Mi
@@ -78,8 +78,8 @@ const Small = `
       authService:
         resources:
           limits:
-            cpu: 700m
-            memory: 625Mi
+            cpu: 650m
+            memory: 555Mi
           requests:
             cpu: 140m
             memory: 525Mi
@@ -95,7 +95,7 @@ const Small = `
         resources:
           limits:
             cpu: 200m
-            memory: 525Mi
+            memory: 200Mi
           requests:
             cpu: 50m
             memory: 120Mi
@@ -103,7 +103,7 @@ const Small = `
         resources:
           limits:
             cpu: 275m
-            memory: 350Mi
+            memory: 195Mi
           requests:
             cpu: 80m
             memory: 130Mi
@@ -129,7 +129,7 @@ const Small = `
         resources:
           limits:
             cpu: 100m
-            memory: 600Mi
+            memory: 330Mi
           requests:
             cpu: 50m
             memory: 160Mi
@@ -243,7 +243,7 @@ const Small = `
           resources:
             limits:
               cpu: 50m
-              memory: 250Mi
+              memory: 200Mi
             requests:
               cpu: 25m
               memory: 175Mi
@@ -274,8 +274,8 @@ const Small = `
           cpu: 100m
           memory: 220Mi
         limits:
-          cpu: 220m
-          memory: 350Mi
+          cpu: 200m
+          memory: 250Mi
     IBMLicenseServiceReporter:
       databaseContainer:
         resources:
@@ -302,7 +302,7 @@ const Small = `
           memory: 256Mi
           cpu: 150m
         limits:
-          memory: 420Mi
+          memory: 256Mi
           cpu: 150m
 - name: ibm-platform-api-operator
   spec:
@@ -425,15 +425,15 @@ const Small = `
             cpu: 20m
             memory: 65Mi
           limits:
-            cpu: 120m
-            memory: 130Mi
+            cpu: 150m
+            memory: 75Mi
       dashboardConfig:
         resources:
           requests:
             cpu: 5m
             memory: 50Mi
           limits:
-            cpu: 10m
+            cpu: 20m
             memory: 60Mi
       routerConfig:
         resources:
@@ -442,7 +442,7 @@ const Small = `
             memory: 50Mi
           limits:
             cpu: 50m
-            memory: 75Mi
+            memory: 50Mi
 - name: ibm-monitoring-prometheusext-operator
   spec:
     prometheusExt:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -58,10 +58,10 @@ const Small = `
       replicas: 1
       resources:
         limits:
-          cpu: 105m
+          cpu: 1500m
           memory: 1Gi
         requests:
-          cpu: 105m
+          cpu: 1500m
           memory: 1Gi
 - name: ibm-iam-operator
   spec:


### PR DESCRIPTION
keep the higher value unchanged. Here is the new table of summary:

```
Service Name                        | CPU Limits            | Memory Limits            | MAX CPU Usage w/o limits   | Max Memory Usage w/o limits  
certManager/certManagerCAInjector   | 35m                   | 290Mi -> 350Mi           | 20m                        | 316Mi
certManager/certManagerController   | 60m -> 80m            | 230Mi -> 400Mi           | 31m -> 60m                 | 386Mi -> 142Mi
pap/papService                      | 100m                  | 330Mi -> 600Mi           | 91m -> 43m                 | 578Mi -> 200Mi 
metering/reader/rdr                 | 30m -> 50m            | 200Mi -> 250Mi           | 40m  -> 33m                | 231Mi -> 143Mi
IBMLicensing                        | 200m -> 220m          | 250Mi -> 350Mi           | 204m -> 138m               | 326Mi -> 179Mi
commonWebUI                         | 150m                  | 256Mi -> 420Mi           | 111m -> 141m               | 406Mi -> 206Mi
grafana/dashboardConfig             | 10m -> 20m            | 60Mi                     | 15m                        | 53Mi
grafana/resources/grafanaConfig     | 70m -> 120m -> 150m   | 75Mi -> 130Mi            | 110m -> 144m               | 121Mi -> 52Mi
grafana/resources/routerConfig      | 50m                   | 50Mi -> 75Mi             | 10m -> 7m                  | 61Mi -> 34Mi
authentication/authService          | 650m -> 700m          | 555Mi -> 625Mi           | 850m -> 577Mi              | 604Mi -> 366Mi
authentication/identityManager      | 200m                  | 160Mi -> 525Mi           | 47m -> 37m                 | 511Mi -> 157Mi
authentication/identityProvider     | 275m                  | 195Mi -> 350Mi           | 81m -> 52m                 | 334Mi -> 162Mi
```