### PR TITLE
onboard and add size comparison for api-catalog

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -100,6 +100,11 @@ spec:
       AnalyticsProxy: {}
       operandBindInfo: {}
       operandRequest: {}
+  - name: ibm-apicatalog
+    spec:
+      apicatalogmanager: {}
+      operandBindInfo: {}
+      operandRequest: {}
 `
 
 const CSV3OperandRegistry = `
@@ -255,6 +260,12 @@ spec:
     name: cloud-native-postgresql
     namespace: {{ .MasterNs }}
     packageName: cloud-native-postgresql
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: v3
+    name: ibm-apicatalog
+    namespace: {{ .MasterNs }}
+    packageName: ibm-apicatalog
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
 `

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -435,4 +435,8 @@ const ConfigurationRules = `
           limits:
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: LARGEST_VALUE
 `

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -433,4 +433,8 @@ const Large = `
           limits:
             cpu: 50m
             memory: 120Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: large
 `

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -433,4 +433,8 @@ const Large = `
           requests:
             cpu: 10m
             memory: 50Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: large
 `

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -433,4 +433,8 @@ const Large = `
           requests:
             cpu: 10m
             memory: 50Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: large
 `

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -433,4 +433,8 @@ const Medium = `
           limits:
             cpu: 50m
             memory: 120Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: medium
 `

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -433,4 +433,8 @@ const Medium = `
           requests:
             cpu: 10m
             memory: 50Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: medium
 `

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -433,4 +433,8 @@ const Medium = `
           requests:
             cpu: 10m
             memory: 50Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: medium
 `

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -433,4 +433,8 @@ const Small = `
           limits:
             cpu: 30m
             memory: 120Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: small
 `

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -433,4 +433,8 @@ const Small = `
           limits:
             cpu: 100m
             memory: 100Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: small
 `

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -433,4 +433,8 @@ const Small = `
           limits:
             cpu: 30m
             memory: 50Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: small
 `

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -433,4 +433,8 @@ const StarterSet = `
           limits:
             cpu: 30m
             memory: 120Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: small
 `

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -433,4 +433,8 @@ const StarterSet = `
           limits:
             cpu: 100m
             memory: 100Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: small
 `

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -433,4 +433,8 @@ const StarterSet = `
           limits:
             cpu: 30m
             memory: 50Mi
+- name: ibm-apicatalog
+  spec:
+    apicatalogmanager:
+      profile: small
 `


### PR DESCRIPTION
the cs-operator should be able to compare `small`, `medium` and `large` string in `api-catalog` profile