### PR TITLE
Change Licensing logLevel in saas

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -257,6 +257,7 @@ spec:
       IBMLicensing:
         datasource: datacollector
         routeEnabled: false
+		logLevel: VERBOSE
       operandBindInfo: {}
   - name: ibm-mongodb-operator
     spec:

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -257,7 +257,7 @@ spec:
       IBMLicensing:
         datasource: datacollector
         routeEnabled: false
-		logLevel: VERBOSE
+        logLevel: VERBOSE
       operandBindInfo: {}
   - name: ibm-mongodb-operator
     spec:


### PR DESCRIPTION
When on SaaS, use Verbose log level for License Service.