### PR TITLE
add iamstatus with cloud pak prefix

### DIFF
--- a/controllers/check/check_iam.go
+++ b/controllers/check/check_iam.go
@@ -156,6 +156,9 @@ func createUpdateConfigmap(bs *bootstrap.Bootstrap, status string) error {
 				cm.Data[statusKey] = status
 				isUpdate = true
 			}
+		} else {
+			cm.Data[statusKey] = status
+			isUpdate = true
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -152,7 +152,7 @@ func main() {
 		}
 
 		// Check IAM pods status
-		go check.IamStatus(mgr)
+		go check.IamStatus(bs)
 		// Generate Issuer and Certificate CR
 		go certmanager.DeployCR(bs)
 


### PR DESCRIPTION
Not 100 percent sure that I understand the design correctly.

Basically, I use `requested-from-namespace` (usually is cloud pak name) as the prefix of `-iamstatus`.
In this situation, one Common Service instance will have multiple namespaced cloud pak prefix `iamstatus` like `cp4i-iamstatus` and `cp4mcm-iamstatus` if the ConfigMap looks like this
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: common-service-maps
  namespace: kube-public
data: 
  common-service-maps.yaml: |
    controlNamespace: cs-control
    namespaceMapping:
    - requested-from-namespace:
      - cp4i
      - cp4mcm
      map-to-common-service-namespace: common-service
```

Also there is a overall status called `iamstatus` as our previous release, it is only `Ready` when all other namespaced cloud pak prefix `-iamstatus` are `Ready` to keep the compatibility for the previous release.