### PR TITLE
use default path for two probes

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -330,7 +330,7 @@ spec:
                     livenessProbe:
                       failureThreshold: 10
                       httpGet:
-                        path: /readyz
+                        path: /healthz
                         port: 8081
                       initialDelaySeconds: 120
                       periodSeconds: 60
@@ -339,7 +339,7 @@ spec:
                     readinessProbe:
                       failureThreshold: 10
                       httpGet:
-                        path: /healthz
+                        path: /readyz
                         port: 8081
                       initialDelaySeconds: 3
                       periodSeconds: 20

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,7 +41,7 @@ spec:
         - /manager
         readinessProbe:
           httpGet:
-            path: /healthz
+            path: /readyz
             port: 8081
           initialDelaySeconds: 3
           timeoutSeconds: 3
@@ -49,7 +49,7 @@ spec:
           failureThreshold: 10
         livenessProbe:
           httpGet:
-            path: /readyz
+            path: /healthz
             port: 8081
           initialDelaySeconds: 120
           timeoutSeconds: 10

--- a/main.go
+++ b/main.go
@@ -193,11 +193,11 @@ func main() {
 		}
 	}
 
-	if err := mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		klog.Errorf("unable to set up health check: %v", err)
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("check", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		klog.Errorf("unable to set up ready check: %v", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
The default Readiness probe endpoint name is `readyz` and default Liveness probe endpoint name is "healthz"
https://github.com/kubernetes-sigs/controller-runtime/blob/release-0.6/pkg/manager/manager.go#L187

Also try to align it with the example in kubebuilder
```
    // +kubebuilder:scaffold:builder

    if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
        setupLog.Error(err, "unable to set up health check")
        os.Exit(1)
    }
    if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
        setupLog.Error(err, "unable to set up ready check")
        os.Exit(1)
    }
```
https://book.kubebuilder.io/cronjob-tutorial/empty-main.html