### PR TITLE
fetch channel and version in bootstrap

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -119,25 +119,25 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap) {
 		CSOperators: csOperators,
 		CSData:      csData,
 	}
+
+	// Get all the resources from the deployment annotations
+	annotations, err := bs.GetAnnotations()
+	if err != nil {
+		klog.Errorf("failed to get Annotations from csv: %v", err)
+	}
+
+	if r, ok := annotations["operatorChannel"]; ok {
+		bs.CSData.Channel = r
+	}
+
+	if r, ok := annotations["operatorVersion"]; ok {
+		bs.CSData.Version = r
+	}
 	return
 }
 
 // InitResources initialize resources at the bootstrap of operator
 func (b *Bootstrap) InitResources(manualManagement bool) error {
-	// Get all the resources from the deployment annotations
-	annotations, err := b.GetAnnotations()
-	if err != nil {
-		return err
-	}
-
-	if r, ok := annotations["operatorChannel"]; ok {
-		b.CSData.Channel = r
-	}
-
-	if r, ok := annotations["operatorVersion"]; ok {
-		b.CSData.Version = r
-	}
-
 	// Check Saas or Multi instances Deployment
 	if len(b.CSData.ControlNs) > 0 {
 		klog.Infof("Creating IBM Common Services control namespace: %s", b.CSData.ControlNs)


### PR DESCRIPTION
Got the error when installing the common-service
```
I0419 21:40:48.781603       1 request.go:621] Throttling request took 1.022673721s, request: GET:https://172.30.0.1:443/apis/whereabouts.cni.cncf.io/v1alpha1?timeout=32s
I0419 21:40:50.375027       1 main.go:124] Creating IBM Common Services master namespace: cs-installed
I0419 21:40:50.463307       1 main.go:130] Creating OperatorGroup for IBM Common Services
I0419 21:40:50.469434       1 main.go:136] Creating ConfigMap for operators
I0419 21:40:50.501523       1 main.go:165] Creating common service operator subscription in namespace cs-installed
I0419 21:40:50.511831       1 init.go:357] Creating resource with name: ibm-common-service-operator, namespace: cs-installed, kind: Subscription, apiversion: operators.coreos.com/v1alpha1
E0419 21:40:50.520035       1 main.go:167] Failed to create common service operator subscription: could not Create resource: Subscription.operators.coreos.com "ibm-common-service-operator" is invalid: spec.channel: Invalid value: "null": spec.channel in body must be of type string: "null"
```

It is because we set the `channel` and `version` at the initial stage, but it should be in the stage when we create bootstrap.