### PR TITLE
fix: Keep both storageclass and size info

### DIFF
--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -231,9 +231,9 @@ func (r *CommonServiceReconciler) updateOperandConfig(newConfigs []interface{}) 
 		return true, err
 	}
 
-	for _, opService := range opconServices {
+	for _, newConfigForOperator := range newConfigs {
+		opService := getItemByName(opconServices, newConfigForOperator.(map[string]interface{})["name"].(string))
 		// Fetch newConfigForOperator and rules for an operator
-		newConfigForOperator := getItemByName(newConfigs, opService.(map[string]interface{})["name"].(string))
 		rules := getItemByName(ruleSlice, opService.(map[string]interface{})["name"].(string))
 		if newConfigForOperator == nil {
 			continue


### PR DESCRIPTION
iterate services in the newconfig instead of services in the common service CR


fix #432 