### PR TITLE
watching cs-maps change, validate cs-mapping and filter its cs-scope

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -114,84 +114,6 @@ metadata:
           spec:
             grafana: {}
             operandRequest: {}
-    csV3SaasOperandConfig: |-
-      apiVersion: operator.ibm.com/v1alpha1
-      kind: OperandConfig
-      metadata:
-        name: common-service
-        namespace: placeholder
-        annotations:
-          version: "3.8.0"
-      spec:
-        services:
-        - name: ibm-licensing-operator
-          spec:
-            IBMLicensing:
-              datasource: datacollector
-              routeEnabled: false
-            operandBindInfo: {}
-        - name: ibm-mongodb-operator
-          spec:
-            mongoDB: {}
-            operandRequest: {}
-        - name: ibm-cert-manager-operator
-          spec:
-            certManager: {}
-        - name: ibm-iam-operator
-          spec:
-            authentication: {}
-            oidcclientwatcher: {}
-            pap: {}
-            policycontroller: {}
-            policydecision: {}
-            secretwatcher: {}
-            securityonboarding: {}
-            operandBindInfo:
-              bindings:
-                protected-zen-serviceid:
-                  secret: zen-serviceid-apikey-secret
-            operandRequest: {}
-        - name: ibm-healthcheck-operator
-          spec:
-            healthService: {}
-            mustgatherService: {}
-            mustgatherConfig: {}
-        - name: ibm-commonui-operator
-          spec:
-            commonWebUI: {}
-            switcheritem: {}
-            operandRequest: {}
-            navconfiguration: {}
-            operandBindInfo: {}
-        - name: ibm-management-ingress-operator
-          spec:
-            managementIngress: {}
-            operandBindInfo: {}
-            operandRequest: {}
-        - name: ibm-ingress-nginx-operator
-          spec:
-            nginxIngress: {}
-        - name: ibm-auditlogging-operator
-          spec:
-            auditLogging: {}
-            operandBindInfo: {}
-            operandRequest: {}
-        - name: ibm-platform-api-operator
-          spec:
-            platformApi: {}
-            operandRequest: {}
-        - name: ibm-monitoring-exporters-operator
-          spec:
-            exporter: {}
-            operandRequest: {}
-        - name: ibm-monitoring-prometheusext-operator
-          spec:
-            prometheusExt: {}
-            operandRequest: {}
-        - name: ibm-monitoring-grafana-operator
-          spec:
-            grafana: {}
-            operandRequest: {}
     csV3OperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry
@@ -320,6 +242,83 @@ metadata:
           scope: public
           sourceName: ibm-operator-catalog
           sourceNamespace: openshift-marketplace
+    csV3SaasOperandConfig: |-
+      apiVersion: operator.ibm.com/v1alpha1
+      kind: OperandConfig
+      metadata:
+        name: common-service
+        namespace: placeholder
+        annotations:
+          version: "3.8.0"
+      spec:
+        services:
+        - name: ibm-licensing-operator
+          spec:
+            IBMLicensing:
+              datasource: datacollector
+            operandBindInfo: {}
+        - name: ibm-mongodb-operator
+          spec:
+            mongoDB: {}
+            operandRequest: {}
+        - name: ibm-cert-manager-operator
+          spec:
+            certManager: {}
+        - name: ibm-iam-operator
+          spec:
+            authentication: {}
+            oidcclientwatcher: {}
+            pap: {}
+            policycontroller: {}
+            policydecision: {}
+            secretwatcher: {}
+            securityonboarding: {}
+            operandBindInfo:
+              bindings:
+                protected-zen-serviceid:
+                  secret: zen-serviceid-apikey-secret
+            operandRequest: {}
+        - name: ibm-healthcheck-operator
+          spec:
+            healthService: {}
+            mustgatherService: {}
+            mustgatherConfig: {}
+        - name: ibm-commonui-operator
+          spec:
+            commonWebUI: {}
+            switcheritem: {}
+            operandRequest: {}
+            navconfiguration: {}
+            operandBindInfo: {}
+        - name: ibm-management-ingress-operator
+          spec:
+            managementIngress: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-ingress-nginx-operator
+          spec:
+            nginxIngress: {}
+        - name: ibm-auditlogging-operator
+          spec:
+            auditLogging: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-platform-api-operator
+          spec:
+            platformApi: {}
+            operandRequest: {}
+        - name: ibm-monitoring-exporters-operator
+          spec:
+            exporter: {}
+            operandRequest: {}
+        - name: ibm-monitoring-prometheusext-operator
+          spec:
+            prometheusExt: {}
+            operandRequest: {}
+        - name: ibm-monitoring-grafana-operator
+          spec:
+            grafana: {}
+            operandRequest: {}
     csV3SaasOperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry
