### PR TITLE
Revert "update certmanager APIGroup version to v1 (#637)" so that CICD

### DIFF
--- a/controllers/constant/certmanager.go
+++ b/controllers/constant/certmanager.go
@@ -18,7 +18,7 @@ package constant
 
 // CSCAIssuer is the CR of cs-ca-issuer
 const CSCAIssuer = `
-apiVersion: cert-manager.io/v1
+apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
   annotations:
@@ -36,7 +36,7 @@ spec:
 
 // CSSSIsuuer is the CR of cs-ss-issuer
 const CSSSIssuer = `
-apiVersion: cert-manager.io/v1
+apiVersion: certmanager.k8s.io/v1alpha1
 kind: Issuer
 metadata:
   annotations:
@@ -53,7 +53,7 @@ spec:
 
 // CSCACert is the CR of cs-ca-certificate
 const CSCACert = `
-apiVersion: cert-manager.io/v1
+apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
   annotations:

--- a/controllers/goroutines/variables.go
+++ b/controllers/goroutines/variables.go
@@ -27,7 +27,7 @@ var (
 	IAMDeployNames     = []string{"ibm-iam-operator", "auth-idp", "auth-pap", "auth-pdp", "oidcclient-watcher", "secret-watcher"}
 	IAMJobNames        = []string{"iam-onboarding", "security-onboarding", "oidc-client-registration"}
 
-	CertManagerAPIGroupVersion = "cert-manager.io/v1"
+	CertManagerAPIGroupVersion = "certmanager.k8s.io/v1alpha1"
 	CertManagerKinds           = []string{"Issuer", "Certificate"}
 	CertManagerCRs             = []string{constant.CSSSIssuer, constant.CSCACert, constant.CSCAIssuer}
 


### PR DESCRIPTION
can produce latest-validated build earlier. Will add back in once
cert-manager can handle mixing v1 and v1alpha1 certs

This reverts commit b032cf32b85af87a1d9472778b7ce640b5ca0f91.