### PR TITLE
Adding navconfiguration to operandrequess

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -131,6 +131,7 @@ metadata:
             commonWebUI: {}
             switcheritem: {}
             operandRequest: {}
+            navconfiguration: {}
         - name: ibm-management-ingress-operator
           spec:
             managementIngress: {}

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -114,6 +114,7 @@ metadata:
             commonWebUI: {}
             switcheritem: {}
             operandRequest: {}
+            navconfiguration: {}
         - name: ibm-management-ingress-operator
           spec:
             managementIngress: {}

--- a/deploy/olm-catalog/ibm-common-service-operator/3.6.0/ibm-common-service-operator.v3.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-common-service-operator/3.6.0/ibm-common-service-operator.v3.6.0.clusterserviceversion.yaml
@@ -131,6 +131,7 @@ metadata:
             commonWebUI: {}
             switcheritem: {}
             operandRequest: {}
+            navconfiguration: {}
         - name: ibm-management-ingress-operator
           spec:
             managementIngress: {}


### PR DESCRIPTION
We moved the navconfiguration CRD as being owned by the commonui operator. We need to make sure it is installed with the operand request for commonui.