### PR TITLE
reconcile cluster scope resource

### DIFF
--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -62,7 +62,7 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	klog.Infof("Reconciling CommonService: %s", req.NamespacedName)
 
 	// Validate common-service-maps and filter the namespace of CommonService CR
-	isScoped := true
+	inScope := true
 	cm, err := util.GetCmOfMapCs(r.Client)
 	if err == nil {
 		if err := util.ValidateCsMaps(cm); err != nil {
@@ -73,7 +73,7 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if isScoped = r.checkScope(csScope, req.NamespacedName.Namespace); !isScoped {
+		if inScope = r.checkScope(csScope, req.NamespacedName.Namespace); !inScope {
 			klog.Infof("CommonService CR %v is not in the scope, only reconciles its configuration of cluster scope resource", req.NamespacedName.String())
 		}
 	} else if !errors.IsNotFound(err) {
@@ -95,12 +95,12 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	if r.checkNamespace(req.NamespacedName.String()) {
-		return r.ReconcileMasterCR(instance, isScoped)
+		return r.ReconcileMasterCR(instance, inScope)
 	}
-	return r.ReconcileGeneralCR(instance, isScoped)
+	return r.ReconcileGeneralCR(instance, inScope)
 }
 
-func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonService, isScoped bool) (ctrl.Result, error) {
+func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonService, inScope bool) (ctrl.Result, error) {
 
 	if instance.Status.Phase == "" {
 		if err := r.updatePhase(instance, CRInitializing); err != nil {
@@ -134,7 +134,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonServic
 		return ctrl.Result{}, err
 	}
 
-	newConfigs, err := r.getNewConfigs(cs, isScoped)
+	newConfigs, err := r.getNewConfigs(cs, inScope)
 	if err != nil {
 		if err := r.updatePhase(instance, CRFailed); err != nil {
 			klog.Error(err)
@@ -167,7 +167,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonServic
 }
 
 // ReconcileGeneralCR is for setting the OperandConfig
-func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonService, isScoped bool) (ctrl.Result, error) {
+func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonService, inScope bool) (ctrl.Result, error) {
 
 	if instance.Status.Phase == "" {
 		if err := r.updatePhase(instance, CRInitializing); err != nil {
@@ -201,7 +201,7 @@ func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonServi
 		return ctrl.Result{}, err
 	}
 
-	newConfigs, err := r.getNewConfigs(cs, isScoped)
+	newConfigs, err := r.getNewConfigs(cs, inScope)
 	if err != nil {
 		if err := r.updatePhase(instance, CRFailed); err != nil {
 			klog.Error(err)

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -62,6 +62,7 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	klog.Infof("Reconciling CommonService: %s", req.NamespacedName)
 
 	// Validate common-service-maps and filter the namespace of CommonService CR
+	isScoped := true
 	cm, err := util.GetCmOfMapCs(r.Client)
 	if err == nil {
 		if err := util.ValidateCsMaps(cm); err != nil {
@@ -72,9 +73,8 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		if isScoped := r.checkScope(csScope, req.NamespacedName.Namespace); !isScoped {
-			klog.Infof("CommonService CR %v is not in the scope", req.NamespacedName.String())
-			return ctrl.Result{}, nil
+		if isScoped = r.checkScope(csScope, req.NamespacedName.Namespace); !isScoped {
+			klog.Infof("CommonService CR %v is not in the scope, only reconciles its configuration of cluster scope resource", req.NamespacedName.String())
 		}
 	} else if !errors.IsNotFound(err) {
 		klog.Errorf("Failed to get common-service-maps: %v", err)
@@ -95,12 +95,12 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	if r.checkNamespace(req.NamespacedName.String()) {
-		return r.ReconcileMasterCR(instance)
+		return r.ReconcileMasterCR(instance, isScoped)
 	}
-	return r.ReconcileGeneralCR(instance)
+	return r.ReconcileGeneralCR(instance, isScoped)
 }
 
-func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonService) (ctrl.Result, error) {
+func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonService, isScoped bool) (ctrl.Result, error) {
 
 	if instance.Status.Phase == "" {
 		if err := r.updatePhase(instance, CRInitializing); err != nil {
@@ -134,7 +134,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonServic
 		return ctrl.Result{}, err
 	}
 
-	newConfigs, err := r.getNewConfigs(cs)
+	newConfigs, err := r.getNewConfigs(cs, isScoped)
 	if err != nil {
 		if err := r.updatePhase(instance, CRFailed); err != nil {
 			klog.Error(err)
@@ -167,7 +167,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonServic
 }
 
 // ReconcileGeneralCR is for setting the OperandConfig
-func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonService) (ctrl.Result, error) {
+func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonService, isScoped bool) (ctrl.Result, error) {
 
 	if instance.Status.Phase == "" {
 		if err := r.updatePhase(instance, CRInitializing); err != nil {
@@ -201,7 +201,7 @@ func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonServi
 		return ctrl.Result{}, err
 	}
 
-	newConfigs, err := r.getNewConfigs(cs)
+	newConfigs, err := r.getNewConfigs(cs, isScoped)
 	if err != nil {
 		if err := r.updatePhase(instance, CRFailed); err != nil {
 			klog.Error(err)

--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -317,20 +317,20 @@ func (r *CommonServiceReconciler) getMinimalSizes(opconServices, ruleSlice []int
 			continue
 		}
 
-		isScoped := true
+		inScope := true
 		cm, err := util.GetCmOfMapCs(r.Client)
 		if err == nil {
 			csScope, err := util.GetCsScope(cm, r.Bootstrap.CSData.MasterNs)
 			if err != nil {
 				return configSummary, err
 			}
-			isScoped = r.checkScope(csScope, cs.GetNamespace())
+			inScope = r.checkScope(csScope, cs.GetNamespace())
 		} else if !errors.IsNotFound(err) {
 			klog.Errorf("Failed to get common-service-maps: %v", err)
 			return configSummary, err
 		}
 
-		csConfigs, err := r.getNewConfigs(&cs, isScoped)
+		csConfigs, err := r.getNewConfigs(&cs, inScope)
 		if err != nil {
 			return []interface{}{}, err
 		}
@@ -438,16 +438,16 @@ func (r *CommonServiceReconciler) updatePhase(instance *apiv3.CommonService, sta
 
 // checkScope checks whether the namespace is in scope
 func (r *CommonServiceReconciler) checkScope(csScope []string, key string) bool {
-	isScoped := false
+	inScope := false
 	if len(csScope) == 0 {
-		isScoped = true
+		inScope = true
 	} else {
 		for _, ns := range csScope {
 			if ns == key {
-				isScoped = true
+				inScope = true
 				break
 			}
 		}
 	}
-	return isScoped
+	return inScope
 }

--- a/controllers/render_template.go
+++ b/controllers/render_template.go
@@ -74,10 +74,15 @@ func applySizeConfigs(cs *unstructured.Unstructured, isScoped bool) []interface{
 	if cs.Object["spec"].(map[string]interface{})["services"] != nil {
 		for _, configSize := range cs.Object["spec"].(map[string]interface{})["services"].([]interface{}) {
 			if !isScoped {
+				isClusterScope := false
 				for _, operator := range clusterScopeOperators {
-					if configSize.(map[string]interface{})["name"].(string) != operator {
-						continue
+					if configSize.(map[string]interface{})["name"].(string) == operator {
+						isClusterScope = true
+						break
 					}
+				}
+				if !isClusterScope {
+					continue
 				}
 			}
 			dest = append(dest, configSize)
@@ -103,10 +108,15 @@ func applySizeTemplate(cs *unstructured.Unstructured, sizeTemplate string, isSco
 
 	for _, configSize := range sizes {
 		if !isScoped {
+			isClusterScope := false
 			for _, operator := range clusterScopeOperators {
-				if configSize.(map[string]interface{})["name"].(string) != operator {
-					continue
+				if configSize.(map[string]interface{})["name"].(string) == operator {
+					isClusterScope = true
+					break
 				}
+			}
+			if !isClusterScope {
+				continue
 			}
 		}
 		config := getItemByName(src, configSize.(map[string]interface{})["name"].(string))


### PR DESCRIPTION
## Reconcile cluster scope resource strategy for multi instance CS

Each `ibm-common-service-operator` still need to watch all CommonService CRs in the cluster, but we need to split the logic of hardware profile merging into two parts.
1. For namespaced scope operator, we will only combine their resource values from the CRs in namespaced scope like what we do before.
2. For cluster scope operator, each cs-operator will fetch their values from all CRs across the cluster, finding out the max value and applying it to `OperandConfig` of its own namespaced ODLM. On the other word, all the hardware profiles for cluster scope resources are the same in every `OperandConfig` of ODLMs.
