### PR TITLE
align the subscription name on deleting Crossplane

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -255,11 +255,11 @@ func (b *Bootstrap) DeleteCrossplaneAndProviderSubscription(namespace string) er
 	}
 
 	if uninstallCrossplane {
-		_, providerErr := b.GetSubscription(ctx, "crossplane-provider-kubernetes-operator", namespace)
+		_, providerErr := b.GetSubscription(ctx, constant.ICPPKOperator, namespace)
 		if errors.IsNotFound(providerErr) {
-			klog.Infof("%s not installed, skipping", "crossplane-provider-kubernetes-operator")
+			klog.Infof("%s not installed, skipping", constant.ICPPKOperator)
 		} else if providerErr != nil {
-			klog.Errorf("Failed to get subscription %s/%s", namespace, "crossplane-provider-kubernetes-operator")
+			klog.Errorf("Failed to get subscription %s/%s", namespace, constant.ICPPKOperator)
 		} else {
 			klog.Infof("Trying to delete Kubernetes Provider in %s", namespace)
 			// delete ProviderConfig cr
@@ -269,18 +269,18 @@ func (b *Bootstrap) DeleteCrossplaneAndProviderSubscription(namespace string) er
 			}
 
 			// delete Kubernetes Provider subscription
-			klog.Infof("Trying to delete crossplane-provider-kubernetes-operator in %s", namespace)
-			if err := b.deleteSubscription("crossplane-provider-kubernetes-operator", namespace); err != nil {
-				klog.Errorf("Failed to delete crossplane-provider-kubernetes-operator in %s: %v", namespace, err)
+			klog.Infof("Trying to delete %s in %s", constant.ICPPKOperator, namespace)
+			if err := b.deleteSubscription(constant.ICPPKOperator, namespace); err != nil {
+				klog.Errorf("Failed to delete %s in %s: %v", constant.ICPPKOperator, namespace, err)
 				return err
 			}
 		}
 
-		_, providerErr = b.GetSubscription(ctx, "crossplane-provider-ibm-cloud-operator", namespace)
+		_, providerErr = b.GetSubscription(ctx, constant.ICPPICOperator, namespace)
 		if errors.IsNotFound(providerErr) {
-			klog.Infof("%s not installed, skipping", "crossplane-provider-ibm-cloud-operator")
+			klog.Infof("%s not installed, skipping", constant.ICPPICOperator)
 		} else if providerErr != nil {
-			klog.Errorf("Failed to get subscription %s/%s", namespace, "crossplane-provider-ibm-cloud-operator")
+			klog.Errorf("Failed to get subscription %s/%s", namespace, constant.ICPPICOperator)
 		} else {
 			klog.Infof("Trying to delete IBM Cloud Provider in %s", namespace)
 			// delete ProviderConfig cr
@@ -290,21 +290,21 @@ func (b *Bootstrap) DeleteCrossplaneAndProviderSubscription(namespace string) er
 			}
 
 			// delete IBM Cloud Provider subscription
-			klog.Infof("Trying to delete crossplane-provider-ibm-cloud-operator in %s", namespace)
-			if err := b.deleteSubscription("crossplane-provider-ibm-cloud-operator", namespace); err != nil {
-				klog.Errorf("Failed to delete crossplane-provider-ibm-cloud-operator in %s: %v", namespace, err)
+			klog.Infof("Trying to delete %s in %s", constant.ICPPICOperator, namespace)
+			if err := b.deleteSubscription(constant.ICPPICOperator, namespace); err != nil {
+				klog.Errorf("Failed to delete %s in %s: %v", constant.ICPPICOperator, namespace, err)
 				return err
 			}
 		}
 
-		_, crossplaneErr := b.GetSubscription(ctx, "ibm-crossplane-operator-app", namespace)
+		_, crossplaneErr := b.GetSubscription(ctx, constant.ICPOperator, namespace)
 		if errors.IsNotFound(crossplaneErr) {
-			klog.Infof("%s not installed, skipping", "ibm-crossplane-operator-app")
+			klog.Infof("%s not installed, skipping", constant.ICPOperator)
 		} else if crossplaneErr != nil {
-			klog.Errorf("Failed to get subscription %s/%s", namespace, "ibm-crossplane-operator-app")
+			klog.Errorf("Failed to get subscription %s/%s", namespace, constant.ICPOperator)
 		} else {
 			// delete crossplane cr
-			klog.Infof("Trying to delete ibm-crossplane-operator CR in %s", namespace)
+			klog.Infof("Trying to delete %s CR in %s", constant.ICPOperator, namespace)
 			resourceCrossConfiguration := constant.CrossConfiguration
 			if err := b.DeleteFromYaml(resourceCrossConfiguration, b.CSData); err != nil {
 				return err
@@ -315,9 +315,9 @@ func (b *Bootstrap) DeleteCrossplaneAndProviderSubscription(namespace string) er
 			}
 
 			// delete crossplane operator subscription
-			klog.Infof("Trying to delete ibm-crossplane-operator in %s", namespace)
-			if err := b.deleteSubscription("ibm-crossplane-operator-app", namespace); err != nil {
-				klog.Errorf("Failed to delete ibm-crossplane-operator in %s: %v", namespace, err)
+			klog.Infof("Trying to delete %s in %s", constant.ICPOperator, namespace)
+			if err := b.deleteSubscription(constant.ICPOperator, namespace); err != nil {
+				klog.Errorf("Failed to delete %s in %s: %v", constant.ICPOperator, namespace, err)
 				return err
 			}
 		}

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -92,6 +92,9 @@ type CSData struct {
 	OnPremMultiEnable  string
 	CrossplaneProvider string
 	ZenOperatorImage   string
+	ICPPKOperator      string
+	ICPPICOperator     string
+	ICPOperator        string
 }
 
 type CSOperator struct {
@@ -146,6 +149,9 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		CatalogSourceNs:   catalogSourceNs,
 		ApprovalMode:      approvalMode,
 		ZenOperatorImage:  util.GetImage("IBM_ZEN_OPERATOR_IMAGE"),
+		ICPPKOperator:     constant.ICPPKOperator,
+		ICPPICOperator:    constant.ICPPICOperator,
+		ICPOperator:       constant.ICPOperator,
 	}
 
 	bs = &Bootstrap{

--- a/controllers/constant/crossplane.go
+++ b/controllers/constant/crossplane.go
@@ -16,6 +16,12 @@
 
 package constant
 
+const (
+	ICPPKOperator  = "ibm-crossplane-provider-kubernetes-operator"
+	ICPPICOperator = "ibm-crossplane-provider-ibm-cloud-operator"
+	ICPOperator    = "ibm-crossplane-operator-app"
+)
+
 const CrossSubscription = `
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription

--- a/controllers/constant/crossplane.go
+++ b/controllers/constant/crossplane.go
@@ -17,8 +17,8 @@
 package constant
 
 const (
-	ICPPKOperator  = "ibm-crossplane-provider-kubernetes-operator"
-	ICPPICOperator = "ibm-crossplane-provider-ibm-cloud-operator"
+	ICPPKOperator  = "ibm-crossplane-provider-kubernetes-operator-app"
+	ICPPICOperator = "ibm-crossplane-provider-ibm-cloud-operator-app"
 	ICPOperator    = "ibm-crossplane-operator-app"
 )
 
@@ -26,12 +26,12 @@ const CrossSubscription = `
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: ibm-crossplane-operator-app
+  name: {{ .ICPOperator }}
   namespace: {{ .MasterNs }}
 spec:
   channel: {{ .Channel }}
   installPlanApproval: Automatic
-  name: ibm-crossplane-operator-app
+  name: {{ .ICPOperator }}
   source: {{ .CatalogSourceName }}
   sourceNamespace: {{ .CatalogSourceNs }}
 `
@@ -63,12 +63,12 @@ const CrossKubernetesProviderSubscription = `
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: ibm-crossplane-provider-kubernetes-operator
+  name: {{ .ICPPKOperator}}
   namespace: {{ .MasterNs }}
 spec:
   channel: {{ .Channel }}
   installPlanApproval: Automatic
-  name: ibm-crossplane-provider-kubernetes-operator
+  name: {{ .ICPPKOperator }}
   source: {{ .CatalogSourceName }}
   sourceNamespace: {{ .CatalogSourceNs }}
 `
@@ -89,12 +89,12 @@ const CrossIBMCloudProviderSubscription = `
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: ibm-crossplane-provider-ibm-cloud-operator
+  name: {{ .ICPPICOperator }}
   namespace: {{ .MasterNs }}
 spec:
   channel: {{ .Channel }}
   installPlanApproval: Automatic
-  name: ibm-crossplane-provider-ibm-cloud-operator
+  name: {{ .ICPPICOperator }}
   source: {{ .CatalogSourceName }}
   sourceNamespace: {{ .CatalogSourceNs }}
 `

--- a/controllers/goroutines/operator_status.go
+++ b/controllers/goroutines/operator_status.go
@@ -62,8 +62,9 @@ func UpdateCsCrStatus(bs *bootstrap.Bootstrap) {
 			operatorsName = append(operatorsName, opreg.Spec.Operators[i].Name)
 		}
 		operatorsName = append(operatorsName, []string{
-			"ibmcloud-operator",
-			"ibm-crossplane-operator-app",
+			constant.ICPPKOperator,
+			constant.ICPPICOperator,
+			constant.ICPOperator,
 			"ibm-namespace-scope-operator",
 			"operand-deployment-lifecycle-manager-app"}...)
 


### PR DESCRIPTION
missing prefix `ibm` when deleting the subscription #725  