### PR TITLE
switch 3.7 to v3 channel

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -748,5 +748,4 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.6.2
   version: 3.7.0

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -550,5 +550,4 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.6.2
   version: 0.0.0


### PR DESCRIPTION
1. Remove the `replace` section as it is the origin of `v3` channel.

2. Keep `olm.skipRange: '>=3.3.0 <3.7.0'` as it supports upgrading from the version smaller than `3.7.0`.

3. ~~Update the channel to `v3` for the subscription and the operator in the `opencloud-operators` CatalogSource.~~
Currently, we did not update the channel of subscription and operator in `OperandRegistry` in `beta` stage, leaving the task to CICD pipeline.

4. Did not update the version in annotation since there is no release published yet.