### PR TITLE
Events Operator should be added to common services 3.6, not 3.5.5

### DIFF
--- a/deploy/olm-catalog/ibm-common-service-operator/3.5.5/ibm-common-service-operator.v3.5.5.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.5.5/ibm-common-service-operator.v3.5.5.clusterserviceversion.yaml
@@ -260,13 +260,6 @@ metadata:
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: beta
-          name: ibm-events-operator
-          namespace: ibm-common-services
-          packageName: ibm-events-operator
-          scope: public
-          sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
     csOperatorSubscription: |-
       apiVersion: operators.coreos.com/v1alpha1
       kind: Subscription


### PR DESCRIPTION
Events Operator should be added to common services 3.6, not
3.5.5.  Removing

https://github.com/IBM/ibm-common-service-operator/issues/254

Signed-off-by: Emma Humber <emma.humber@uk.ibm.com>