### PR TITLE
remove deprecated beta.kubernetes.io label for EDB Job

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -124,7 +124,7 @@ spec:
                     requiredDuringSchedulingIgnoredDuringExecution:
                       nodeSelectorTerms:
                       - matchExpressions:
-                        - key: beta.kubernetes.io/arch
+                        - key: kubernetes.io/arch
                           operator: In
                           values:
                           - amd64


### PR DESCRIPTION
`beta.kubernetes.io/arch` -> `kubernetes.io/arch`