### PR TITLE
Update OperandRegistry and OperandConfig for SaaS deployment

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -116,6 +116,83 @@ metadata:
           spec:
             grafana: {}
             operandRequest: {}
+    csV3SaasOperandConfig: |-
+      apiVersion: operator.ibm.com/v1alpha1
+      kind: OperandConfig
+      metadata:
+        name: common-service
+        namespace: placeholder
+        annotations:
+          version: "9"
+      spec:
+        services:
+        - name: ibm-licensing-operator
+          spec:
+            IBMLicensing:
+              datasource: datacollector
+            operandBindInfo: {}
+        - name: ibm-mongodb-operator
+          spec:
+            mongoDB: {}
+            operandRequest: {}
+        - name: ibm-cert-manager-operator
+          spec:
+            certManager: {}
+        - name: ibm-iam-operator
+          spec:
+            authentication: {}
+            oidcclientwatcher: {}
+            pap: {}
+            policycontroller: {}
+            policydecision: {}
+            secretwatcher: {}
+            securityonboarding: {}
+            operandBindInfo:
+              bindings:
+                protected-zen-serviceid:
+                  secret: zen-serviceid-apikey-secret
+            operandRequest: {}
+        - name: ibm-healthcheck-operator
+          spec:
+            healthService: {}
+            mustgatherService: {}
+            mustgatherConfig: {}
+        - name: ibm-commonui-operator
+          spec:
+            commonWebUI: {}
+            switcheritem: {}
+            operandRequest: {}
+            navconfiguration: {}
+            operandBindInfo: {}
+        - name: ibm-management-ingress-operator
+          spec:
+            managementIngress: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-ingress-nginx-operator
+          spec:
+            nginxIngress: {}
+        - name: ibm-auditlogging-operator
+          spec:
+            auditLogging: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-platform-api-operator
+          spec:
+            platformApi: {}
+            operandRequest: {}
+        - name: ibm-monitoring-exporters-operator
+          spec:
+            exporter: {}
+            operandRequest: {}
+        - name: ibm-monitoring-prometheusext-operator
+          spec:
+            prometheusExt: {}
+            operandRequest: {}
+        - name: ibm-monitoring-grafana-operator
+          spec:
+            grafana: {}
+            operandRequest: {}
     csV3OperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry
@@ -141,6 +218,134 @@ metadata:
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
           namespace: placeholder
+          channel: beta
+          packageName: ibm-cert-manager-operator
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-iam-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-iam-operator
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-healthcheck-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-healthcheck-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-commonui-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-commonui-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-management-ingress-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-management-ingress-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-ingress-nginx-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-ingress-nginx-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-auditlogging-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-auditlogging-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-platform-api-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-platform-api-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-monitoring-exporters-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-monitoring-exporters-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-monitoring-prometheusext-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-monitoring-prometheusext-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - channel: beta
+          name: ibm-monitoring-grafana-operator
+          namespace: placeholder
+          packageName: ibm-monitoring-grafana-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - channel: beta
+          name: ibm-events-operator
+          namespace: placeholder
+          packageName: ibm-events-operator
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - channel: stable
+          name: redhat-marketplace-operator
+          namespace: openshift-redhat-marketplace
+          packageName: redhat-marketplace-operator
+          scope: public
+          sourceName: certified-operators
+          sourceNamespace: openshift-marketplace
+        - channel: beta
+          name: ibm-zen-operator
+          namespace: placeholder
+          packageName: ibm-zen-operator
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - channel: v1.0
+          name: ibm-db2u-operator
+          namespace: placeholder
+          packageName: db2u-operator
+          scope: public
+          sourceName: ibm-operator-catalog
+          sourceNamespace: openshift-marketplace
+    csV3SaasOperandRegistry: |-
+      apiVersion: operator.ibm.com/v1alpha1
+      kind: OperandRegistry
+      metadata:
+        name: common-service
+        namespace: placeholder
+        annotations:
+          version: "14"
+      spec:
+        operators:
+        - name: ibm-licensing-operator
+          namespace: placeholderControlNs
+          channel: beta
+          packageName: ibm-licensing-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-mongodb-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-mongodb-operator-app
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-cert-manager-operator
+          namespace: placeholderControlNs
           channel: beta
           packageName: ibm-cert-manager-operator
           scope: public

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -152,18 +152,6 @@ metadata:
                 protected-zen-serviceid:
                   secret: zen-serviceid-apikey-secret
             operandRequest: {}
