### PR TITLE
Add pre-check of whether storageClass existing

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -180,6 +180,15 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService) error {
 		}
 	}
 
+	// Check storageClass
+	csStorageClass, err := util.GetStorageClass(b.Reader)
+	if err == nil {
+		if err := util.ValidateStorageClass(csStorageClass); err != nil {
+			klog.Errorf("StorageClass is not found in current cluster")
+			return err
+		}
+	}
+
 	// Install Namespace Scope Operator
 	if err := b.installNssOperator(manualManagement); err != nil {
 		return err

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -186,7 +186,6 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService) error {
 		return fmt.Errorf("failed to get StorageClass")
 	}
 	if err := util.ValidateStorageClass(csStorageClass); err != nil {
-		klog.Errorf("%v", err)
 		return err
 	}
 

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -182,11 +182,12 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService) error {
 
 	// Check storageClass
 	csStorageClass, err := util.GetStorageClass(b.Reader)
-	if err == nil {
-		if err := util.ValidateStorageClass(csStorageClass); err != nil {
-			klog.Errorf("StorageClass is not found in current cluster")
-			return err
-		}
+	if err != nil {
+		return fmt.Errorf("failed to get StorageClass")
+	}
+	if err := util.ValidateStorageClass(csStorageClass); err != nil {
+		klog.Errorf("%v", err)
+		return err
 	}
 
 	// Install Namespace Scope Operator

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -232,7 +232,7 @@ func ValidateStorageClass(csStorageClass *storagev1.StorageClassList) error {
 	klog.Info("StorageClass Number: ", size)
 
 	if size <= 0 {
-		return fmt.Errorf("no storageClass")
+		return fmt.Errorf("storageClass is not found in current cluster")
 	}
 	return nil
 }

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	storagev1 "k8s.io/api/storage/v1"
+
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
 
 	"github.com/IBM/ibm-common-service-operator/controllers/constant"
@@ -212,6 +214,27 @@ func GetCmOfMapCs(r client.Reader) (*corev1.ConfigMap, error) {
 		return nil, err
 	}
 	return csConfigmap, nil
+}
+
+// GetStorageClass gets StorageClass in current cluster
+func GetStorageClass(r client.Reader) (*storagev1.StorageClassList, error) {
+	csStorageClass := &storagev1.StorageClassList{}
+	err := r.List(context.TODO(), csStorageClass)
+	if err != nil {
+		return nil, err
+	}
+	return csStorageClass, nil
+}
+
+// ValidateStorageClass validates whether the StorageClass exist
+func ValidateStorageClass(csStorageClass *storagev1.StorageClassList) error {
+	size := len(csStorageClass.Items)
+	klog.Info("StorageClass Number: ", size)
+
+	if size <= 0 {
+		return fmt.Errorf("no storageClass")
+	}
+	return nil
 }
 
 // GetMasterNs gets MasterNamespaces of deploying Common Services


### PR DESCRIPTION
### why we need this
Since MongoDB requires StorageClass and many other common services require MongoDB, so we add storageClass pre-check before installation.

### test results
logs with 2 StorageClass:
<img width="498" alt="Screen Shot 2021-05-02 at 6 38 16 PM" src="https://user-images.githubusercontent.com/30216742/116830308-1d8a6880-ab77-11eb-916a-bc28d9e6138e.png">


logs with No StorageClass (report error & stop deployment
<img width="1119" alt="Screen Shot 2021-05-02 at 6 39 40 PM" src="https://user-images.githubusercontent.com/30216742/116830310-23804980-ab77-11eb-92f4-c1bfa155d1f9.png">

### issue
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/44307