### PR TITLE
find nssConfigMap in masterNs instead of operatorNs

### DIFF
--- a/controllers/check/check_iam.go
+++ b/controllers/check/check_iam.go
@@ -135,7 +135,7 @@ func createUpdateConfigmap(bs *bootstrap.Bootstrap, status string) error {
 		klog.Info("IAM status is NotReady, waiting some minutes...")
 	}
 
-	nssNsSlice := util.GetNssCmNs(bs.Reader)
+	nssNsSlice := util.GetNssCmNs(bs.Reader, bs.CSData.MasterNs)
 	err := bs.Reader.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: cmNs}, cm)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -192,7 +192,7 @@ func updateConfigmap(bs *bootstrap.Bootstrap, status string) error {
 	} else if err != nil {
 		return err
 	}
-	nssNsSlice := util.GetNssCmNs(bs.Reader)
+	nssNsSlice := util.GetNssCmNs(bs.Reader, bs.CSData.MasterNs)
 	isUpdate := false
 	for _, nssNs := range nssNsSlice {
 		// update the iam status for each cloud pak which is using this common service

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -588,7 +588,7 @@ func GetCmOfNss(r client.Reader, operatorNs string) *corev1.ConfigMap {
 			err = r.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: cmNs}, nssConfigmap)
 			if err != nil {
 				if errors.IsNotFound(err) {
-					klog.V(2).Infof("waiting for configmap %v/%v", operatorNs, constant.NamespaceScopeConfigmapName)
+					klog.Infof("waiting for configmap %v/%v", operatorNs, constant.NamespaceScopeConfigmapName)
 					return false, nil
 				}
 				return false, err

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -564,18 +564,12 @@ func GetRequestNs(r client.Reader) (requestNs []string) {
 }
 
 // GetNssCmNs gets namespaces from namespace-scope ConfigMap
-func GetNssCmNs(r client.Reader) (nssCmNs []string) {
-	operatorNs, err := GetOperatorNamespace()
-	if err != nil {
-		klog.Errorf("Getting operator namespace failed: %v", err)
-		return
-	}
-
-	nssConfigMap := GetCmOfNss(r, operatorNs)
+func GetNssCmNs(r client.Reader, masterNs string) (nssCmNs []string) {
+	nssConfigMap := GetCmOfNss(r, masterNs)
 
 	nssNsMems, ok := nssConfigMap.Data["namespaces"]
 	if !ok {
-		klog.Infof("There is no namespace in configmap %v/%v", operatorNs, constant.NamespaceScopeConfigmapName)
+		klog.Infof("There is no namespace in configmap %v/%v", masterNs, constant.NamespaceScopeConfigmapName)
 		return
 	}
 	nssCmNs = strings.Split(nssNsMems, ",")


### PR DESCRIPTION
To adopt the all namespace mode, the NSS ConfigMap will always be in `MasterNs` instead of `OperatorNs`