### PR TITLE
fixed error checking out code in workflow

### DIFF
--- a/.github/workflows/ocp.yaml
+++ b/.github/workflows/ocp.yaml
@@ -43,6 +43,7 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
         with:
           ref: ${{ github.event.pull_request.head.ref }}
+          repo: ${{ github.event.pull_request.head.repo.full_name }}
           persist-credentials: false
         uses: actions/checkout@v2
 


### PR DESCRIPTION
both
```
          ref: ${{ github.event.pull_request.head.ref }}
          repo: ${{ github.event.pull_request.head.repo.full_name }}
```
are necessary to check out the PR code