### PR TITLE
check dev image for individual operator package

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -375,7 +375,7 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService) error {
 		return err
 	}
 
-	// Clean up deprecated ressource
+	// Clean up deprecated resource
 	if err := b.cleanup(operatorNs); err != nil {
 		return err
 	}


### PR DESCRIPTION
It is for solving the following problem.

If a developer is using opencloudio with dev image (artifactory) for common services, then other bedrock operators out of opencloudio, like postgresal, can't be installed from the ibm-operator-catalog caatalogsource.  

This PR moves the dev image checking logic into catalogsource comparison, then we can analyze the case individually without impact crossing different catalogsources