### PR TITLE
bump master branch to 4.0.0 for future release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Red Hat OpenShift Container Platform 4.3 or newer installed on one of the follow
 
 ## Operator versions
 
- - 3.8.1
+ - 4.0.0
 
 ## Prerequisites
 

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -24,9 +24,9 @@ metadata:
     containerImage: quay.io/opencloudio/common-service-operator:latest
     createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
-    olm.skipRange: ">=3.3.0 <3.8.1"
+    olm.skipRange: ">=3.3.0 <4.0.0"
     operatorChannel: v3
-    operatorVersion: 3.8.1
+    operatorVersion: 4.0.0
     operators.operatorframework.io/builder: operator-sdk-v1.8.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/ibm-common-service-operator
@@ -36,7 +36,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-common-service-operator.v3.8.1
+  name: ibm-common-service-operator.v4.0.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -78,7 +78,7 @@ spec:
 
     ## Operator versions
 
-     - 3.8.1
+     - 4.0.0
 
     ## Prerequisites
 
@@ -327,5 +327,5 @@ spec:
   maturity: alpha
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.8.0
-  version: 3.8.1
+  replaces: ibm-common-service-operator.v3.9.0
+  version: 4.0.0

--- a/common/scripts/multiarch_image.sh
+++ b/common/scripts/multiarch_image.sh
@@ -24,7 +24,7 @@ ALL_PLATFORMS="amd64 ppc64le s390x"
 IMAGE_REPO=${1}
 IMAGE_NAME=${2}
 VERSION=${3-"$(git describe --exact-match 2> /dev/null || git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)"}
-RELEASE_VERSION=${4:-3.8.1}
+RELEASE_VERSION=${4:-4.0.0}
 MAX_PULLING_RETRY=${MAX_PULLING_RETRY-10}
 RETRY_INTERVAL=${RETRY_INTERVAL-10}
 # support other container tools, e.g. podman

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -9,7 +9,7 @@ metadata:
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     olm.skipRange: ""
     operatorChannel: v3
-    operatorVersion: 3.8.1
+    operatorVersion: 4.0.0
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-common-service-operator
@@ -62,7 +62,7 @@ spec:
 
     ## Operator versions
 
-     - 3.8.1
+     - 4.0.0
 
     ## Prerequisites
 

--- a/controllers/certmanager/cert_cr.go
+++ b/controllers/certmanager/cert_cr.go
@@ -22,7 +22,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
   labels:
     app.kubernetes.io/instance: cs-ca-issuer
     app.kubernetes.io/managed-by: cert-manager-controller
@@ -40,7 +40,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
   labels:
     app.kubernetes.io/instance: cs-ss-issuer
     app.kubernetes.io/managed-by: cert-manager-controller
@@ -57,7 +57,7 @@ apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
   labels:
     app.kubernetes.io/instance: cs-ca-certificate
     app.kubernetes.io/managed-by: cert-manager-controller

--- a/controllers/constant/secretshare.go
+++ b/controllers/constant/secretshare.go
@@ -78,7 +78,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
   creationTimestamp: null
   name: secretshare
 rules:
@@ -153,7 +153,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
-    version: "3.8.1"
+    version: "4.0.0"
   name: secretshares.ibmcpcs.ibm.com
 spec:
   group: ibmcpcs.ibm.com
@@ -271,7 +271,7 @@ metadata:
   name: secretshare
   namespace: placeholder
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
 spec:
   replicas: 1
   selector:

--- a/controllers/constant/webhook.go
+++ b/controllers/constant/webhook.go
@@ -91,7 +91,7 @@ kind: ClusterRole
 metadata:
   name: ibm-common-service-webhook
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
 rules:
 - apiGroups:
     - ""
@@ -170,7 +170,7 @@ kind: CustomResourceDefinition
 metadata:
   name: podpresets.operator.ibm.com
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
 spec:
   group: operator.ibm.com
   names:
@@ -1646,7 +1646,7 @@ metadata:
   name: ibm-common-service-webhook
   namespace: placeholder
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
 spec:
   replicas: 1
   selector:
@@ -1704,7 +1704,7 @@ metadata:
   name: ibm-common-service-webhook
   namespace: placeholder
   annotations:
-    version: "3.8.1"
+    version: "4.0.0"
 spec:
   replicas: 1
   selector:

--- a/testdata/deploy/deploy.yaml
+++ b/testdata/deploy/deploy.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         description: The IBM Common Service Operator is used to deploy IBM Common Services
         operatorChannel: v3
-        operatorVersion: 3.8.1
+        operatorVersion: 4.0.0
     spec:
       affinity:
         nodeAffinity:

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "3.8.1"
+	Version = "4.0.0"
 )


### PR DESCRIPTION
Master branch will be used for the future pipeline going forward.

We can put future dev code into these builds as long as your operator is set to a higher version than any of the versions in `eus`, `efix`, and `cd` branches.