-        - name: ibm-healthcheck-operator
-          spec:
-            healthService: {}
-            mustgatherService: {}
-            mustgatherConfig: {}
-        - name: ibm-commonui-operator
-          spec:
-            commonWebUI: {}
-            switcheritem: {}
-            operandRequest: {}
-            navconfiguration: {}
-            operandBindInfo: {}
         - name: ibm-management-ingress-operator
           spec:
             managementIngress: {}
@@ -172,27 +160,6 @@ metadata:
         - name: ibm-ingress-nginx-operator
           spec:
             nginxIngress: {}
-        - name: ibm-auditlogging-operator
-          spec:
-            auditLogging: {}
-            operandBindInfo: {}
-            operandRequest: {}
-        - name: ibm-platform-api-operator
-          spec:
-            platformApi: {}
-            operandRequest: {}
-        - name: ibm-monitoring-exporters-operator
-          spec:
-            exporter: {}
-            operandRequest: {}
-        - name: ibm-monitoring-prometheusext-operator
-          spec:
-            prometheusExt: {}
-            operandRequest: {}
-        - name: ibm-monitoring-grafana-operator
-          spec:
-            grafana: {}
-            operandRequest: {}
     csV3OperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry
@@ -358,20 +325,6 @@ metadata:
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - name: ibm-healthcheck-operator
-          namespace: placeholder
-          channel: beta
-          packageName: ibm-healthcheck-operator-app
-          scope: public
-          sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
-        - name: ibm-commonui-operator
-          namespace: placeholder
-          channel: beta
-          packageName: ibm-commonui-operator-app
-          scope: public
-          sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
         - name: ibm-management-ingress-operator
           namespace: placeholder
           channel: beta
@@ -386,41 +339,6 @@ metadata:
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - name: ibm-auditlogging-operator
-          namespace: placeholder
-          channel: beta
-          packageName: ibm-auditlogging-operator-app
-          scope: public
-          sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
-        - name: ibm-platform-api-operator
-          namespace: placeholder
-          channel: beta
-          packageName: ibm-platform-api-operator-app
-          scope: public
-          sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
-        - name: ibm-monitoring-exporters-operator
-          namespace: placeholder
-          channel: beta
-          packageName: ibm-monitoring-exporters-operator-app
-          scope: public
-          sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
-        - name: ibm-monitoring-prometheusext-operator
-          namespace: placeholder
-          channel: beta
-          packageName: ibm-monitoring-prometheusext-operator-app
-          scope: public
-          sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
-        - channel: beta
-          name: ibm-monitoring-grafana-operator
-          namespace: placeholder
-          packageName: ibm-monitoring-grafana-operator-app
-          scope: public
-          sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
         - channel: beta
           name: ibm-events-operator
           namespace: placeholder
@@ -428,26 +346,12 @@ metadata:
           scope: public
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
-        - channel: stable
-          name: redhat-marketplace-operator
-          namespace: openshift-redhat-marketplace
-          packageName: redhat-marketplace-operator
-          scope: public
-          sourceName: certified-operators
-          sourceNamespace: openshift-marketplace
         - channel: beta
           name: ibm-zen-operator
           namespace: placeholder
           packageName: ibm-zen-operator
           scope: public
           sourceName: opencloud-operators
-          sourceNamespace: openshift-marketplace
-        - channel: v1.0
-          name: ibm-db2u-operator
-          namespace: placeholder
-          packageName: db2u-operator
-          scope: public
-          sourceName: ibm-operator-catalog
           sourceNamespace: openshift-marketplace
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nsRestrictedSubscription: |-

--- a/common/scripts/lint-csv.sh
+++ b/common/scripts/lint-csv.sh
@@ -40,7 +40,7 @@ echo "Lint alm-examples"
 $YQ r $CSV_PATH metadata.annotations.alm-examples | $JQ . >/dev/null || STATUS=1
 
 # Lint yamls, only CS Operator needs this part
