### PR TITLE
Support reconciling the common service CR from other namespaces

### DIFF
--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -19,22 +19,24 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 
 	utilyaml "github.com/ghodss/yaml"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
 	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
 	util "github.com/IBM/ibm-common-service-operator/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/controllers/constant"
 	"github.com/IBM/ibm-common-service-operator/controllers/deploy"
+	"github.com/IBM/ibm-common-service-operator/controllers/rules"
 	"github.com/IBM/ibm-common-service-operator/controllers/size"
 )
 
@@ -54,6 +56,13 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 
 	klog.Infof("Reconciling CommonService: %s", req.NamespacedName)
 
+	if checkNamespace(req.NamespacedName.String()) {
+		return r.ReconcileMasterCR(req)
+	}
+	return r.ReconcileGeneralCR(req)
+}
+
+func (r *CommonServiceReconciler) ReconcileMasterCR(req ctrl.Request) (ctrl.Result, error) {
 	// Fetch the CommonService instance
 	instance := &apiv3.CommonService{}
 
@@ -61,7 +70,11 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// Init common servcie bootstrap resource
+	// Init common service bootstrap resource
+	// Including namespace-scope configmap, nss operator, nss CR
+	// Webhook Operator and Secretshare
+	// Delete ODLM from openshift-operators and deploy it in the masterNamespaces
+	// Deploy OperandConfig and OperandRegistry
 	if err := r.Bootstrap.InitResources(instance.Spec.ManualManagement); err != nil {
 		klog.Errorf("Failed to initialize resources: %v", err)
 		return ctrl.Result{}, err
@@ -72,7 +85,33 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	if err = r.updateOpcon(newConfigs); err != nil {
+	if err = r.updateOperandConfig(newConfigs); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	klog.Infof("Finished reconciling CommonService: %s", req.NamespacedName)
+	return ctrl.Result{}, nil
+}
+
+// ReconcileGeneralCR is for setting the OperandConfig
+func (r *CommonServiceReconciler) ReconcileGeneralCR(req ctrl.Request) (ctrl.Result, error) {
+
+	opcon := util.NewUnstructured("operator.ibm.com", "OperandConfig", "v1alpha1")
+	opconKey := types.NamespacedName{
+		Name:      "common-service",
+		Namespace: constant.MasterNamespace,
+	}
+	if err := r.Reader.Get(ctx, opconKey, opcon); err != nil {
+		klog.Errorf("failed to get OperandConfig %s: %v", opconKey.String(), err)
+		return ctrl.Result{}, err
+	}
+
+	newConfigs, err := r.getNewConfigs(req)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if err = r.updateOperandConfig(newConfigs); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -88,112 +127,99 @@ func (r *CommonServiceReconciler) getNewConfigs(req ctrl.Request) ([]interface{}
 	var newConfigs []interface{}
 	switch cs.Object["spec"].(map[string]interface{})["size"] {
 	case "small":
-		if cs.Object["spec"].(map[string]interface{})["services"] == nil {
-			newConfigs = deepMerge(newConfigs, size.Small)
-		} else {
-			newConfigs = deepMerge(cs.Object["spec"].(map[string]interface{})["services"].([]interface{}), size.Small)
-		}
+		newConfigs = applySizeTemplate(cs, size.Small)
 	case "medium":
-		if cs.Object["spec"].(map[string]interface{})["services"] == nil {
-			newConfigs = deepMerge(newConfigs, size.Medium)
-		} else {
-			newConfigs = deepMerge(cs.Object["spec"].(map[string]interface{})["services"].([]interface{}), size.Medium)
-		}
+		newConfigs = applySizeTemplate(cs, size.Medium)
 	case "large":
-		if cs.Object["spec"].(map[string]interface{})["services"] == nil {
-			newConfigs = deepMerge(newConfigs, size.Large)
-		} else {
-			newConfigs = deepMerge(cs.Object["spec"].(map[string]interface{})["services"].([]interface{}), size.Large)
-		}
+		newConfigs = applySizeTemplate(cs, size.Large)
 	default:
 		if cs.Object["spec"].(map[string]interface{})["services"] != nil {
 			newConfigs = cs.Object["spec"].(map[string]interface{})["services"].([]interface{})
 		}
 	}
-
 	return newConfigs, nil
 }
 
-func (r *CommonServiceReconciler) updateOpcon(newConfigs []interface{}) error {
-	opcon := util.NewUnstructured("operator.ibm.com", "OperandConfig", "v1alpha1")
-	opconKey := types.NamespacedName{
-		Name:      "common-service",
-		Namespace: "ibm-common-services",
+func applySizeTemplate(cs *unstructured.Unstructured, sizeTemplate string) []interface{} {
+
+	var src []interface{}
+	if cs.Object["spec"].(map[string]interface{})["services"] != nil {
+		src = cs.Object["spec"].(map[string]interface{})["services"].([]interface{})
 	}
-	if err := r.Reader.Get(ctx, opconKey, opcon); err != nil {
-		klog.Errorf("failed to get OperandConfig %s: %v", opconKey.String(), err)
-		return err
-	}
-	services := opcon.Object["spec"].(map[string]interface{})["services"].([]interface{})
-	for _, service := range services {
-		for _, size := range newConfigs {
-			if service.(map[string]interface{})["name"].(string) == size.(map[string]interface{})["name"].(string) {
-				for cr, spec := range service.(map[string]interface{})["spec"].(map[string]interface{}) {
-					if size.(map[string]interface{})["spec"].(map[string]interface{})[cr] == nil {
-						continue
-					}
-					service.(map[string]interface{})["spec"].(map[string]interface{})[cr] = mergeConfig(spec.(map[string]interface{}), size.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{}))
-				}
-			}
-		}
-	}
-
-	opcon.Object["spec"].(map[string]interface{})["services"] = services
-
-	if err := r.Update(ctx, opcon); err != nil {
-		klog.Errorf("failed to update OperandConfig %s: %v", opconKey.String(), err)
-		return err
-	}
-
-	return nil
-}
-
-func deepMerge(src []interface{}, dest string) []interface{} {
-
-	jsonSpec, err := utilyaml.YAMLToJSON([]byte(dest))
-
-	if err != nil {
-		klog.Errorf("failed to convert yaml to json: %v", err)
-	}
-
-	// Create a slice for sizes
-	var sizes []interface{}
 
 	// Convert sizes string to slice
-	err = json.Unmarshal(jsonSpec, &sizes)
-
+	sizes, err := convertStringToSlice(sizeTemplate)
 	if err != nil {
-		klog.Errorf("failed to convert string to slice: %v", err)
+		klog.Errorf("convert size to interface slice: %v", err)
 	}
 
 	for _, configSize := range sizes {
-		for _, config := range src {
-			if config.(map[string]interface{})["name"].(string) == configSize.(map[string]interface{})["name"].(string) {
-				if config == nil {
-					continue
-				}
-				if configSize == nil {
-					configSize = config
-					continue
-				}
-				for cr, size := range mergeConfig(configSize.(map[string]interface{})["spec"].(map[string]interface{}), config.(map[string]interface{})["spec"].(map[string]interface{})) {
-					configSize.(map[string]interface{})["spec"].(map[string]interface{})[cr] = size
-				}
-			}
+		config := getSpecByName(src, configSize.(map[string]interface{})["name"].(string))
+		if config == nil {
+			continue
+		}
+		if configSize == nil {
+			configSize = config
+			continue
+		}
+		for cr, size := range mergeSizeProfile(configSize.(map[string]interface{})["spec"].(map[string]interface{}), config.(map[string]interface{})["spec"].(map[string]interface{})) {
+			configSize.(map[string]interface{})["spec"].(map[string]interface{})[cr] = size
 		}
 	}
+
 	return sizes
 }
 
-// mergeConfig deep merge two configs
-func mergeConfig(defaultMap map[string]interface{}, changedMap map[string]interface{}) map[string]interface{} {
+// mergeCRsFromOperandConfig merges CRs by specific rules
+func mergeCRsFromOperandConfig(defaultMap map[string]interface{}, changedMap map[string]interface{}, rules map[string]interface{}) map[string]interface{} {
+	for key := range changedMap {
+		filterChangedMapWithRules(key, changedMap[key], rules[key], changedMap)
+	}
 	for key := range defaultMap {
-		checkKeyBeforeMerging(key, defaultMap[key], changedMap[key], changedMap)
+		if reflect.DeepEqual(defaultMap[key], changedMap[key]) {
+			continue
+		}
+		mergeChangedMap(key, defaultMap[key], changedMap[key], changedMap)
 	}
 	return changedMap
 }
 
-func checkKeyBeforeMerging(key string, defaultMap interface{}, changedMap interface{}, finalMap map[string]interface{}) {
+// mergeCRsFromOperandConfig merges CRs by specific rules
+func mergeCRsFromOperandConfigWithDefaultRules(defaultMap map[string]interface{}, changedMap map[string]interface{}) map[string]interface{} {
+	for key := range defaultMap {
+		if reflect.DeepEqual(defaultMap[key], changedMap[key]) {
+			continue
+		}
+		mergeChangedMap(key, defaultMap[key], changedMap[key], changedMap)
+	}
+	return changedMap
+}
+
+func filterChangedMapWithRules(key string, changedMap interface{}, rules interface{}, finalMap map[string]interface{}) {
+	switch changedMap.(type) {
+	case map[string]interface{}:
+		//Check that the changed map value doesn't contain this map at all and is nil
+		if rules == nil {
+			delete(finalMap, key)
+		} else {
+			if _, ok := rules.(map[string]interface{}); ok {
+				rulesRef := rules.(map[string]interface{})
+				changedMapRef := changedMap.(map[string]interface{})
+				for newKey := range changedMapRef {
+					filterChangedMapWithRules(newKey, changedMapRef[newKey], rulesRef[newKey], finalMap[key].(map[string]interface{}))
+				}
+			} else {
+				delete(finalMap, key)
+			}
+		}
+	default:
+		if rules == nil && changedMap != nil {
+			delete(finalMap, key)
+		}
+	}
+}
+
+func mergeChangedMap(key string, defaultMap interface{}, changedMap interface{}, finalMap map[string]interface{}) {
 	if !reflect.DeepEqual(defaultMap, changedMap) {
 		switch defaultMap := defaultMap.(type) {
 		case map[string]interface{}:
@@ -204,7 +230,7 @@ func checkKeyBeforeMerging(key string, defaultMap interface{}, changedMap interf
 				defaultMapRef := defaultMap
 				changedMapRef := changedMap.(map[string]interface{})
 				for newKey := range defaultMapRef {
-					checkKeyBeforeMerging(newKey, defaultMapRef[newKey], changedMapRef[newKey], finalMap[key].(map[string]interface{}))
+					mergeChangedMap(newKey, defaultMapRef[newKey], changedMapRef[newKey], finalMap[key].(map[string]interface{}))
 				}
 			}
 		default:
@@ -216,44 +242,123 @@ func checkKeyBeforeMerging(key string, defaultMap interface{}, changedMap interf
 	}
 }
 
-// Check if the request's NamespacedName is equal "ibm-common-services/common-service"
-func checkNamespace(key string) bool {
-	if key != "ibm-common-services/common-service" {
-		klog.Infof("Ignore reconcile when commonservices.operator.ibm.com is NamespacedName '%s', only reconcile for NamespacedName 'ibm-common-services/common-service'", key)
-		return false
+// mergeSizeProfile deep merge two configs
+func mergeSizeProfile(defaultMap map[string]interface{}, changedMap map[string]interface{}) map[string]interface{} {
+	for key := range defaultMap {
+		if reflect.DeepEqual(defaultMap[key], changedMap[key]) {
+			continue
+		}
+		deepMergeTwoMaps(key, defaultMap[key], changedMap[key], changedMap)
 	}
-	return true
+	return changedMap
 }
 
-func filterNamespacePredicate() predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			// Only reconcle when NamespacedName equal "ibm-common-services/common-service"
-			key := e.Meta.GetNamespace() + "/" + e.Meta.GetName()
-			return checkNamespace(key)
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			// Only reconcle when NamespacedName equal "ibm-common-services/common-service"
-			key := e.MetaNew.GetNamespace() + "/" + e.MetaNew.GetName()
-			return checkNamespace(key)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			// Evaluates to false if the object has been confirmed deleted.
-			// Only reconcle when NamespacedName equal "ibm-common-services/common-service"
-			key := e.Meta.GetNamespace() + "/" + e.Meta.GetName()
-			return !e.DeleteStateUnknown && checkNamespace(key)
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			// Only reconcle when NamespacedName equal "ibm-common-services/common-service"
-			key := e.Meta.GetNamespace() + "/" + e.Meta.GetName()
-			return checkNamespace(key)
-		},
+func deepMergeTwoMaps(key string, defaultMap interface{}, changedMap interface{}, finalMap map[string]interface{}) {
+	switch defaultMap := defaultMap.(type) {
+	case map[string]interface{}:
+		//Check that the changed map value doesn't contain this map at all and is nil
+		if changedMap == nil {
+			finalMap[key] = defaultMap
+		} else if _, ok := changedMap.(map[string]interface{}); ok { //Check that the changed map value is also a map[string]interface
+			defaultMapRef := defaultMap
+			changedMapRef := changedMap.(map[string]interface{})
+			for newKey := range defaultMapRef {
+				deepMergeTwoMaps(newKey, defaultMapRef[newKey], changedMapRef[newKey], finalMap[key].(map[string]interface{}))
+			}
+		}
+	default:
+		//Check if the value was set, otherwise set it
+		if changedMap == nil {
+			finalMap[key] = defaultMap
+		}
 	}
+}
+
+func (r *CommonServiceReconciler) updateOperandConfig(newConfigs []interface{}) error {
+	opcon := util.NewUnstructured("operator.ibm.com", "OperandConfig", "v1alpha1")
+	opconKey := types.NamespacedName{
+		Name:      "common-service",
+		Namespace: constant.MasterNamespace,
+	}
+	if err := r.Reader.Get(ctx, opconKey, opcon); err != nil {
+		klog.Errorf("failed to get OperandConfig %s: %v", opconKey.String(), err)
+		return err
+	}
+
+	opconServices := opcon.Object["spec"].(map[string]interface{})["services"].([]interface{})
+
+	// Convert rules string to slice
+	ruleSlice, err := convertStringToSlice(rules.ConfigurationRules)
+	if err != nil {
+		return err
+	}
+
+	for _, opService := range opconServices {
+		size := getSpecByName(newConfigs, opService.(map[string]interface{})["name"].(string))
+		rules := getSpecByName(ruleSlice, opService.(map[string]interface{})["name"].(string))
+		if size == nil {
+			continue
+		}
+		for cr, spec := range opService.(map[string]interface{})["spec"].(map[string]interface{}) {
+			if size.(map[string]interface{})["spec"].(map[string]interface{})[cr] == nil {
+				continue
+			}
+			sizeForCR := size.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
+			if rules != nil && rules.(map[string]interface{})["spec"] != nil && rules.(map[string]interface{})["spec"].(map[string]interface{})[cr] != nil {
+				ruleForCR := rules.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
+				opService.(map[string]interface{})["spec"].(map[string]interface{})[cr] = mergeCRsFromOperandConfig(spec.(map[string]interface{}), sizeForCR, ruleForCR)
+			} else {
+				opService.(map[string]interface{})["spec"].(map[string]interface{})[cr] = mergeCRsFromOperandConfigWithDefaultRules(spec.(map[string]interface{}), sizeForCR)
+			}
+		}
+
+	}
+
+	opcon.Object["spec"].(map[string]interface{})["services"] = opconServices
+
+	if err := r.Update(ctx, opcon); err != nil {
+		klog.Errorf("failed to update OperandConfig %s: %v", opconKey.String(), err)
+		return err
+	}
+
+	return nil
+}
+
+func convertStringToSlice(str string) ([]interface{}, error) {
+
+	jsonSpec, err := utilyaml.YAMLToJSON([]byte(str))
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert yaml to json: %v", err)
+	}
+
+	// Create a slice
+	var slice []interface{}
+	// Convert sizes string to slice
+	err = json.Unmarshal(jsonSpec, &slice)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert string to slice: %v", err)
+	}
+
+	return slice, nil
+}
+
+func getSpecByName(slice []interface{}, name string) interface{} {
+	for _, item := range slice {
+		if item.(map[string]interface{})["name"].(string) == name {
+			return item
+		}
+	}
+	return nil
+}
+
+// Check if the request's NamespacedName is the "master" CR
+func checkNamespace(key string) bool {
+	klog.Info(key)
+	return key == constant.MasterNamespace+"/common-service"
 }
 
 func (r *CommonServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&apiv3.CommonService{}).
-		WithEventFilter(filterNamespacePredicate()).
 		Complete(r)
 }

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -1,0 +1,478 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package rules
+
+// ConfigurationRules is a yaml defines the rule of patching paramaters
+const ConfigurationRules = `
+- name: ibm-cert-manager-operator
+  spec:
+    certManager:
+      certManagerCAInjector:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      certManagerController:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      certManagerWebhook:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      configMapWatcher:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+- name: ibm-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: LARGEST_VALUE
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+- name: ibm-iam-operator
+  spec:
+    authentication:
+      replicas: LARGEST_VALUE
+      auditService:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      authService:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      clientRegistration:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      identityManager:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      identityProvider:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+    oidcclientwatcher:
+      replicas: LARGEST_VALUE
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+    pap:
+      auditService:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      papService:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      replicas: LARGEST_VALUE
+    policycontroller:
+      replicas: LARGEST_VALUE
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+    policydecision:
+      auditService:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+      replicas: LARGEST_VALUE
+    secretwatcher:
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+      replicas: LARGEST_VALUE
+    securityonboarding:
+      replicas: LARGEST_VALUE
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+      iamOnboarding:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+- name: ibm-management-ingress-operator
+  spec:
+    managementIngress:
+      replicas: LARGEST_VALUE
+      resources:
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+- name: ibm-ingress-nginx-operator
+  spec:
+    nginxIngress:
+      ingress:
+        replicas: LARGEST_VALUE
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      defaultBackend:
+        replicas: LARGEST_VALUE
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      kubectl:
+        resources:
+          requests:
+            memory: LARGEST_VALUE
+            cpu: LARGEST_VALUE
+          limits:
+            memory: LARGEST_VALUE
+            cpu: LARGEST_VALUE
+- name: ibm-metering-operator
+  spec:
+    metering:
+      dataManager:
+        dm:
+          resources:
+            limits:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+            requests:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+      reader:
+        rdr:
+          resources:
+            limits:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+            requests:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+    meteringReportServer:
+      reportServer:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+    meteringUI:
+      replicas: LARGEST_VALUE
+      ui:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+- name: ibm-licensing-operator
+  spec:
+    IBMLicensing:
+      resources:
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+    IBMLicenseServiceReporter:
+      databaseContainer:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      receiverContainer:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+- name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: LARGEST_VALUE
+      resources:
+        requests:
+          memory: LARGEST_VALUE
+          cpu: LARGEST_VALUE
+        limits:
+          memory: LARGEST_VALUE
+          cpu: LARGEST_VALUE
+      commonWebUIConfig:
+        dashboardData:
+          resources:
+            limits:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+            requests:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+- name: ibm-platform-api-operator
+  spec:
+    platformApi:
+      auditService:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      platformApi:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      replicas: LARGEST_VALUE
+- name: ibm-healthcheck-operator
+  spec:
+    healthService:
+      memcached:
+        replicas: LARGEST_VALUE
+        resources:
+          requests:
+            memory: LARGEST_VALUE
+            cpu: LARGEST_VALUE
+          limits:
+            memory: LARGEST_VALUE
+            cpu: LARGEST_VALUE
+      healthService:
+        replicas: LARGEST_VALUE
+        resources:
+          requests:
+            memory: LARGEST_VALUE
+            cpu: LARGEST_VALUE
+          limits:
+            memory: LARGEST_VALUE
+            cpu: LARGEST_VALUE
+- name: ibm-auditlogging-operator
+  spec:
+    auditLogging:
+      fluentd:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+- name: ibm-monitoring-exporters-operator
+  spec:
+    exporter:
+      collectd:
+        resource:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+        routerResource:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      nodeExporter:
+        resource:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+        routerResource:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      kubeStateMetrics:
+        resource:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+        routerResource:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+- name: ibm-monitoring-grafana-operator
+  spec:
+    grafana:
+      grafanaConfig:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      dashboardConfig:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      routerConfig:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+- name: ibm-monitoring-prometheusext-operator
+  spec:
+    prometheusExt:
+      prometheusConfig:
+        routerResource:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+        resource:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      alertManagerConfig:
+        resource:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      mcmMonitor:
+        resource:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+`


### PR DESCRIPTION
1. Initialize resources only happens when reconciling master CR.
2. Apply different rules for the parameters within the Rules and without Rules

**TODO:** Implement the sizing comparison functions.