### PR TITLE
fixed workflow unable to access secrets in forked PR

### DIFF
--- a/.github/workflows/ocp.yaml
+++ b/.github/workflows/ocp.yaml
@@ -17,7 +17,8 @@
 name: ocp.yaml
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [labeled]
 
 env:
   AWS_OCP_KUBECONFIG: ${{ secrets.AWS_OCP_KUBECONFIG }}
@@ -39,6 +40,10 @@ jobs:
         id: go
 
       - name: Checkout
+        if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
         uses: actions/checkout@v2
 
       - name: Access cluster

--- a/.github/workflows/ocp.yaml
+++ b/.github/workflows/ocp.yaml
@@ -18,7 +18,7 @@ name: ocp.yaml
 
 on:
   pull_request_target:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   AWS_OCP_KUBECONFIG: ${{ secrets.AWS_OCP_KUBECONFIG }}


### PR DESCRIPTION
Current workflow only runs properly if opening a pull request from a branch in the upstream repo. The workflow will not get Github secrets from forked PRs using the `pull_request` event, so need to use `pull_request_target`. 

There are some security concerns with this though, as described [here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). The main concern is that the workflow will run code from any forked PR, which could contain malicious code. To prevent this, a check is added so that the code will only be checked out if repo maintainers label the PR as `ok-to-test`.