### PR TITLE
Make probe more loose

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -316,14 +316,18 @@ spec:
                       httpGet:
                         path: /healthz
                         port: 8081
-                      initialDelaySeconds: 2
-                      periodSeconds: 3
+                      initialDelaySeconds: 60
+                      timeoutSeconds: 3
+                      periodSeconds: 20
+                      failureThreshold: 10
                     livenessProbe:
                       httpGet:
                         path: /readyz
                         port: 8081
-                      initialDelaySeconds: 2
-                      periodSeconds: 5
+                      initialDelaySeconds: 120
+                      timeoutSeconds: 10
+                      periodSeconds: 60
+                      failureThreshold: 10
                     resources:
                       limits:
                         cpu: 500m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -43,14 +43,18 @@ spec:
           httpGet:
             path: /healthz
             port: 8081
-          initialDelaySeconds: 2
-          periodSeconds: 3
+          initialDelaySeconds: 60
+          timeoutSeconds: 3
+          periodSeconds: 20
+          failureThreshold: 10
         livenessProbe:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: 2
-          periodSeconds: 5
+          initialDelaySeconds: 120
+          timeoutSeconds: 10
+          periodSeconds: 60
+          failureThreshold: 10
         image: quay.io/opencloudio/common-service-operator:latest
         imagePullPolicy: Always
         name: ibm-common-service-operator


### PR DESCRIPTION
CS operator expects its container can be ready within 1 second, but it can’t in the machine with bad performance.
We need to make to probe more loose to prevent this error