### PR TITLE
Add service_account.yaml under config

### DIFF
--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: "ibm-common-service-operator"
+    app.kubernetes.io/managed-by: "ibm-common-service-operator"
+    app.kubernetes.io/name: "ibm-common-service-operator"
+  name: ibm-common-service-operator
+  

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -6,4 +6,3 @@ metadata:
     app.kubernetes.io/managed-by: "ibm-common-service-operator"
     app.kubernetes.io/name: "ibm-common-service-operator"
   name: ibm-common-service-operator
-  


### PR DESCRIPTION
we removed `ibm-common-service-operator/deploy/` in after v3.6.x. Thus, we need to relocate service_account.yaml under `config`.