### PR TITLE
[WIP] sync up NSS CR for common service and ODLM

### DIFF
--- a/controllers/namespacescope/namespacescope.go
+++ b/controllers/namespacescope/namespacescope.go
@@ -79,11 +79,12 @@ func SyncUpCR(bs *bootstrap.Bootstrap) {
 
 		sourceNsSet := gset.NewSet()
 		targetNsSet := gset.NewSet()
-		// we cann't convert []T to []interface{} directly in Go, have to add it to set by loop
+		// we can't convert []T to []interface{} directly in Go, have to add it to set by loop
 		for _, ns := range sourceNsScope.Spec.NamespaceMembers {
 			sourceNsSet.Add(ns)
 		}
 		for _, ns := range targetNsScope.Spec.NamespaceMembers {
+			sourceNsSet.Add(ns)
 			targetNsSet.Add(ns)
 		}
 

--- a/controllers/namespacescope/namespacescope.go
+++ b/controllers/namespacescope/namespacescope.go
@@ -77,22 +77,22 @@ func SyncUpCR(bs *bootstrap.Bootstrap) {
 			continue
 		}
 
-		sourceNsSet := gset.NewSet()
+		mergeNsSet := gset.NewSet()
 		targetNsSet := gset.NewSet()
 		// we can't convert []T to []interface{} directly in Go, have to add it to set by loop
 		for _, ns := range sourceNsScope.Spec.NamespaceMembers {
-			sourceNsSet.Add(ns)
+			mergeNsSet.Add(ns)
 		}
 		for _, ns := range targetNsScope.Spec.NamespaceMembers {
-			sourceNsSet.Add(ns)
+			mergeNsSet.Add(ns)
 			targetNsSet.Add(ns)
 		}
 
 		// sync up when namepsace in source CR is different from target CR
-		if !sourceNsSet.Equal(targetNsSet) {
-			sourcenNsMems := sourceNsSet.ToSlice()
+		if !mergeNsSet.Equal(targetNsSet) {
+			mergeNsMems := mergeNsSet.ToSlice()
 			var targetNsMems []string
-			for _, ns := range sourcenNsMems {
+			for _, ns := range mergeNsMems {
 				targetNsMems = append(targetNsMems, ns.(string))
 			}
 			targetNsScope.Spec.NamespaceMembers = targetNsMems

--- a/controllers/namespacescope/namespacescope.go
+++ b/controllers/namespacescope/namespacescope.go
@@ -1,0 +1,117 @@
+//
+// Copyright 2021 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package nss
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+
+	nssv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
+
+	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
+)
+
+var (
+	apiGroupVersion = "operator.ibm.com/v1"
+	Kinds           = []string{"NamespaceScope"}
+	CRList          = []string{"common-service", "nss-odlm-scope"}
+	sourceCR        = "common-service"
+	targetCR        = "nss-odlm-scope"
+)
+
+var ctx = context.Background()
+
+// SyncUpCR syncs up the namespace members in source CR and target CR
+func SyncUpCR(bs *bootstrap.Bootstrap) {
+	for {
+		// wait for nss CRD
+		for _, kind := range Kinds {
+			if err := bs.WaitResourceReady(apiGroupVersion, kind); err != nil {
+				klog.Errorf("Failed to wait for resource ready with kind %s, apiGroupVersion: %s", kind, apiGroupVersion)
+				continue
+			}
+		}
+
+		// wait for source and target CR
+		for _, cr := range CRList {
+			for {
+				ready := waitCRReady(bs, cr, bs.CSData.MasterNs)
+				if ready {
+					break
+				}
+				time.Sleep(10 * time.Second)
+			}
+		}
+
+		// fetch the source and target NSS CR
+		sourceNsScope := &nssv1.NamespaceScope{}
+		sourceNsScopeKey := types.NamespacedName{Name: sourceCR, Namespace: bs.CSData.MasterNs}
+		if err := bs.Reader.Get(ctx, sourceNsScopeKey, sourceNsScope); err != nil {
+			klog.Errorf("Failed to get NSS CR %s: %v, retry again", sourceNsScopeKey.String(), err)
+			continue
+		}
+
+		targetNsScope := &nssv1.NamespaceScope{}
+		targetNsScopeKey := types.NamespacedName{Name: targetCR, Namespace: bs.CSData.MasterNs}
+		if err := bs.Reader.Get(ctx, targetNsScopeKey, targetNsScope); err != nil {
+			klog.Errorf("Failed to get NSS CR %s: %v, retry again", targetNsScopeKey.String(), err)
+			continue
+		}
+
+		// sync up when namepsace in source CR is different from target CR
+		if len(sourceNsScope.Spec.NamespaceMembers) != len(targetNsScope.Spec.NamespaceMembers) {
+			var sourcenNsMems []string
+			sourceNsSet := make(map[string]interface{})
+			for _, ns := range sourceNsScope.Spec.NamespaceMembers {
+				sourceNsSet[ns] = struct{}{}
+			}
+
+			for ns := range sourceNsSet {
+				sourcenNsMems = append(sourcenNsMems, ns)
+			}
+
+			targetNsScope.Spec.NamespaceMembers = sourcenNsMems
+
+			if err := bs.Client.Update(ctx, targetNsScope); err != nil {
+				klog.Errorf("Failed to update NSS resource %s: %v, retry again", targetNsScopeKey.String(), err)
+				continue
+			}
+		}
+
+		time.Sleep(1 * time.Minute)
+	}
+}
+
+func waitCRReady(bs *bootstrap.Bootstrap, nssKey, namespace string) bool {
+	if err := utilwait.PollImmediateInfinite(time.Second*10, func() (done bool, err error) {
+		nsScope := &nssv1.NamespaceScope{}
+		nsScopeKey := types.NamespacedName{Name: nssKey, Namespace: namespace}
+		err = bs.Reader.Get(ctx, nsScopeKey, nsScope)
+		if err != nil {
+			return false, err
+		}
+		return true, nil
+	}); err != nil {
+		klog.Errorf("waiting for NSS CR: %v, retry in 10 seconds", err)
+		return false
+	}
+	return true
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/IBM/controller-filtered-cache v0.2.1
 	github.com/IBM/ibm-namespace-scope-operator v1.0.1
 	github.com/IBM/operand-deployment-lifecycle-manager v1.5.0
+	github.com/deckarep/golang-set v1.7.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/onsi/ginkgo v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/IBM/ibm-common-service-operator/controllers/check"
 	util "github.com/IBM/ibm-common-service-operator/controllers/common"
 	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	nss "github.com/IBM/ibm-common-service-operator/controllers/namespacescope"
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
@@ -164,6 +165,8 @@ func main() {
 		go check.IamStatus(bs)
 		// Generate Issuer and Certificate CR
 		go certmanager.DeployCR(bs)
+		// Sync up NSS CR
+		go nss.SyncUpCR(bs)
 
 		if err = (&controllers.CommonServiceReconciler{
 			Bootstrap: bs,


### PR DESCRIPTION
It creates an additional go routine to sync up the `common-service` and `nss-odlm-scope` NSS CR.

Currently, we use `common-service` NSS CR to control the namespace scope for individual common service operator and use `nss-odlm-scope` to control the namespace scope for ODLM.

When user manually extend their operator's permission to other namespaces, they will be instructed about adding namespace in `common-service` NSS CR.

Therefore, we need to sync up the namespace member in both `common-service` and `nss-odlm-scope` NSS CR, to ensure that ODLM's permission is be extended as well.

The code part is finished, need to do some test before merging it.