### PR TITLE
updated go to version 1.15.7 to fix CVE-2021-3114 and CVE-2021-3115

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.14.7 as builder
+FROM golang:1.15.7 as builder
 ARG GOARCH
 
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-common-service-operator
 
-go 1.13
+go 1.15
 
 require (
 	github.com/IBM/ibm-namespace-scope-operator v1.0.1


### PR DESCRIPTION
/cherry-pick release-3.6