### PR TITLE
create issuer and certificate

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -59,8 +59,6 @@ metadata:
         - name: ibm-cert-manager-operator
           spec:
             certManager: {}
-            issuer: {}
-            certificate: {}
         - name: ibm-iam-operator
           spec:
             authentication: {}
@@ -152,6 +150,18 @@ metadata:
                 protected-zen-serviceid:
                   secret: zen-serviceid-apikey-secret
             operandRequest: {}
+        - name: ibm-healthcheck-operator
+          spec:
+            healthService: {}
+            mustgatherService: {}
+            mustgatherConfig: {}
+        - name: ibm-commonui-operator
+          spec:
+            commonWebUI: {}
+            switcheritem: {}
+            operandRequest: {}
+            navconfiguration: {}
+            operandBindInfo: {}
         - name: ibm-management-ingress-operator
           spec:
             managementIngress: {}
@@ -160,6 +170,27 @@ metadata:
         - name: ibm-ingress-nginx-operator
           spec:
             nginxIngress: {}
+        - name: ibm-auditlogging-operator
+          spec:
+            auditLogging: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-platform-api-operator
+          spec:
+            platformApi: {}
+            operandRequest: {}
+        - name: ibm-monitoring-exporters-operator
+          spec:
+            exporter: {}
+            operandRequest: {}
+        - name: ibm-monitoring-prometheusext-operator
+          spec:
+            prometheusExt: {}
+            operandRequest: {}
+        - name: ibm-monitoring-grafana-operator
+          spec:
+            grafana: {}
+            operandRequest: {}
     csV3OperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry
@@ -299,7 +330,7 @@ metadata:
       spec:
         operators:
         - name: ibm-licensing-operator
-          namespace: placeholderControlNs
+          namespace: controlns
           channel: beta
           packageName: ibm-licensing-operator-app
           scope: public
@@ -312,7 +343,7 @@ metadata:
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
-          namespace: placeholderControlNs
+          namespace: controlns
           channel: beta
           packageName: ibm-cert-manager-operator
           scope: public

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -42,8 +42,6 @@ metadata:
         - name: ibm-cert-manager-operator
           spec:
             certManager: {}
-            issuer: {}
-            certificate: {}
         - name: ibm-iam-operator
           spec:
             authentication: {}
@@ -135,6 +133,18 @@ metadata:
                 protected-zen-serviceid:
                   secret: zen-serviceid-apikey-secret
             operandRequest: {}
+        - name: ibm-healthcheck-operator
+          spec:
+            healthService: {}
+            mustgatherService: {}
+            mustgatherConfig: {}
+        - name: ibm-commonui-operator
+          spec:
+            commonWebUI: {}
+            switcheritem: {}
+            operandRequest: {}
+            navconfiguration: {}
+            operandBindInfo: {}
         - name: ibm-management-ingress-operator
           spec:
             managementIngress: {}
@@ -143,6 +153,27 @@ metadata:
         - name: ibm-ingress-nginx-operator
           spec:
             nginxIngress: {}
+        - name: ibm-auditlogging-operator
+          spec:
+            auditLogging: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-platform-api-operator
+          spec:
+            platformApi: {}
+            operandRequest: {}
+        - name: ibm-monitoring-exporters-operator
+          spec:
+            exporter: {}
+            operandRequest: {}
+        - name: ibm-monitoring-prometheusext-operator
+          spec:
+            prometheusExt: {}
+            operandRequest: {}
+        - name: ibm-monitoring-grafana-operator
+          spec:
+            grafana: {}
+            operandRequest: {}
     csV3OperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry
@@ -282,7 +313,7 @@ metadata:
       spec:
         operators:
         - name: ibm-licensing-operator
-          namespace: placeholderControlNs
+          namespace: controlns
           channel: beta
           packageName: ibm-licensing-operator-app
           scope: public
@@ -295,7 +326,7 @@ metadata:
           sourceName: opencloud-operators
           sourceNamespace: openshift-marketplace
         - name: ibm-cert-manager-operator
-          namespace: placeholderControlNs
+          namespace: controlns
           channel: beta
           packageName: ibm-cert-manager-operator
           scope: public

