### PR TITLE
deploy cluster-scope in ControlNs for on-prem multi instance case

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -106,7 +106,7 @@ metadata:
 spec:
   operators:
   - name: ibm-licensing-operator
-    namespace: {{ .MasterNs }}
+    namespace: {{ .ControlNs }}
     channel: {{ .Channel }}
     packageName: ibm-licensing-operator-app
     scope: public
@@ -119,7 +119,7 @@ spec:
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-cert-manager-operator
-    namespace: {{ .MasterNs }}
+    namespace: {{ .ControlNs }}
     channel: {{ .Channel }}
     packageName: ibm-cert-manager-operator
     scope: public


### PR DESCRIPTION
We have two templates for SaaS and on-prem deployment respectively.

In the on-prem deployment,
1. the Single instance will deploy all resources in `masterNs`. and `ControlNs == masterNs`.
2. the multi instances case will deploy cluster scope resource like `cert-manager-operator` and `licensing-operator` in `ControlNs`.