### PR TITLE
Update crossplane's Lock API version

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -810,19 +810,9 @@ func (b *Bootstrap) installCrossplaneOperator() error {
 		return err
 	}
 
-	if err := b.waitResourceReady("pkg.ibm.crossplane.io/v1alpha1", "Lock"); err != nil {
-		return err
-	}
-
 	klog.Info("Creating Crossplane Configuration")
 	if err := b.createCrossplaneConfiguration(); err != nil {
 		klog.Errorf("Failed to create or update Crossplane Configuration: %v", err)
-		return err
-	}
-
-	klog.Info("Creating Crossplane Lock")
-	if err := b.createCrossplaneLock(); err != nil {
-		klog.Errorf("Failed to create or update Crossplane Lock: %v", err)
 		return err
 	}
 
@@ -913,14 +903,6 @@ func (b *Bootstrap) createCrossplaneSubscription() error {
 
 func (b *Bootstrap) createCrossplaneConfiguration() error {
 	resourceName := constant.CrossConfiguration
-	if err := b.renderTemplate(resourceName, b.CSData, true); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (b *Bootstrap) createCrossplaneLock() error {
-	resourceName := constant.CrossLock
 	if err := b.renderTemplate(resourceName, b.CSData, true); err != nil {
 		return err
 	}

--- a/controllers/constant/crossplane.go
+++ b/controllers/constant/crossplane.go
@@ -47,7 +47,7 @@ spec:
 `
 
 const CrossLock = `
-apiVersion: pkg.ibm.crossplane.io/v1alpha1
+apiVersion: pkg.ibm.crossplane.io/v1beta1
 kind: Lock
 metadata:
   name: lock


### PR DESCRIPTION
Update Crossplane's Lock API version from v1alpha1 to v1beta1.
Remove code creating Lock during installation - Crossplane will create Lock on its own when necessary. 