### PR TITLE
update the memory limit for receiverContainer

### DIFF
--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -292,7 +292,7 @@ const Large = `
             memory: 256Mi
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
 - name: ibm-commonui-operator
   spec:
     commonWebUI:

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -281,7 +281,7 @@ const Large = `
         resources:
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
           requests:
             cpu: 200m
             memory: 256Mi

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -292,7 +292,7 @@ const Large = `
             memory: 256Mi
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
 - name: ibm-commonui-operator
   spec:
     commonWebUI:

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -292,7 +292,7 @@ const Medium = `
             memory: 256Mi
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
 - name: ibm-commonui-operator
   spec:
     commonWebUI:

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -281,7 +281,7 @@ const Medium = `
         resources:
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
           requests:
             cpu: 200m
             memory: 256Mi

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -292,7 +292,7 @@ const Medium = `
             memory: 256Mi
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
 - name: ibm-commonui-operator
   spec:
     commonWebUI:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -292,7 +292,7 @@ const Small = `
             memory: 256Mi
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
 - name: ibm-commonui-operator
   spec:
     commonWebUI:

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -292,7 +292,7 @@ const Small = `
             memory: 256Mi
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
 - name: ibm-commonui-operator
   spec:
     commonWebUI:

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -292,7 +292,7 @@ const Small = `
             memory: 256Mi
           limits:
             cpu: 300m
-            memory: 300Mi
+            memory: 384Mi
 - name: ibm-commonui-operator
   spec:
     commonWebUI:


### PR DESCRIPTION
IBMLicenseServiceReporter is a CR that wouldn't be created by default. The memory increase wouldn't impact the release test.