### PR TITLE
Fix upgrade backward compatible issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ build: ## Build manager binary
 	go build -o bin/manager main.go
 
 run: generate code-fmt code-vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
-	OPERATOR_NAME=ibm-common-service-operator go run ./main.go -v=2
+	OPERATOR_NAMESPACE=ibm-common-services OPERATOR_NAME=ibm-common-service-operator go run ./main.go -v=2
 
 install: manifests ## Install CRDs into a cluster
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -101,6 +101,13 @@ func (b *Bootstrap) InitResources(manualManagement bool) error {
 	}
 
 	// Install Namespace Scope Operator
+	klog.Info("Creating namespace-scope configmap")
+	// Backward compatible upgrade from version 3.4.x
+	if err := b.createNsScopeConfigmap(); err != nil {
+		klog.Errorf("Failed to create Namespace Scope ConfigMap: %v", err)
+		return err
+	}
+
 	klog.Info("Creating Namespace Scope Operator subscription")
 	if err := b.createNsSubscription(manualManagement, annotations); err != nil {
 		klog.Errorf("Failed to create Namespace Scope Operator subscription: %v", err)
@@ -376,6 +383,14 @@ func (b *Bootstrap) createNsSubscription(manualManagement bool, annotations map[
 		return err
 	}
 
+	return nil
+}
+
+func (b *Bootstrap) createNsScopeConfigmap() error {
+	cmRes := constant.NamespaceScopeConfigMap
+	if err := b.createOrUpdateFromYaml([]byte(util.Namespacelize(cmRes))); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/controllers/constant/namespace.go
+++ b/controllers/constant/namespace.go
@@ -36,3 +36,14 @@ spec:
   namespaceMembers:
   - placeholder
 `
+
+// NamespaceScopeConfigMap is the init configmap
+const NamespaceScopeConfigMap = `
+apiVersion: v1
+data:
+  namespaces: placeholder
+kind: ConfigMap
+metadata:
+  name: namespace-scope
+  namespace: placeholder
+`


### PR DESCRIPTION
Upgrade from version 3.4.x, if we don't create namespace-scope configmap, some operators(depend on this configmap) will not upgrade.