### PR TITLE
add permission for webhook to fetch configmap

### DIFF
--- a/controllers/constant/webhook.go
+++ b/controllers/constant/webhook.go
@@ -187,6 +187,13 @@ rules:
     - patch
     - update
     - watch
+# fetch configmap in kube-public ns for common-services mapping
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - get
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
fix issue #345 

verb `get` is enough for webhook to fetch configmap in `kube-public` ns