### PR TITLE
uninstall cert-manager after channel switch

### DIFF
--- a/common/scripts/upgrade_to_continuous_delivery_airgap.sh
+++ b/common/scripts/upgrade_to_continuous_delivery_airgap.sh
@@ -115,6 +115,26 @@ function switch_to_continous_delivery() {
         msg ""
     done < <(oc get sub -n ibm-common-services | awk '{print $1}')
 
+    certmanagersub=$(oc get sub ibm-cert-manager-operator -n ibm-common-services --ignore-not-found)
+    certmanagercsv=$(oc get csv -n ibm-common-services | grep ibm-cert-manager-operator | awk '{print $1}')
+    if [[ "X${certmanagersub}" != "X" ]]; then
+        msg "Deleting ibm-cert-manager-operator in namesapce ibm-common-services, it will be re-installed by ODLM after the upgrade is successful ..."
+        msg "-----------------------------------------------------------------------"
+
+        in_step=1
+        msg "[${in_step}] Removing the subscription of ibm-cert-manager-operator in namesapce ibm-common-services ..."
+        oc delete sub ibm-cert-manager-operator -n ibm-common-services 2> /dev/null
+
+        in_step=$((in_step + 1))
+        msg "[${in_step}] Removing the csv of ibm-cert-manager-operator in namesapce ibm-common-services ..."
+        oc delete csv ${certmanagercsv} -n ibm-common-services 2> /dev/null
+
+        msg ""
+
+        success "Remove ibm-cert-manager-operator successfully."
+        msg ""
+    fi
+
     success "Updated all operator subscriptions in namespace ibm-common-services successfully."
 
     msg "Creating namespace scope config in namespace ibm-common-services..."


### PR DESCRIPTION
Currently when we upgrade from CS 3.6 or below to CS 3.8, the version 3.10 cert-manager-operator in CS 3.8 will use the version 3.9 cert-manager-operator in CS 3.7 as a bridge, it is not a direct upgrade.

In AirGap situation, it will cause the `ImagePullBackOff` error for version 3.9 cert-manager-operator, because we did not include the images about CS 3.7 for CS 3.8 bundle.

Therefore, we will delete the cert-manager-operator before the upgrade, and ODLM will re-install the version 3.10 cert-manager-operator directly after the upgrade.