### PR TITLE
prioritize the dev catalogsource

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -124,6 +124,7 @@ spec:
               resources:
                 - subscriptions
                 - clusterserviceversions
+                - catalogsources
               verbs:
                 - delete
                 - get

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -122,9 +122,14 @@ spec:
             - apiGroups:
                 - operators.coreos.com
               resources:
+                - catalogsources
+              verbs:
+                - get
+            - apiGroups:
+                - operators.coreos.com
+              resources:
                 - subscriptions
                 - clusterserviceversions
-                - catalogsources
               verbs:
                 - delete
                 - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -26,6 +26,13 @@ rules:
   - create
   - update
   - watch
+# check catalogsource migration for highest priority of internal dev build
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - get
 # delete existing subscriptions in openshift-operators/ibm-common-services
 - apiGroups:
   - operators.coreos.com

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -430,7 +430,7 @@ func GetCatalogSource(packageName, ns string, r client.Reader) (CatalogSourceNam
 			klog.Info(err)
 		}
 	} else {
-		reg, _ := regexp.Compile(`^(.*)\.artifactory\.(.*)`)
+		reg, _ := regexp.Compile(constant.DevBuildImage)
 		if reg.MatchString(CSCatalogsource.Spec.Image) {
 			devEnabled = true
 		}

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -60,6 +60,8 @@ const (
 	IBMCSPackage = "ibm-common-service-operator"
 	// NamespaceScopeConfigmapName is the name of ConfigMap which stores the NamespaceScope Info
 	NamespaceScopeConfigmapName = "namespace-scope"
+	// devBuildImage is regular expression of the image address of internal dev build for testing
+	DevBuildImage = `^hyc\-cloud\-private\-(.*)\-docker\-local\.artifactory\.swg\-devops\.com\/ibmcom\/ibm\-common\-service\-catalog\:(.*)`
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/testdata/deploy/role.yaml
+++ b/testdata/deploy/role.yaml
@@ -31,6 +31,13 @@ rules:
   - delete
   - get
   - list
+# check catalogsource migration for highest priority of internal dev build
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - get
 # cluster watch CommonService
 - apiGroups:
   - operator.ibm.com


### PR DESCRIPTION
The dev build with `opencloud-operator` CatalogSource has the highest priority.

When there is no dev build in the cluster, it will follow the previous strategy that we will choose `ibm-operator-catalog` if it exists.

But there is a permission escalation happening, `cs-operator` requires the cluster permission for getting the CatalogSource from `openshift-marketplace` namespace in order to check the image used by `opencloud-operator`. The `packageManifest` of `cs-operator` in its own namespace is not really helpful.