### PR TITLE
updated ibm-iam-operator OperandBindInfo in CSV's OperandConfig template

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -74,21 +74,6 @@ metadata:
               bindings:
                 protected-zen-serviceid:
                   secret: zen-serviceid-apikey-secret
-                public-auth-cert:
-                  secret: platform-auth-secret
-                public-auth-config:
-                  configmap: platform-auth-idp
-                public-auth-creds:
-                  secret: platform-auth-idp-credentials
-                public-cam-map:
-                  configmap: oauth-client-map
-                public-cam-secret:
-                  secret: oauth-client-secret
-                public-oidc-creds:
-                  secret: platform-oidc-credentials
-              description: Binding information that should be accessible to iam adopters
-              operand: ibm-iam-operator
-              registry: common-service
             operandRequest: {}
         - name: ibm-healthcheck-operator
           spec:

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ metadata:
         name: common-service
         namespace: placeholder
         annotations:
-          version: "8"
+          version: "9"
       spec:
         services:
         - name: ibm-licensing-operator
@@ -70,7 +70,25 @@ metadata:
             policydecision: {}
             secretwatcher: {}
             securityonboarding: {}
-            operandBindInfo: {}
+            operandBindInfo:
+              bindings:
+                protected-zen-serviceid:
+                  secret: zen-serviceid-apikey-secret
+                public-auth-cert:
+                  secret: platform-auth-secret
+                public-auth-config:
+                  configmap: platform-auth-idp
+                public-auth-creds:
+                  secret: platform-auth-idp-credentials
+                public-cam-map:
+                  configmap: oauth-client-map
+                public-cam-secret:
+                  secret: oauth-client-secret
+                public-oidc-creds:
+                  secret: platform-oidc-credentials
+              description: Binding information that should be accessible to iam adopters
+              operand: ibm-iam-operator
+              registry: common-service
             operandRequest: {}
         - name: ibm-healthcheck-operator
           spec:

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -57,21 +57,6 @@ metadata:
               bindings:
                 protected-zen-serviceid:
                   secret: zen-serviceid-apikey-secret
-                public-auth-cert:
-                  secret: platform-auth-secret
-                public-auth-config:
-                  configmap: platform-auth-idp
-                public-auth-creds:
-                  secret: platform-auth-idp-credentials
-                public-cam-map:
-                  configmap: oauth-client-map
-                public-cam-secret:
-                  secret: oauth-client-secret
-                public-oidc-creds:
-                  secret: platform-oidc-credentials
-              description: Binding information that should be accessible to iam adopters
-              operand: ibm-iam-operator
-              registry: common-service
             operandRequest: {}
         - name: ibm-healthcheck-operator
           spec:

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
         name: common-service
         namespace: placeholder
         annotations:
-          version: "8"
+          version: "9"
       spec:
         services:
         - name: ibm-licensing-operator
@@ -53,7 +53,25 @@ metadata:
             policydecision: {}
             secretwatcher: {}
             securityonboarding: {}
-            operandBindInfo: {}
+            operandBindInfo:
+              bindings:
+                protected-zen-serviceid:
+                  secret: zen-serviceid-apikey-secret
+                public-auth-cert:
+                  secret: platform-auth-secret
+                public-auth-config:
+                  configmap: platform-auth-idp
+                public-auth-creds:
+                  secret: platform-auth-idp-credentials
+                public-cam-map:
+                  configmap: oauth-client-map
+                public-cam-secret:
+                  secret: oauth-client-secret
+                public-oidc-creds:
+                  secret: platform-oidc-credentials
+              description: Binding information that should be accessible to iam adopters
+              operand: ibm-iam-operator
+              registry: common-service
             operandRequest: {}
         - name: ibm-healthcheck-operator
           spec:


### PR DESCRIPTION
to expose zen-serviceid-apikey-secret for onboarding users from IAM to
Zen