### PR TITLE
Create a new NSS CR managed by ODLM

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -464,8 +464,15 @@ func (b *Bootstrap) installNssOperator(manualManagement bool) error {
 		return err
 	}
 
+	// Create General NSS CRs
 	if err := b.renderTemplate(constant.NamespaceScopeCR, b.CSData); err != nil {
 		return err
+	}
+	// Create NSS CRs managedby ODLM for Single CS instance case
+	if b.CSData.MasterNs == b.CSData.ControlNs {
+		if err := b.renderTemplate(constant.NamespaceScopeCRManagedbyODLM, b.CSData); err != nil {
+			return err
+		}
 	}
 
 	cm, err := util.GetCmOfMapCs(b.Reader)

--- a/controllers/constant/namespace.go
+++ b/controllers/constant/namespace.go
@@ -72,6 +72,18 @@ spec:
 apiVersion: operator.ibm.com/v1
 kind: NamespaceScope
 metadata:
+  name: odlm-scope-managedby-odlm
+  namespace: {{ .MasterNs }}
+spec:
+  namespaceMembers:
+  - {{ .MasterNs }}
+  configmapName: odlm-scope
+  restartLabels:
+    intent: projected-odlm
+---
+apiVersion: operator.ibm.com/v1
+kind: NamespaceScope
+metadata:
   name: nss-odlm-scope
   namespace: {{ .MasterNs }}
 spec:

--- a/controllers/constant/namespace.go
+++ b/controllers/constant/namespace.go
@@ -63,6 +63,21 @@ spec:
 apiVersion: operator.ibm.com/v1
 kind: NamespaceScope
 metadata:
+  name: nss-odlm-scope
+  namespace: {{ .MasterNs }}
+spec:
+  namespaceMembers:
+  - {{ .MasterNs }}
+  configmapName: odlm-scope
+  restartLabels:
+    intent: projected-odlm
+`
+
+// NamespaceScope Operator CR Managed By ODLM
+const NamespaceScopeCRManagedbyODLM = `
+apiVersion: operator.ibm.com/v1
+kind: NamespaceScope
+metadata:
   name: nss-managedby-odlm
   namespace: {{ .MasterNs }}
 spec:
@@ -73,18 +88,6 @@ apiVersion: operator.ibm.com/v1
 kind: NamespaceScope
 metadata:
   name: odlm-scope-managedby-odlm
-  namespace: {{ .MasterNs }}
-spec:
-  namespaceMembers:
-  - {{ .MasterNs }}
-  configmapName: odlm-scope
-  restartLabels:
-    intent: projected-odlm
----
-apiVersion: operator.ibm.com/v1
-kind: NamespaceScope
-metadata:
-  name: nss-odlm-scope
   namespace: {{ .MasterNs }}
 spec:
   namespaceMembers:


### PR DESCRIPTION
`odlm-scope-managedby-odlm` and `nss-managedby-odlm` will have the same `namespaceMember` value.
But the first one is used for extend permission on ODLM, the latter is for other individual operator's permission scope.

`odlm-scope-managedby-odlm` and `nss-managedby-odlm` should only be created when CS is deployed in Single instance case.

On SaaS or on-prem Multi Instances case, we will not have above two CRs and disable the NSS controller in ODLM to avoid the permission overlap in `control namespace`