### PR TITLE
increase cert manager resources for EUS

### DIFF
--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -47,10 +47,10 @@ const Large = `
       configMapWatcher:
         resources:
           limits:
-            cpu: 60m
+            cpu: 20m
             memory: 60Mi
           requests:
-            cpu: 30m
+            cpu: 20m
             memory: 30Mi
 - name: ibm-mongodb-operator
   spec:

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -23,7 +23,7 @@ const Large = `
       certManagerCAInjector:
         resources:
           limits:
-            cpu: 35m
+            cpu: 100m
             memory: 1000Mi
           requests:
             cpu: 30m
@@ -47,10 +47,10 @@ const Large = `
       configMapWatcher:
         resources:
           limits:
-            cpu: 20m
+            cpu: 60m
             memory: 60Mi
           requests:
-            cpu: 20m
+            cpu: 30m
             memory: 30Mi
 - name: ibm-mongodb-operator
   spec:

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -23,7 +23,7 @@ const Medium = `
       certManagerCAInjector:
         resources:
           limits:
-            cpu: 35m
+            cpu: 100m
             memory: 1000Mi
           requests:
             cpu: 30m
@@ -47,10 +47,10 @@ const Medium = `
       configMapWatcher:
         resources:
           limits:
-            cpu: 20m
+            cpu: 60m
             memory: 60Mi
           requests:
-            cpu: 20m
+            cpu: 30m
             memory: 30Mi
 - name: ibm-mongodb-operator
   spec:

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -47,10 +47,10 @@ const Medium = `
       configMapWatcher:
         resources:
           limits:
-            cpu: 60m
+            cpu: 20m
             memory: 60Mi
           requests:
-            cpu: 30m
+            cpu: 20m
             memory: 30Mi
 - name: ibm-mongodb-operator
   spec:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -23,19 +23,19 @@ const Small = `
       certManagerCAInjector:
         resources:
           limits:
-            cpu: 35m
-            memory: 520Mi
+            cpu: 100m
+            memory: 1000Mi
           requests:
-            cpu: 20m
-            memory: 170Mi
+            cpu: 30m
+            memory: 500Mi
       certManagerController:
         resources:
           limits:
             cpu: 80m
-            memory: 530Mi
+            memory: 1010Mi
           requests:
             cpu: 20m
-            memory: 140Mi
+            memory: 510Mi
       certManagerWebhook:
         resources:
           limits:
@@ -47,11 +47,11 @@ const Small = `
       configMapWatcher:
         resources:
           limits:
-            cpu: 20m
+            cpu: 60m
             memory: 60Mi
           requests:
-            cpu: 20m
-            memory: 20Mi
+            cpu: 30m
+            memory: 30Mi
 - name: ibm-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -47,11 +47,11 @@ const Small = `
       configMapWatcher:
         resources:
           limits:
-            cpu: 60m
+            cpu: 20m
             memory: 60Mi
           requests:
-            cpu: 30m
-            memory: 30Mi
+            cpu: 20m
+            memory: 20Mi
 - name: ibm-mongodb-operator
   spec:
     mongoDB:


### PR DESCRIPTION
@horis233 

May I ask that

Should we increase the resources for **all the three profiles** to make all of them exactly same?

Should we only increase the CPU limit of the `cert-manager CA injector`? Or other resources should be changed as well.