### PR TITLE
update operand config for Licensing Operator

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "6"
+          version: "7"
       spec:
         services:
         - name: ibm-metering-operator
@@ -47,9 +47,9 @@ metadata:
             operandRequest: {}
         - name: ibm-licensing-operator
           spec:
-            IBMLicensing: {}
+            IBMLicensing:
+              datasource: datacollector
             operandBindInfo: {}
-            operandRequest: {}
         - name: ibm-mongodb-operator
           spec:
             mongoDB: {}

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "6"
+          version: "7"
       spec:
         services:
         - name: ibm-metering-operator
@@ -30,9 +30,9 @@ metadata:
             operandRequest: {}
         - name: ibm-licensing-operator
           spec:
-            IBMLicensing: {}
+            IBMLicensing:
+              datasource: datacollector
             operandBindInfo: {}
-            operandRequest: {}
         - name: ibm-mongodb-operator
           spec:
             mongoDB: {}

--- a/deploy/olm-catalog/ibm-common-service-operator/3.5.1/ibm-common-service-operator.v3.5.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.5.1/ibm-common-service-operator.v3.5.1.clusterserviceversion.yaml
@@ -35,7 +35,7 @@ metadata:
         name: common-service
         namespace: ibm-common-services
         annotations:
-          version: "6"
+          version: "7"
       spec:
         services:
         - name: ibm-metering-operator
@@ -47,9 +47,9 @@ metadata:
             operandRequest: {}
         - name: ibm-licensing-operator
           spec:
-            IBMLicensing: {}
+            IBMLicensing:
+              datasource: datacollector
             operandBindInfo: {}
-            operandRequest: {}
         - name: ibm-mongodb-operator
           spec:
             mongoDB: {}


### PR DESCRIPTION
remove metering dependency by deleting operandRequest from Licensing Operator templates and force custom resource change for Licensing to not use metering from deleted dependency