### PR TITLE
feat: bootstrap cs operator in the manual approval mode

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -111,12 +111,14 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap) {
 	operatorNs, _ := util.GetOperatorNamespace()
 	catalogSourceName, catalogSourceNs := util.GetCatalogSource("ibm-common-service-operator", operatorNs, mgr.GetAPIReader())
 	db2CatalogSourceName, _ := util.GetCatalogSource("db2u-operator", operatorNs, mgr.GetAPIReader())
+	approvalMode, _ := util.GetApprovalModeinNs(mgr.GetAPIReader(), operatorNs)
 	csData := CSData{
 		MasterNs:             masterNs,
 		ControlNs:            util.GetControlNs(mgr.GetAPIReader()),
 		CatalogSourceName:    catalogSourceName,
 		CatalogSourceNs:      catalogSourceNs,
 		DB2CatalogSourceName: db2CatalogSourceName,
+		ApprovalMode:         approvalMode,
 	}
 
 	bs = &Bootstrap{
@@ -150,10 +152,12 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService) error {
 	installPlanApproval := instance.Spec.InstallPlanApproval
 	manualManagement := instance.Spec.ManualManagement
 
-	if installPlanApproval != "" && installPlanApproval != olmv1alpha1.ApprovalAutomatic && installPlanApproval != olmv1alpha1.ApprovalManual {
-		return fmt.Errorf("invalid value for installPlanApproval %v", installPlanApproval)
+	if installPlanApproval != "" {
+		if installPlanApproval != olmv1alpha1.ApprovalAutomatic && installPlanApproval != olmv1alpha1.ApprovalManual {
+			return fmt.Errorf("invalid value for installPlanApproval %v", installPlanApproval)
+		}
+		b.CSData.ApprovalMode = string(installPlanApproval)
 	}
-	b.CSData.ApprovalMode = string(installPlanApproval)
 
 	// Check Saas or Multi instances Deployment
 	if len(b.CSData.ControlNs) > 0 {
@@ -246,8 +250,10 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService) error {
 	}
 
 	klog.Info("Installing/Updating OperandRegistry")
-	if err := b.updateOperandRegistry(installPlanApproval); err != nil {
-		return err
+	if installPlanApproval != "" || b.CSData.ApprovalMode == string(olmv1alpha1.ApprovalManual) {
+		if err := b.updateApprovalMode(); err != nil {
+			return err
+		}
 	}
 	if b.SaasEnable {
 		// OperandRegistry for SaaS deployment
@@ -813,7 +819,40 @@ func (b *Bootstrap) renderTemplate(objectTemplate string, data interface{}, alwa
 // 	return ""
 // }
 
-func (b *Bootstrap) updateOperandRegistry(installPlanApproval olmv1alpha1.Approval) error {
+func (b *Bootstrap) UpdateCsOpApproval() error {
+	sub := &olmv1alpha1.Subscription{}
+	subKey := types.NamespacedName{
+		Name:      "ibm-common-service-operator",
+		Namespace: b.CSData.MasterNs,
+	}
+
+	if err := b.Reader.Get(ctx, subKey, sub); err != nil {
+		return err
+	}
+	if b.CSData.ApprovalMode == string(olmv1alpha1.ApprovalManual) && sub.Spec.InstallPlanApproval != olmv1alpha1.ApprovalManual {
+		sub.Spec.InstallPlanApproval = olmv1alpha1.ApprovalManual
+		if err := b.Client.Update(ctx, sub); err != nil {
+			return err
+		}
+		podList := &corev1.PodList{}
+		opts := []client.ListOption{
+			client.InNamespace(b.CSData.MasterNs),
+			client.MatchingLabels(map[string]string{"name": "ibm-common-service-operator"}),
+		}
+		if err := b.Reader.List(ctx, podList, opts...); err != nil {
+			return err
+		}
+		for _, pod := range podList.Items {
+			if err := b.Client.Delete(ctx, &pod); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (b *Bootstrap) updateApprovalMode() error {
 	opreg := &odlm.OperandRegistry{}
 	opregKey := types.NamespacedName{
 		Name:      "common-service",
@@ -831,7 +870,7 @@ func (b *Bootstrap) updateOperandRegistry(installPlanApproval olmv1alpha1.Approv
 	}
 
 	for i := range opreg.Spec.Operators {
-		opreg.Spec.Operators[i].InstallPlanApproval = installPlanApproval
+		opreg.Spec.Operators[i].InstallPlanApproval = olmv1alpha1.Approval(b.CSData.ApprovalMode)
 	}
 	if err := b.Update(ctx, opreg); err != nil {
 		klog.Errorf("failed to update OperandRegistry %s: %v", opregKey.String(), err)

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -109,7 +109,7 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap) {
 	}
 	masterNs := util.GetMasterNs(mgr.GetAPIReader())
 	operatorNs, _ := util.GetOperatorNamespace()
-	catalogSourceName, catalogSourceNs := util.GetCatalogSource("ibm-common-service-operator", operatorNs, mgr.GetAPIReader())
+	catalogSourceName, catalogSourceNs := util.GetCatalogSource(constant.IBMCSPackage, operatorNs, mgr.GetAPIReader())
 	db2CatalogSourceName, _ := util.GetCatalogSource("db2u-operator", operatorNs, mgr.GetAPIReader())
 	approvalMode, _ := util.GetApprovalModeinNs(mgr.GetAPIReader(), operatorNs)
 	csData := CSData{
@@ -428,7 +428,7 @@ func (b *Bootstrap) CheckOperatorCatalog(ns string) error {
 
 		var csSub []olmv1alpha1.Subscription
 		for _, sub := range subList.Items {
-			if sub.Spec.Package == "ibm-common-service-operator" {
+			if sub.Spec.Package == constant.IBMCSPackage {
 				csSub = append(csSub, sub)
 			}
 		}

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -27,8 +27,10 @@ import (
 	"strings"
 
 	utilyaml "github.com/ghodss/yaml"
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -38,8 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	storagev1 "k8s.io/api/storage/v1"
 
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
 
@@ -392,6 +392,21 @@ func GetControlNs(r client.Reader) (controlNs string) {
 		controlNs = cmData.ControlNs
 	}
 
+	return
+}
+
+func GetApprovalModeinNs(r client.Reader, ns string) (approvalMode string, err error) {
+	approvalMode = string(olmv1alpha1.ApprovalAutomatic)
+	subList := &olmv1alpha1.SubscriptionList{}
+	if err := r.List(context.TODO(), subList, &client.ListOptions{Namespace: ns}); err != nil {
+		return approvalMode, err
+	}
+	for _, sub := range subList.Items {
+		if sub.Spec.InstallPlanApproval == olmv1alpha1.ApprovalManual {
+			approvalMode = string(olmv1alpha1.ApprovalManual)
+			return
+		}
+	}
 	return
 }
 

--- a/controllers/constant/commonservice.go
+++ b/controllers/constant/commonservice.go
@@ -26,7 +26,7 @@ metadata:
     version: {{ .Version }}
 spec:
   channel: {{ .Channel }}
-  installPlanApproval: Automatic
+  installPlanApproval: {{ .ApprovalMode }}
   name: ibm-common-service-operator
   source: {{ .CatalogSourceName }}
   sourceNamespace: {{ .CatalogSourceNs }}

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -56,6 +56,8 @@ const (
 	CSCatalogsource = "opencloud-operators"
 	//IBMCatalogsource is the names of the ibm catalogsource
 	IBMCatalogsource = "ibm-operator-catalog"
+	//IBMCSPackage is the package name of the ibm common service operator
+	IBMCSPackage = "ibm-common-service-operator"
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -110,12 +110,14 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-licensing-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-mongodb-operator
     namespace: {{ .MasterNs }}
     channel: {{ .Channel }}
     packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-cert-manager-operator
@@ -123,6 +125,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-cert-manager-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-iam-operator
@@ -130,6 +133,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-iam-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-healthcheck-operator
@@ -137,6 +141,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-healthcheck-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-commonui-operator
@@ -144,6 +149,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-commonui-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-management-ingress-operator
@@ -151,6 +157,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-management-ingress-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-ingress-nginx-operator
@@ -158,6 +165,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-ingress-nginx-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-auditlogging-operator
@@ -165,6 +173,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-auditlogging-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-platform-api-operator
@@ -172,6 +181,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-platform-api-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-monitoring-exporters-operator
@@ -179,6 +189,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-monitoring-exporters-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-monitoring-prometheusext-operator
@@ -186,6 +197,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-monitoring-prometheusext-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: {{ .Channel }}
@@ -193,6 +205,7 @@ spec:
     namespace: {{ .MasterNs }}
     packageName: ibm-monitoring-grafana-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: {{ .Channel }}
@@ -200,6 +213,7 @@ spec:
     namespace: {{ .MasterNs }}
     packageName: ibm-events-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: stable
@@ -207,6 +221,7 @@ spec:
     namespace: openshift-redhat-marketplace
     packageName: redhat-marketplace-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: certified-operators
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: {{ .Channel }}
@@ -214,6 +229,7 @@ spec:
     namespace: {{ .MasterNs }}
     packageName: ibm-zen-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: v1.0
@@ -221,6 +237,7 @@ spec:
     namespace: {{ .MasterNs }}
     packageName: db2u-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .DB2CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
 `
@@ -322,12 +339,14 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-licensing-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-mongodb-operator
     namespace: {{ .MasterNs }}
     channel: {{ .Channel }}
     packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-cert-manager-operator
@@ -335,6 +354,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-cert-manager-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-iam-operator
@@ -342,6 +362,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-iam-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-management-ingress-operator
@@ -349,6 +370,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-management-ingress-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - name: ibm-ingress-nginx-operator
@@ -356,6 +378,7 @@ spec:
     channel: {{ .Channel }}
     packageName: ibm-ingress-nginx-operator-app
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: {{ .Channel }}
@@ -363,6 +386,7 @@ spec:
     namespace: {{ .MasterNs }}
     packageName: ibm-events-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: {{ .Channel }}
@@ -370,6 +394,7 @@ spec:
     namespace: {{ .MasterNs }}
     packageName: ibm-zen-operator
     scope: public
+    installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
 `

--- a/main.go
+++ b/main.go
@@ -176,6 +176,10 @@ func main() {
 			klog.Errorf("Failed to create common service operator subscription: %v", err)
 			os.Exit(1)
 		}
+		if err = bs.UpdateCsOpApproval(); err != nil {
+			klog.Errorf("Failed to update common service operator subscription: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	klog.Info("Starting manager")


### PR DESCRIPTION
When cloudpak operator is installed in the approval mode, then the common service operator in master namespace will be deployed in the manual approval mode.