@@ -446,6 +445,8 @@ metadata:
           env:
           - name: INSTALL_SCOPE
             value: namespaced
+          - name: ODLM_SCOPE
+            value: odlmScopesholder
     olm.skipRange: ">=3.3.0 <3.8.0"
     operators.operatorframework.io/builder: operator-sdk-v1.3.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -446,7 +446,7 @@ metadata:
           - name: INSTALL_SCOPE
             value: namespaced
           - name: ODLM_SCOPE
-            value: odlmScopesholder
+            value: "odlmScopesholder"
     olm.skipRange: ">=3.3.0 <3.8.0"
     operators.operatorframework.io/builder: operator-sdk-v1.3.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -97,83 +97,6 @@ metadata:
           spec:
             grafana: {}
             operandRequest: {}
-    csV3SaasOperandConfig: |-
-      apiVersion: operator.ibm.com/v1alpha1
-      kind: OperandConfig
-      metadata:
-        name: common-service
-        namespace: placeholder
-        annotations:
-          version: "3.8.0"
-      spec:
-        services:
-        - name: ibm-licensing-operator
-          spec:
-            IBMLicensing:
-              datasource: datacollector
-            operandBindInfo: {}
-        - name: ibm-mongodb-operator
-          spec:
-            mongoDB: {}
-            operandRequest: {}
-        - name: ibm-cert-manager-operator
-          spec:
-            certManager: {}
-        - name: ibm-iam-operator
-          spec:
-            authentication: {}
-            oidcclientwatcher: {}
-            pap: {}
-            policycontroller: {}
-            policydecision: {}
-            secretwatcher: {}
-            securityonboarding: {}
-            operandBindInfo:
-              bindings:
-                protected-zen-serviceid:
-                  secret: zen-serviceid-apikey-secret
-            operandRequest: {}
-        - name: ibm-healthcheck-operator
-          spec:
-            healthService: {}
-            mustgatherService: {}
-            mustgatherConfig: {}
-        - name: ibm-commonui-operator
-          spec:
-            commonWebUI: {}
-            switcheritem: {}
-            operandRequest: {}
-            navconfiguration: {}
-            operandBindInfo: {}
-        - name: ibm-management-ingress-operator
-          spec:
-            managementIngress: {}
-            operandBindInfo: {}
-            operandRequest: {}
-        - name: ibm-ingress-nginx-operator
-          spec:
-            nginxIngress: {}
-        - name: ibm-auditlogging-operator
-          spec:
-            auditLogging: {}
-            operandBindInfo: {}
-            operandRequest: {}
-        - name: ibm-platform-api-operator
-          spec:
-            platformApi: {}
-            operandRequest: {}
-        - name: ibm-monitoring-exporters-operator
-          spec:
-            exporter: {}
-            operandRequest: {}
-        - name: ibm-monitoring-prometheusext-operator
-          spec:
-            prometheusExt: {}
-            operandRequest: {}
-        - name: ibm-monitoring-grafana-operator
-          spec:
-            grafana: {}
-            operandRequest: {}
     csV3OperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry
@@ -302,6 +225,83 @@ metadata:
           scope: public
           sourceName: ibm-operator-catalog
           sourceNamespace: openshift-marketplace