-for section in csV3OperandConfig csV3OperandRegistry csOperatorSubscription csSecretshareOperator csWebhookOperator csWebhookOperatorEnableOpreqWebhook nsRestrictedSubscription nsSubscription odlmClusterSubscription odlmNamespacedSubscription; do
+for section in csV3OperandConfig csV3SaasOperandConfig csV3OperandRegistry csV3SaasOperandRegistry csOperatorSubscription csSecretshareOperator csWebhookOperator csWebhookOperatorEnableOpreqWebhook nsRestrictedSubscription nsSubscription odlmClusterSubscription odlmNamespacedSubscription; do
     echo "Lint $section"
     $YQ r $CSV_PATH metadata.annotations.$section | $YQ r - >/dev/null || STATUS=1
 done

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -99,6 +99,50 @@ metadata:
           spec:
             grafana: {}
             operandRequest: {}
+    csV3SaasOperandConfig: |-
+      apiVersion: operator.ibm.com/v1alpha1
+      kind: OperandConfig
+      metadata:
+        name: common-service
+        namespace: placeholder
+        annotations:
+          version: "9"
+      spec:
+        services:
+        - name: ibm-licensing-operator
+          spec:
+            IBMLicensing:
+              datasource: datacollector
+            operandBindInfo: {}
+        - name: ibm-mongodb-operator
+          spec:
+            mongoDB: {}
+            operandRequest: {}
+        - name: ibm-cert-manager-operator
+          spec:
+            certManager: {}
+        - name: ibm-iam-operator
+          spec:
+            authentication: {}
+            oidcclientwatcher: {}
+            pap: {}
+            policycontroller: {}
+            policydecision: {}
+            secretwatcher: {}
+            securityonboarding: {}
+            operandBindInfo:
+              bindings:
+                protected-zen-serviceid:
+                  secret: zen-serviceid-apikey-secret
+            operandRequest: {}
+        - name: ibm-management-ingress-operator
+          spec:
+            managementIngress: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-ingress-nginx-operator
+          spec:
+            nginxIngress: {}
     csV3OperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry
@@ -226,6 +270,71 @@ metadata:
           packageName: db2u-operator
           scope: public
           sourceName: ibm-operator-catalog
+          sourceNamespace: openshift-marketplace
+    csV3SaasOperandRegistry: |-
+      apiVersion: operator.ibm.com/v1alpha1
+      kind: OperandRegistry
+      metadata:
+        name: common-service
+        namespace: placeholder
+        annotations:
+          version: "14"
+      spec:
+        operators:
+        - name: ibm-licensing-operator
+          namespace: placeholderControlNs
+          channel: beta
+          packageName: ibm-licensing-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-mongodb-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-mongodb-operator-app
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-cert-manager-operator
+          namespace: placeholderControlNs
+          channel: beta
+          packageName: ibm-cert-manager-operator
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-iam-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-iam-operator
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-management-ingress-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-management-ingress-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - name: ibm-ingress-nginx-operator
+          namespace: placeholder
+          channel: beta
+          packageName: ibm-ingress-nginx-operator-app
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - channel: beta
+          name: ibm-events-operator
+          namespace: placeholder
+          packageName: ibm-events-operator
+          scope: public
+          sourceName: opencloud-operators
+          sourceNamespace: openshift-marketplace
+        - channel: beta
+          name: ibm-zen-operator
+          namespace: placeholder
+          packageName: ibm-zen-operator
+          scope: public
+          sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nsRestrictedSubscription: |-