--- a/controllers/certmanager/cert_cr.go
+++ b/controllers/certmanager/cert_cr.go
@@ -1,0 +1,76 @@
+//
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package certmanager
+
+// CSCAIssuer is the CR of cs-ca-issuer
+const CSCAIssuer = `
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  annotations:
+    version: "1"
+  labels:
+    app.kubernetes.io/instance: cs-ca-issuer
+    app.kubernetes.io/managed-by: cert-manager-controller
+    app.kubernetes.io/name: Issuer
+  name: cs-ca-issuer
+  namespace: placeholder
+spec:
+  ca:
+    secretName: cs-ca-certificate-secret
+`
+
+// CSSSIsuuer is the CR of cs-ss-issuer
+const CSSSIssuer = `
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  annotations:
+    version: "1"
+  labels:
+    app.kubernetes.io/instance: cs-ss-issuer
+    app.kubernetes.io/managed-by: cert-manager-controller
+    app.kubernetes.io/name: Issuer
+  name: cs-ss-issuer
+  namespace: placeholder
+spec:
+  selfSigned: {}
+`
+
+// CSCACert is the CR of cs-ca-certificate
+const CSCACert = `
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  annotations:
+    version: "1"
+  labels:
+    app.kubernetes.io/instance: cs-ca-certificate
+    app.kubernetes.io/managed-by: cert-manager-controller
+    app.kubernetes.io/name: Certificate
+  name: cs-ca-certificate
+  namespace: placeholder
+spec:
+  secretName: cs-ca-certificate-secret
+  issuerRef:
+    name: cs-ss-issuer
+    kind: Issuer
+  commonName: cs-ca-certificate
+  isCA: true
+  duration: 17520h0m0s
+  renewBefore: 720h0m0s
+`