+    csV3SaasOperandConfig: |-
+      apiVersion: operator.ibm.com/v1alpha1
+      kind: OperandConfig
+      metadata:
+        name: common-service
+        namespace: placeholder
+        annotations:
+          version: "3.8.0"
+      spec:
+        services:
+        - name: ibm-licensing-operator
+          spec:
+            IBMLicensing:
+              datasource: datacollector
+            operandBindInfo: {}
+        - name: ibm-mongodb-operator
+          spec:
+            mongoDB: {}
+            operandRequest: {}
+        - name: ibm-cert-manager-operator
+          spec:
+            certManager: {}
+        - name: ibm-iam-operator
+          spec:
+            authentication: {}
+            oidcclientwatcher: {}
+            pap: {}
+            policycontroller: {}
+            policydecision: {}
+            secretwatcher: {}
+            securityonboarding: {}
+            operandBindInfo:
+              bindings:
+                protected-zen-serviceid:
+                  secret: zen-serviceid-apikey-secret
+            operandRequest: {}
+        - name: ibm-healthcheck-operator
+          spec:
+            healthService: {}
+            mustgatherService: {}
+            mustgatherConfig: {}
+        - name: ibm-commonui-operator
+          spec:
+            commonWebUI: {}
+            switcheritem: {}
+            operandRequest: {}
+            navconfiguration: {}
+            operandBindInfo: {}
+        - name: ibm-management-ingress-operator
+          spec:
+            managementIngress: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-ingress-nginx-operator
+          spec:
+            nginxIngress: {}
+        - name: ibm-auditlogging-operator
+          spec:
+            auditLogging: {}
+            operandBindInfo: {}
+            operandRequest: {}
+        - name: ibm-platform-api-operator
+          spec:
+            platformApi: {}
+            operandRequest: {}
+        - name: ibm-monitoring-exporters-operator
+          spec:
+            exporter: {}
+            operandRequest: {}
+        - name: ibm-monitoring-prometheusext-operator
+          spec:
+            prometheusExt: {}
+            operandRequest: {}
+        - name: ibm-monitoring-grafana-operator
+          spec:
+            grafana: {}
+            operandRequest: {}
     csV3SaasOperandRegistry: |-
       apiVersion: operator.ibm.com/v1alpha1
       kind: OperandRegistry

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -380,26 +380,27 @@ func ValidateCsMaps(cm *corev1.ConfigMap) error {
 		return fmt.Errorf("failed to fetch data of configmap common-service-maps: %v", err)
 	}
 
