### PR TITLE
remove checking installedcsv with currentcsv for manual approval strategy

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -769,10 +769,6 @@ func (b *Bootstrap) waitOperatorReady(name, namespace string) error {
 			}
 		}
 
-		if sub.Status.InstalledCSV != sub.Status.CurrentCSV {
-			return false, nil
-		}
-
 		// check csv
 		csvName := sub.Status.InstalledCSV
 		if csvName != "" {


### PR DESCRIPTION
Avoid the situation that the user does not wanna upgrade when there is a newer version coming, but cs-operator continue waiting for others' upgrading because the currentCSV is larger than installedCSV.