--- a/controllers/render_template.go
+++ b/controllers/render_template.go
@@ -32,10 +32,7 @@ func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured) (
 	var newConfigs []interface{}
 	var err error
 	// Update IAM in OperandConfig
-	saasEnable, err := util.CheckSaas(r.Reader)
-	if err != nil {
-		return nil, err
-	}
+	saasEnable := util.CheckSaas(r.Reader)
 	if saasEnable {
 		klog.Info("IAM Saas configuration")
 		iamConfig, err := convertStringToSlice(iam.Template)

--- a/testdata/deploy/deploy.yaml
+++ b/testdata/deploy/deploy.yaml
@@ -97,6 +97,50 @@ spec:
                 elasticStack: {}
                 operandBindInfo: {}
                 operandRequest: {}
+        csV3SaasOperandConfig: |-
+          apiVersion: operator.ibm.com/v1alpha1
+          kind: OperandConfig
+          metadata:
+            name: common-service
+            namespace: placeholder
+            annotations:
+              version: "9"
+          spec:
+            services:
+            - name: ibm-licensing-operator
+              spec:
+                IBMLicensing:
+                  datasource: datacollector
+                operandBindInfo: {}
+            - name: ibm-mongodb-operator
+              spec:
+                mongoDB: {}
+                operandRequest: {}
+            - name: ibm-cert-manager-operator
+              spec:
+                certManager: {}
+            - name: ibm-iam-operator
+              spec:
+                authentication: {}
+                oidcclientwatcher: {}
+                pap: {}
+                policycontroller: {}
+                policydecision: {}
+                secretwatcher: {}
+                securityonboarding: {}
+                operandBindInfo:
+                  bindings:
+                    protected-zen-serviceid:
+                      secret: zen-serviceid-apikey-secret
+                operandRequest: {}
+            - name: ibm-management-ingress-operator
+              spec:
+                managementIngress: {}
+                operandBindInfo: {}
+                operandRequest: {}
+            - name: ibm-ingress-nginx-operator
+              spec:
+                nginxIngress: {}
         csV3OperandRegistry: |-
           apiVersion: operator.ibm.com/v1alpha1
           kind: OperandRegistry
@@ -201,6 +245,71 @@ spec:
               name: ibm-events-operator
               namespace: placeholder
               packageName: ibm-events-operator
+              scope: public
+              sourceName: opencloud-operators
+              sourceNamespace: openshift-marketplace
+        csV3SaasOperandRegistry: |-
+          apiVersion: operator.ibm.com/v1alpha1
+          kind: OperandRegistry
+          metadata:
+            name: common-service
+            namespace: placeholder
+            annotations:
+              version: "14"
+          spec:
+            operators:
+            - name: ibm-licensing-operator
+              namespace: placeholderControlNs
+              channel: beta
+              packageName: ibm-licensing-operator-app
+              scope: public
+              sourceName: opencloud-operators
+              sourceNamespace: openshift-marketplace
+            - name: ibm-mongodb-operator
+              namespace: placeholder
+              channel: beta
+              packageName: ibm-mongodb-operator-app
+              sourceName: opencloud-operators
+              sourceNamespace: openshift-marketplace
+            - name: ibm-cert-manager-operator
+              namespace: placeholderControlNs
+              channel: beta
+              packageName: ibm-cert-manager-operator
+              scope: public
+              sourceName: opencloud-operators
+              sourceNamespace: openshift-marketplace
+            - name: ibm-iam-operator
+              namespace: placeholder
+              channel: beta
+              packageName: ibm-iam-operator
+              scope: public
+              sourceName: opencloud-operators
+              sourceNamespace: openshift-marketplace
+            - name: ibm-management-ingress-operator
+              namespace: placeholder
+              channel: beta
+              packageName: ibm-management-ingress-operator-app
+              scope: public
+              sourceName: opencloud-operators
+              sourceNamespace: openshift-marketplace
+            - name: ibm-ingress-nginx-operator
+              namespace: placeholder
+              channel: beta
+              packageName: ibm-ingress-nginx-operator-app
+              scope: public
+              sourceName: opencloud-operators
+              sourceNamespace: openshift-marketplace
+            - channel: beta
+              name: ibm-events-operator
+              namespace: placeholder
+              packageName: ibm-events-operator
+              scope: public
+              sourceName: opencloud-operators
+              sourceNamespace: openshift-marketplace
+            - channel: beta
+              name: ibm-zen-operator
+              namespace: placeholder
+              packageName: ibm-zen-operator
               scope: public
               sourceName: opencloud-operators
               sourceNamespace: openshift-marketplace


### PR DESCRIPTION
What is this PR doing?

1. In CSV, Create brand new templates of `OperandConfig` and `OperandRegistry` for SaaS deployment.
2. Integrate `ControlNs` and `SaasEnable` into `bootstrap`
3. Integrate the installation flow of Namespace-scope operator into one function in order to reduce the complexity of `InitResources` function.
4. don't install `secretshare operator` in SaaS deployment https://github.com/IBM/ibm-common-service-operator/pull/446#discussion_r605361604
5. Install different `OperandConfig` and `OperandRegistry` based on SaaS or non-SaaS deployment. https://github.com/IBM/ibm-common-service-operator/pull/450#issuecomment-809105028

What is unclear?
1. the content of templates for both `OperandConfig` and `OperandRegistry`