-	nsSet := make(map[string]interface{})
+	CsNsSet := make(map[string]interface{})
+	RequestNsSet := make(map[string]interface{})
 
 	for _, nsMapping := range cmData.NsMappingList {
 		// validate masterNamespace and controlNamespace
 		if cmData.ControlNs == nsMapping.CsNs {
 			return fmt.Errorf("invalid controlNamespace: %v", cmData.ControlNs)
 		}
-		if _, ok := nsSet[nsMapping.CsNs]; ok {
+		if _, ok := CsNsSet[nsMapping.CsNs]; ok {
 			return fmt.Errorf("invalid map-to-common-service-namespace: %v", nsMapping.CsNs)
 		}
-		nsSet[nsMapping.CsNs] = struct{}{}
+		CsNsSet[nsMapping.CsNs] = struct{}{}
 		// validate CloudPak Namespace and controlNamespace
 		for _, ns := range nsMapping.RequestNs {
 			if cmData.ControlNs == ns {
 				return fmt.Errorf("invalid controlNamespace: %v", cmData.ControlNs)
 			}
-			if _, ok := nsSet[ns]; ok {
+			if _, ok := RequestNsSet[ns]; ok {
 				return fmt.Errorf("invalid requested-from-namespace: %v", ns)
 			}
-			nsSet[ns] = struct{}{}
+			RequestNsSet[ns] = struct{}{}
 		}
 	}
 	return nil

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -258,9 +258,9 @@ func GetMasterNs(r client.Reader) (masterNs string) {
 }
 
 // UpdateNSList updates adopter namespaces of Common Services
-func UpdateNSList(r client.Reader, c client.Client, cm *corev1.ConfigMap, masterNs string) error {
+func UpdateNSList(r client.Reader, c client.Client, cm *corev1.ConfigMap, nssKey, masterNs string, addControlNs bool) error {
 	nsScope := &nssv1.NamespaceScope{}
-	nsScopeKey := types.NamespacedName{Name: "common-service", Namespace: masterNs}
+	nsScopeKey := types.NamespacedName{Name: nssKey, Namespace: masterNs}
 	if err := r.Get(context.TODO(), nsScopeKey, nsScope); err != nil {
 		return err
 	}
@@ -281,8 +281,10 @@ func UpdateNSList(r client.Reader, c client.Client, cm *corev1.ConfigMap, master
 		return fmt.Errorf("failed to fetch data of configmap common-service-maps: %v", err)
 	}
 
-	if len(cmData.ControlNs) > 0 {
-		nsSet[cmData.ControlNs] = struct{}{}
+	if addControlNs {
+		if len(cmData.ControlNs) > 0 {
+			nsSet[cmData.ControlNs] = struct{}{}
+		}
 	}
 
 	for _, nsMapping := range cmData.NsMappingList {

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -436,3 +436,13 @@ func GetCsScope(cm *corev1.ConfigMap, masterNs string) ([]string, error) {
 
 	return nsMems, nil
 }
+
+// EnsureLabelsForConfigMap ensures that the specifc ConfigMap has the certain labels
+func EnsureLabelsForConfigMap(cm *corev1.ConfigMap, labels map[string]string) {
+	if cm.Labels == nil {
+		cm.Labels = make(map[string]string)
+	}
+	for k, v := range labels {
+		cm.Labels[k] = v
+	}
+}

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -388,7 +388,7 @@ func ValidateCsMaps(cm *corev1.ConfigMap) error {
 	for _, nsMapping := range cmData.NsMappingList {
 		// validate masterNamespace and controlNamespace
 		if cmData.ControlNs == nsMapping.CsNs {
-			return fmt.Errorf("invalid controlNamespace: %v", cmData.ControlNs)
+			return fmt.Errorf("invalid controlNamespace: %v. Cannot be the same as map-to-common-service-namespace", cmData.ControlNs)
 		}
 		if _, ok := CsNsSet[nsMapping.CsNs]; ok {
 			return fmt.Errorf("invalid map-to-common-service-namespace: %v", nsMapping.CsNs)
@@ -397,7 +397,7 @@ func ValidateCsMaps(cm *corev1.ConfigMap) error {
 		// validate CloudPak Namespace and controlNamespace
 		for _, ns := range nsMapping.RequestNs {
 			if cmData.ControlNs == ns {
-				return fmt.Errorf("invalid controlNamespace: %v", cmData.ControlNs)
+				return fmt.Errorf("invalid controlNamespace: %v. Cannot be the same as requested-from-namespace", cmData.ControlNs)
 			}
 			if _, ok := RequestNsSet[ns]; ok {
 				return fmt.Errorf("invalid requested-from-namespace: %v", ns)

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -66,7 +66,7 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	klog.Infof("Reconciling CommonService: %s", req.NamespacedName)
 
 	// Validate common-service-maps and filter the namespace of CommonService CR
-	cm, err := util.GetCmOfMapCs(r.Reader)
+	cm, err := util.GetCmOfMapCs(r.Client)
 	if err == nil {
 		if err := util.ValidateCsMaps(cm); err != nil {
 			klog.Errorf("Unsupported common-service-maps: %v", err)

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -16,6 +16,10 @@
 
 package constant
 
+import (
+	"time"
+)
+
 const (
 	// OperatorNameEnvVar is the constant for env variable OPERATOR_NAME
 	// which is the name of the current operator
@@ -42,6 +46,8 @@ const (
 	NsSubName = "ibm-namespace-scope-operator"
 	// Namespace Scope Operator Restricted sub name
 	NsRestrictedSubName = "ibm-namespace-scope-operator-restricted"
+	//DefaultRequeueDuration is the default requeue time duration for request
+	DefaultRequeueDuration = 20 * time.Second
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -48,6 +48,8 @@ const (
 	NsRestrictedSubName = "ibm-namespace-scope-operator-restricted"
 	//DefaultRequeueDuration is the default requeue time duration for request
 	DefaultRequeueDuration = 20 * time.Second
+	//CsMapsLabel is the label used to label the configmaps are managed by cs operator
+	CsManagedLabel = "operator.ibm.com/managedByCsOperator"
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/controllers/constant/namespace.go
+++ b/controllers/constant/namespace.go
@@ -36,6 +36,18 @@ metadata:
 spec:
   namespaceMembers:
   - placeholder
+---
+apiVersion: operator.ibm.com/v1
+kind: NamespaceScope
+metadata:
+  name: nss-odlm-scope
+  namespace: placeholder
+spec:
+  namespaceMembers:
+  - placeholder
+  configmapName: odlm-scope
+  restartLabels:
+    intent: projected-odlm
 `
 
 // NamespaceScopeConfigMap is the init configmap
@@ -46,5 +58,13 @@ data:
 kind: ConfigMap
 metadata:
   name: namespace-scope
+  namespace: placeholder
+---
+apiVersion: v1
+data:
+  namespaces: placeholder
+kind: ConfigMap
+metadata:
+  name: odlm-scope
   namespace: placeholder
 `

--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -420,3 +420,19 @@ func (r *CommonServiceReconciler) updatePhase(instance *apiv3.CommonService, sta
 	instance.Status.Phase = status
 	return r.Client.Status().Update(ctx, instance)
 }
+
+// checkScope checks whether the namespace is in scope
+func (r *CommonServiceReconciler) checkScope(csScope []string, key string) bool {
+	isScoped := false
+	if len(csScope) == 0 {
+		isScoped = true
+	} else {
+		for _, ns := range csScope {
+			if ns == key {
+				isScoped = true
+				break
+			}
+		}
+	}
+	return isScoped
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/IBM/ibm-common-service-operator
 go 1.15
 
 require (
+	github.com/IBM/controller-filtered-cache v0.2.1
 	github.com/IBM/ibm-namespace-scope-operator v1.0.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxB
 github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6LSNgds39diKLz7Vrc=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/IBM/controller-filtered-cache v0.2.1 h1:9pKLDkFRSI4uddBGvaz5tVzSAJHLlOsvVK5nN9CGz1E=
 github.com/IBM/controller-filtered-cache v0.2.1/go.mod h1:x6kTgtNFa6YL5mqVUh14RMoW89ycqP9/6ZjgzkBP808=
 github.com/IBM/ibm-namespace-scope-operator v1.0.1 h1:o5t/cr+HlgCHXmHofMK4GvpBZ1nnrFf1w75Z2FX6QQI=
 github.com/IBM/ibm-namespace-scope-operator v1.0.1/go.mod h1:VxYHSntVk9dfhs53TFMOX7UTorH+twHXQJgd6tgq5vE=
@@ -136,6 +137,7 @@ github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2K
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
+github.com/gobuffalo/flect v0.2.0 h1:EWCvMGGxOjsgwlWaP+f4+Hh6yrrte7JeFL2S6b+0hdM=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -76,6 +77,18 @@ func main() {
 	})
 	if err != nil {
 		klog.Errorf("Unable to start manager: %v", err)
+		os.Exit(1)
+	}
+
+	// Validate common-service-maps
+	cm, err := util.GetCmOfMapCs(mgr.GetAPIReader())
+	if err == nil {
+		if err := util.ValidateCsMaps(cm); err != nil {
+			klog.Errorf("Unsupported common-service-maps: %v", err)
+			os.Exit(1)
+		}
+	} else if !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get common-service-maps: %v", err)
 		os.Exit(1)
 	}
 

--- a/testdata/deploy/deploy.yaml
+++ b/testdata/deploy/deploy.yaml
@@ -415,6 +415,8 @@ spec:
               env:
               - name: INSTALL_SCOPE
                 value: namespaced
+              - name: ODLM_SCOPE
+                value: odlmScopesholder
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
1. When the `cs-mapping` ConfigMap is changed, it will reconcile the master CR, going through the steps of initializing the resource to update the scope list in NSS CR for both `common-service` and `odlm-scope` to update the scope for individual cs operator and ODLM.

2. Also `cs-operator` will validate the `cs-mapping` ConfigMap, if it is an unsupported case, the `cs-operator` will raise the error. In the future, we will handle it by validating web hook, to prohibit the invalid change to ConfigMap from the user.

3. Also `cs-operator` will filter its `cs-scope` from `cs-mapping` ConfigMap. If the triggered CR is not in the namespace of this scope. It will skip the reconciliation.