### PR TITLE
fix: Remove the status check of the subscription in order to avoid th…

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -709,10 +709,6 @@ func (b *Bootstrap) waitOperatorReady(name, namespace string) error {
 			return false, nil
 		}
 
-		if sub.Status.State != olmv1alpha1.SubscriptionStateAtLatest {
-			return false, nil
-		}
-
 		// check csv
 		csvName := sub.Status.InstalledCSV
 		if csvName != "" {


### PR DESCRIPTION
…e block from manual approval operator

@Daniel-Fan 

I found our operator check logic is somehow too restricted. We should focus on CSV status check instead of subscription status check. 