### PR TITLE
add csWebhookOperatorEnableOpreqWebhook into csv

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -298,7 +298,7 @@ metadata:
             containers:
             - command:
               - /manager
-              image: quay.io/opencloudio/ibm-secretshare-operator@sha256:54e2e44785a240ea9d633aef9c043c0d8793f557be499f05ed2909803d3bb6ba
+              image: quay.io/opencloudio/ibm-secretshare-operator@sha256:448a2dcf4b3a44b8984fa527c43de0c8a029802a60d59c553a9d345bc01824be
               imagePullPolicy: Always
               name: ibm-secretshare-operator
               env:

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -342,7 +342,7 @@ metadata:
             serviceAccountName: ibm-common-service-webhook
             containers:
               - name: ibm-common-service-webhook
-                image: quay.io/opencloudio/ibm-cs-webhook@sha256:707a233c3f388123ae0869f9fd974f42f4ee32045ddeb8908d9ceb4ff82488a1
+                image: quay.io/opencloudio/ibm-cs-webhook@sha256:7b74eca54944f95134e4f751d977b40e9890315c9d0f794d4e55f3b8edffa4b7
                 command:
                 - ibm-common-service-webhook
                 imagePullPolicy: Always
@@ -357,6 +357,64 @@ metadata:
                         fieldPath: metadata.name
                   - name: OPERATOR_NAME
                     value: "ibm-common-service-webhook"
+                ports:
+                  - containerPort: 8443
+                    protocol: TCP
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 256Mi
+                  requests:
+                    cpu: 200m
+                    memory: 256Mi
+                volumeMounts:
+                - name: webhook-certs
+                  mountPath: "/etc/ssl/certs/webhook"
+            volumes:
+            - name: webhook-certs
+              emptyDir: {}
+    csWebhookOperatorEnableOpreqWebhook: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ibm-common-service-webhook
+        namespace: placeholder
+        annotations:
+          version: "8"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            name: ibm-common-service-webhook
+        template:
+          metadata:
+            annotations:
+              productID: 068a62892a1e4db39641342e592daa25
+              productMetric: FREE
+              productName: IBM Cloud Platform Common Services
+            labels:
+              name: ibm-common-service-webhook
+          spec:
+            serviceAccountName: ibm-common-service-webhook
+            containers:
+              - name: ibm-common-service-webhook
+                image: quay.io/opencloudio/ibm-cs-webhook@sha256:7b74eca54944f95134e4f751d977b40e9890315c9d0f794d4e55f3b8edffa4b7
+                command:
+                - ibm-common-service-webhook
+                imagePullPolicy: Always
+                env:
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: "ibm-common-service-webhook"
+                  - name: ENABLE_OPREQ_WEBHOOK
+                    value: "TRUE"
                 ports:
                   - containerPort: 8443
                     protocol: TCP

--- a/common/scripts/lint-csv.sh
+++ b/common/scripts/lint-csv.sh
@@ -40,7 +40,7 @@ echo "Lint alm-examples"
 $YQ r $CSV_PATH metadata.annotations.alm-examples | $JQ . >/dev/null || STATUS=1
 
 # Lint yamls, only CS Operator needs this part
-for section in csOperandConfig csOperandRegistry csOperatorSubscription csSecretshareOperator csWebhookOperator nsRestrictedSubscription nsSubscription odlmClusterSubscription odlmNamespacedSubscription; do
+for section in csOperandConfig csOperandRegistry csOperatorSubscription csSecretshareOperator csWebhookOperator csWebhookOperatorEnableOpreqWebhook nsRestrictedSubscription nsSubscription odlmClusterSubscription odlmNamespacedSubscription; do
     echo "Lint $section"
     $YQ r $CSV_PATH metadata.annotations.$section | $YQ r - >/dev/null || STATUS=1
 done

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -281,7 +281,7 @@ metadata:
             containers:
             - command:
               - /manager
-              image: quay.io/opencloudio/ibm-secretshare-operator@sha256:54e2e44785a240ea9d633aef9c043c0d8793f557be499f05ed2909803d3bb6ba
+              image: quay.io/opencloudio/ibm-secretshare-operator@sha256:448a2dcf4b3a44b8984fa527c43de0c8a029802a60d59c553a9d345bc01824be
               imagePullPolicy: Always
               name: ibm-secretshare-operator
               env:

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -356,6 +356,64 @@ metadata:
             volumes:
             - name: webhook-certs
               emptyDir: {}
