### PR TITLE
filter the template size when the CR is out of scope

### DIFF
--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -261,7 +261,7 @@ func (r *CommonServiceReconciler) updateOperandConfig(newConfigs []interface{}) 
 		}
 	}
 
-	// Checking all the common service CRs to get the minimal size
+	// Checking all the common service CRs to get the minimal(unique largest) size
 	opconServices, err = r.getMinimalSizes(opconServices, ruleSlice)
 	if err != nil {
 		return true, err

--- a/controllers/render_template.go
+++ b/controllers/render_template.go
@@ -105,20 +105,20 @@ func applySizeTemplate(cs *unstructured.Unstructured, sizeTemplate string, inSco
 		klog.Errorf("convert size to interface slice: %v", err)
 		return nil, err
 	}
-
-	for _, configSize := range sizes {
-		if !inScope {
-			isClusterScope := false
+	var newSizes []interface{}
+	if !inScope {
+		// delete all namespace-scoped operator's template
+		for _, configSize := range sizes {
 			for _, operator := range clusterScopeOperators {
 				if configSize.(map[string]interface{})["name"].(string) == operator {
-					isClusterScope = true
-					break
+					newSizes = append(newSizes, configSize)
 				}
 			}
-			if !isClusterScope {
-				continue
-			}
 		}
+		sizes = newSizes
+	}
+
+	for _, configSize := range sizes {
 		config := getItemByName(src, configSize.(map[string]interface{})["name"].(string))
 		if config == nil {
 			continue


### PR DESCRIPTION
We will always return the size template in function `applySizeTemplate()`.

Therefore, when it is out of scope, we should remove those namespace-scoped operator from template, and then return it as the `newConfigs`