### PR TITLE
add comparison for slices

### DIFF
--- a/controllers/rules/resource_comparison.go
+++ b/controllers/rules/resource_comparison.go
@@ -93,8 +93,20 @@ func ResourceEqualComparison(resourceA interface{}, resourceB interface{}) bool 
 
 	isEqual := true
 	switch resourceA := resourceA.(type) {
-	// TODO: consider the slices
-	// case []interface{}:
+	case []interface{}:
+		if resourceB == nil {
+			isEqual = false
+		} else if resourceB, ok := resourceB.([]interface{}); ok {
+			if len(resourceA) != len(resourceB) {
+				isEqual = false
+			} else {
+				// TODO: need to find a better way to compare when the order of slice is not fixed
+				for index := range resourceA {
+					isEqual = isEqual && ResourceEqualComparison(resourceA[index], resourceB[index])
+				}
+			}
+		}
+		return isEqual
 	case map[string]interface{}:
 		if resourceB == nil {
 			isEqual = false

--- a/controllers/rules/resource_comparison.go
+++ b/controllers/rules/resource_comparison.go
@@ -102,7 +102,9 @@ func ResourceEqualComparison(resourceA interface{}, resourceB interface{}) bool 
 			} else {
 				// TODO: need to find a better way to compare when the order of slice is not fixed
 				for index := range resourceA {
-					isEqual = isEqual && ResourceEqualComparison(resourceA[index], resourceB[index])
+					if !ResourceEqualComparison(resourceA[index], resourceB[index]) {
+						return false
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When there are slices defined in OperandConfig, we will simply compare those values to check whether they are equal, but we will **not apply any changes insides the slices** for now.

This is for api-catalog boarding task