+    csWebhookOperatorEnableOpreqWebhook: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ibm-common-service-webhook
+        namespace: placeholder
+        annotations:
+          version: "8"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            name: ibm-common-service-webhook
+        template:
+          metadata:
+            annotations:
+              productID: 068a62892a1e4db39641342e592daa25
+              productMetric: FREE
+              productName: IBM Cloud Platform Common Services
+            labels:
+              name: ibm-common-service-webhook
+          spec:
+            serviceAccountName: ibm-common-service-webhook
+            containers:
+              - name: ibm-common-service-webhook
+                image: quay.io/opencloudio/ibm-cs-webhook@sha256:7b74eca54944f95134e4f751d977b40e9890315c9d0f794d4e55f3b8edffa4b7
+                command:
+                - ibm-common-service-webhook
+                imagePullPolicy: Always
+                env:
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: "ibm-common-service-webhook"
+                  - name: ENABLE_OPREQ_WEBHOOK
+                    value: "TRUE"
+                ports:
+                  - containerPort: 8443
+                    protocol: TCP
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 256Mi
+                  requests:
+                    cpu: 200m
+                    memory: 256Mi
+                volumeMounts:
+                - name: webhook-certs
+                  mountPath: "/etc/ssl/certs/webhook"
+            volumes:
+            - name: webhook-certs
+              emptyDir: {}
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nsRestrictedSubscription: |-
       apiVersion: operators.coreos.com/v1alpha1

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -180,8 +180,8 @@ func Namespacelize(resource, ns string) string {
 	return strings.ReplaceAll(resource, "placeholder", ns)
 }
 
-// Get ConfigMap of Common Services Maps
-func getCmOfMapCs(r client.Reader) (*corev1.ConfigMap, error) {
+// GetCmOfMapCs gets ConfigMap of Common Services Maps
+func GetCmOfMapCs(r client.Reader) (*corev1.ConfigMap, error) {
 	cmName := constant.CsMapConfigMap
 	cmNs := "kube-public"
 	csConfigmap := &corev1.ConfigMap{}
@@ -204,7 +204,7 @@ func GetMasterNs(r client.Reader) (masterNs string) {
 		return
 	}
 
-	csConfigmap, err := getCmOfMapCs(r)
+	csConfigmap, err := GetCmOfMapCs(r)
 	if err != nil {
 		klog.Infof("Don't find configmap kube-public/common-service-maps: %v", err)
 		return

--- a/testdata/deploy/deploy.yaml
+++ b/testdata/deploy/deploy.yaml
@@ -277,7 +277,7 @@ spec:
                 containers:
                 - command:
                   - /manager
-                  image: quay.io/opencloudio/ibm-secretshare-operator@sha256:54e2e44785a240ea9d633aef9c043c0d8793f557be499f05ed2909803d3bb6ba
+                  image: quay.io/opencloudio/ibm-secretshare-operator@sha256:448a2dcf4b3a44b8984fa527c43de0c8a029802a60d59c553a9d345bc01824be
                   imagePullPolicy: Always
                   name: ibm-secretshare-operator
                   env:

--- a/testdata/deploy/deploy.yaml
+++ b/testdata/deploy/deploy.yaml
@@ -352,6 +352,64 @@ spec:
                 volumes:
                 - name: webhook-certs
                   emptyDir: {}
+    csWebhookOperatorEnableOpreqWebhook: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ibm-common-service-webhook
+        namespace: placeholder
+        annotations:
+          version: "8"
+      spec:
+        replicas: 1
+        selector:
+          matchLabels:
+            name: ibm-common-service-webhook
+        template:
+          metadata:
+            annotations:
+              productID: 068a62892a1e4db39641342e592daa25
+              productMetric: FREE
+              productName: IBM Cloud Platform Common Services
+            labels:
+              name: ibm-common-service-webhook
+          spec:
+            serviceAccountName: ibm-common-service-webhook
+            containers:
+              - name: ibm-common-service-webhook
+                image: quay.io/opencloudio/ibm-cs-webhook@sha256:7b74eca54944f95134e4f751d977b40e9890315c9d0f794d4e55f3b8edffa4b7
+                command:
+                - ibm-common-service-webhook
+                imagePullPolicy: Always
+                env:
+                  - name: WATCH_NAMESPACE
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.namespace
+                  - name: POD_NAME
+                    valueFrom:
+                      fieldRef:
+                        fieldPath: metadata.name
+                  - name: OPERATOR_NAME
+                    value: "ibm-common-service-webhook"
+                  - name: ENABLE_OPREQ_WEBHOOK
+                    value: "TRUE"
+                ports:
+                  - containerPort: 8443
+                    protocol: TCP
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 256Mi
+                  requests:
+                    cpu: 200m
+                    memory: 256Mi
+                volumeMounts:
+                - name: webhook-certs
+                  mountPath: "/etc/ssl/certs/webhook"
+            volumes:
+            - name: webhook-certs
+              emptyDir: {}
         description: The IBM Common Service Operator is used to deploy IBM Common Services
         nsRestrictedSubscription: |-
           apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
Update digest for the cs webhook and secretshare.
Only generates operandrequest webhook when there is common service mapping configmap.  