--- a/controllers/certmanager/certmanager.go
+++ b/controllers/certmanager/certmanager.go
@@ -1,0 +1,78 @@
+//
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package certmanager
+
+import (
+	"time"
+
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	discovery "k8s.io/client-go/discovery"
+	"k8s.io/klog"
+
+	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
+	util "github.com/IBM/ibm-common-service-operator/controllers/common"
+)
+
+var (
+	DeployCRs       = []string{CSSSIssuer, CSCACert, CSCAIssuer}
+	apiGroupVersion = "certmanager.k8s.io/v1alpha1"
+	Kinds           = []string{"Issuer", "Certificate"}
+	MasterNamespace string
+	placeholder     = "placeholder"
+)
+
+// DeployCR deploys CR certificate and issuer when their CRDs are ready
+func DeployCR(bs *bootstrap.Bootstrap) {
+	for _, kind := range Kinds {
+		if err := waitResourceReady(bs, apiGroupVersion, kind); err != nil {
+			klog.Errorf("Failed to wait for resource ready with kind %s, apiGroupVersion: %s", kind, apiGroupVersion)
+		}
+	}
+
+	for _, cr := range DeployCRs {
+		deployResource(bs, cr)
+	}
+}
+
+func waitResourceReady(bs *bootstrap.Bootstrap, apiGroupVersion string, kind string) error {
+	dc := discovery.NewDiscoveryClientForConfigOrDie(bs.Config)
+	if err := utilwait.PollImmediateInfinite(time.Second*10, func() (done bool, err error) {
+		exist, err := bs.ResourceExists(dc, apiGroupVersion, kind)
+		if err != nil {
+			return exist, err
+		}
+		if !exist {
+			klog.Infof("waiting for resource ready with kind: %s, apiGroupVersion: %s", kind, apiGroupVersion)
+		}
+		return exist, nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func deployResource(bs *bootstrap.Bootstrap, cr string) {
+	if err := utilwait.PollImmediateInfinite(time.Second*10, func() (done bool, err error) {
+		err = bs.CreateOrUpdateFromYaml([]byte(util.Namespacelize(cr, placeholder, bs.MasterNamespace)))
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}); err != nil {
+		klog.Errorf("Failed to create Certmanager resource: %v", err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	operatorv3 "github.com/IBM/ibm-common-service-operator/api/v3"
 	"github.com/IBM/ibm-common-service-operator/controllers"
 	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
+	certmanager "github.com/IBM/ibm-common-service-operator/controllers/certmanager"
 	"github.com/IBM/ibm-common-service-operator/controllers/check"
 	util "github.com/IBM/ibm-common-service-operator/controllers/common"
 	"github.com/IBM/ibm-common-service-operator/controllers/constant"
@@ -116,6 +117,8 @@ func main() {
 
 		// Check IAM pods status
 		go check.IamStatus(mgr)
+		// Generate Issuer and Certificate CR
+		go certmanager.DeployCR(bs)
 
 		if err = (&controllers.CommonServiceReconciler{
 			Client:    mgr.GetClient(),

--- a/testdata/deploy/deploy.yaml
+++ b/testdata/deploy/deploy.yaml
@@ -21,7 +21,7 @@ spec:
             name: common-service
             namespace: placeholder
             annotations:
-              version: "7"
+              version: "9"
           spec:
             services:
             - name: ibm-licensing-operator
@@ -36,17 +36,19 @@ spec:
             - name: ibm-cert-manager-operator
               spec:
                 certManager: {}
-                issuer: {}
-                certificate: {}
             - name: ibm-iam-operator
               spec:
                 authentication: {}
                 oidcclientwatcher: {}
                 pap: {}
+                policycontroller: {}
                 policydecision: {}
                 secretwatcher: {}
                 securityonboarding: {}
-                operandBindInfo: {}
+                operandBindInfo:
+                  bindings:
+                    protected-zen-serviceid:
+                      secret: zen-serviceid-apikey-secret
                 operandRequest: {}
             - name: ibm-healthcheck-operator
               spec:
@@ -59,6 +61,7 @@ spec:
                 switcheritem: {}
                 operandRequest: {}
                 navconfiguration: {}
+                operandBindInfo: {}
             - name: ibm-management-ingress-operator
               spec:
                 managementIngress: {}
@@ -71,10 +74,6 @@ spec:
               spec:
                 auditLogging: {}
                 operandBindInfo: {}
-                operandRequest: {}
-            - name: ibm-catalog-ui-operator
-              spec:
-                catalogUI: {}
                 operandRequest: {}
             - name: ibm-platform-api-operator
               spec:
@@ -91,11 +90,6 @@ spec:
             - name: ibm-monitoring-grafana-operator
               spec:
                 grafana: {}
-                operandRequest: {}
-            - name: ibm-elastic-stack-operator
-              spec:
-                elasticStack: {}
-                operandBindInfo: {}
                 operandRequest: {}
         csV3SaasOperandConfig: |-
           apiVersion: operator.ibm.com/v1alpha1
@@ -133,6 +127,18 @@ spec:
                     protected-zen-serviceid:
                       secret: zen-serviceid-apikey-secret
                 operandRequest: {}
+            - name: ibm-healthcheck-operator
+              spec:
+                healthService: {}
+                mustgatherService: {}
+                mustgatherConfig: {}
+            - name: ibm-commonui-operator
+              spec:
+                commonWebUI: {}
+                switcheritem: {}
+                operandRequest: {}
+                navconfiguration: {}
+                operandBindInfo: {}
             - name: ibm-management-ingress-operator
               spec:
                 managementIngress: {}
@@ -141,6 +147,27 @@ spec:
             - name: ibm-ingress-nginx-operator
               spec:
                 nginxIngress: {}
+            - name: ibm-auditlogging-operator
+              spec:
+                auditLogging: {}
+                operandBindInfo: {}
+                operandRequest: {}
+            - name: ibm-platform-api-operator
+              spec:
+                platformApi: {}
+                operandRequest: {}
+            - name: ibm-monitoring-exporters-operator
+              spec:
+                exporter: {}
+                operandRequest: {}
+            - name: ibm-monitoring-prometheusext-operator
+              spec:
+                prometheusExt: {}
+                operandRequest: {}
+            - name: ibm-monitoring-grafana-operator
+              spec:
+                grafana: {}
+                operandRequest: {}
         csV3OperandRegistry: |-
           apiVersion: operator.ibm.com/v1alpha1
           kind: OperandRegistry
@@ -259,7 +286,7 @@ spec:
           spec:
             operators:
             - name: ibm-licensing-operator
-              namespace: placeholderControlNs
+              namespace: controlns
               channel: beta
               packageName: ibm-licensing-operator-app
               scope: public
@@ -272,7 +299,7 @@ spec:
               sourceName: opencloud-operators
               sourceNamespace: openshift-marketplace
             - name: ibm-cert-manager-operator
-              namespace: placeholderControlNs
+              namespace: controlns
               channel: beta
               packageName: ibm-cert-manager-operator
               scope: public


### PR DESCRIPTION
1. Create a separate go routine to deploy the common ca resources, running beside the cs-controller.
2. Those resources will be created in `MasterNamespace` where the default is `ibm-common-services`.
3. The routine will wait to deploy the resource until the CRDs ready which are `Issuer` and `Certificate` under `certmanager.k8s.io/v1alpha1`.