### PR TITLE
bump version for replace image

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -24,9 +24,9 @@ metadata:
     containerImage: quay.io/opencloudio/common-service-operator:latest
     createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
-    operatorChannel: "v3"
-    operatorVersion: "3.8.0"
     olm.skipRange: ">=3.3.0 <3.8.0"
+    operatorChannel: v3
+    operatorVersion: 3.8.0
     operators.operatorframework.io/builder: operator-sdk-v1.3.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/ibm-common-service-operator
@@ -327,5 +327,5 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.7.1
+  replaces: ibm-common-service-operator.v3.7.2
   version: 3.8.0

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -327,5 +327,5 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.7.2
+  replaces: ibm-common-service-operator.v3.7.3
   version: 3.8.0

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -7,9 +7,9 @@ metadata:
     containerImage: quay.io/opencloudio/common-service-operator:latest
     createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
-    operatorChannel: "v3"
-    operatorVersion: "3.8.0"
     olm.skipRange: ""
+    operatorChannel: v3
+    operatorVersion: 3.8.0
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-common-service-operator
@@ -19,7 +19,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-common-service-operator.vX.Y.Z
+  name: ibm-common-service-operator.v0.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}


### PR DESCRIPTION
Not sure whether we need to update the version of replace image in 3.8 since there is a newer 3.7.2.