### PR TITLE
config IAM with OnPremMultiEnable

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -84,6 +84,7 @@ type CSData struct {
 	CatalogSourceNs    string
 	IsolatedModeEnable string
 	ApprovalMode       string
+	OnPremMultiEnable  string
 }
 
 type CSOperator struct {
@@ -304,6 +305,7 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService) error {
 		}
 	} else {
 		// OperandConfig for on-prem deployment
+		b.CSData.OnPremMultiEnable = strconv.FormatBool(b.MultiInstancesEnable)
 		if err := b.renderTemplate(constant.CSV3OperandConfig, b.CSData); err != nil {
 			return err
 		}

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -40,7 +40,9 @@ spec:
       certManager: {}
   - name: ibm-iam-operator
     spec:
-      authentication: {}
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
       oidcclientwatcher: {}
       pap: {}
       policycontroller: {}


### PR DESCRIPTION
1. On-Prem Multi instances case:
```
    - name: ibm-iam-operator
      spec:
        operandRequest: {}
        secretwatcher: {}
        policycontroller: {}
        policydecision: {}
        operandBindInfo:
          bindings:
            protected-zen-serviceid:
              secret: zen-serviceid-apikey-secret
        oidcclientwatcher: {}
        authentication:
          config:
            onPremMultipleDeploy: true
```

2. On-Prem Single instance case:
```
    - name: ibm-iam-operator
      spec:
        operandRequest: {}
        secretwatcher: {}
        policycontroller: {}
        policydecision: {}
        operandBindInfo:
          bindings:
            protected-zen-serviceid:
              secret: zen-serviceid-apikey-secret
        oidcclientwatcher: {}
        authentication:
          config:
            onPremMultipleDeploy: false
```

3. SaaS case:
```
    - name: ibm-iam-operator
      spec:
        operandRequest: {}
        secretwatcher: {}
        policycontroller: {}
        policydecision: {}
        operandBindInfo:
          bindings:
            protected-zen-serviceid:
              secret: zen-serviceid-apikey-secret
        oidcclientwatcher: {}
        authentication:
          config:
            ibmCloudSaas: true
```