### PR TITLE
Disable licensing route on SaaS

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -128,6 +128,7 @@ metadata:
           spec:
             IBMLicensing:
               datasource: datacollector
+              routeEnabled: false
             operandBindInfo: {}
         - name: ibm-mongodb-operator
           spec:


### PR DESCRIPTION
When on SaaS, do not create the external OCP route for License Service.