### PR TITLE
Extend clusterRole to install Crossplane providerConfig

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
             "name": "example-commonservice"
           },
           "spec": {
-            "size": "small"
+            "size": "starterset"
           }
         }
       ]
@@ -24,11 +24,12 @@ metadata:
     containerImage: quay.io/opencloudio/common-service-operator:latest
     createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
-    olm.skipRange: ">=3.3.0 <3.9.1"
+    olm.skipRange: ">=3.3.0 <3.15.0"
     operatorChannel: v3
-    operatorVersion: 3.9.1
-    operators.operatorframework.io/builder: operator-sdk-v1.8.0
+    operatorVersion: 3.15.0
+    operators.operatorframework.io/builder: operator-sdk-v1.11.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    nss.operator.ibm.com/managed-operators: cloud-native-postgresql
     repository: https://github.com/IBM/ibm-common-service-operator
     support: IBM
   labels:
@@ -36,13 +37,13 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-common-service-operator.v3.9.1
+  name: ibm-common-service-operator.v3.15.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: CommonService is the Schema for the commonservices API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license 
+      - description: CommonService is the Schema for the commonservices API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         displayName: CommonService
         kind: CommonService
         name: commonservices.operator.ibm.com
@@ -51,9 +52,34 @@ spec:
             displayName: Size
             path: size
             x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:select:starterset
+              - urn:alm:descriptor:com.tectonic.ui:select:starter
               - urn:alm:descriptor:com.tectonic.ui:select:small
               - urn:alm:descriptor:com.tectonic.ui:select:medium
               - urn:alm:descriptor:com.tectonic.ui:select:large
+              - urn:alm:descriptor:com.tectonic.ui:select:production
+        statusDescriptors:
+          - description: Installed Bedrock Operator Name
+            displayName: Name
+            path: bedrockOperators[0].name
+          - description: Installed Bedrock Operator InstallPlan Name
+            displayName: InstallPlanName
+            path: bedrockOperators[0].installPlanName
+          - description: Installed Bedrock Operator Status
+            displayName: OperatorStatus
+            path: bedrockOperators[0].operatorStatus
+          - description: Installed Bedrock Operator Subscription Status
+            displayName: SubscriptionStatus
+            path: bedrockOperators[0].subscriptionStatus
+          - description: Installed Bedrock Operator Version
+            displayName: Version
+            path: bedrockOperators[0].version
+          - description: Installed Bedrock Operator Troubleshooting
+            displayName: Troubleshooting
+            path: bedrockOperators[0].troubleshooting
+          - description: The Overall Status Of All Installed Bedrock Operators
+            displayName: OverallStatus
+            path: overallStatus
         version: v3
   description: |-
     # Introduction
@@ -81,7 +107,7 @@ spec:
 
     ## Operator versions
 
-     - 3.9.1
+     - 3.15.0
 
     ## Prerequisites
 
@@ -97,7 +123,7 @@ spec:
     | -------------------------- | ----------- | ----------- | --------- | ------ |
     | ibm common service operator | 200          | 0.2        | 1          | worker |
     | **Total**                  | 200         | 0.2         | 1         |        |
-  
+
     ## Documentation
 
     - If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak. For a list of IBM Cloud Paks, see [IBM Cloud Paks that use IBM Cloud Pak foundational services](http://ibm.biz/cpcs_cloudpaks).
@@ -188,8 +214,8 @@ spec:
                 - rbac.authorization.k8s.io
               resources:
                 - clusterroles
-                - clusterrolebindings
                 - roles
+                - clusterrolebindings
                 - rolebindings
               verbs:
                 - create
@@ -198,14 +224,58 @@ spec:
                 - list
                 - update
                 - watch
+                - escalate
+                - bind
+            - apiGroups:
+                - ""
+              resourceNames:
+                - common-service-maps
+                - ibm-common-services-status
+                - odlm-scope
+                - namespace-scope
+              resources:
+                - configmaps
+              verbs:
+                - delete
+                - update
             - apiGroups:
                 - ""
               resources:
-                - events
                 - configmaps
-                - secrets
-                - pods
-                - services
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - update
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - create
+                - get
+            - apiGroups:
+                - apps
+              resourceNames:
+                - ibm-common-service-webhook
+                - secretshare
+              resources:
+                - deployments
+              verbs:
+                - update
+            - apiGroups:
+                - pkg.ibm.crossplane.io
+              resources:
+                - locks
+                - configurations
               verbs:
                 - create
                 - delete
@@ -241,32 +311,13 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - admissionregistration.k8s.io
+                - storage.k8s.io
               resources:
-                - mutatingwebhookconfigurations
-                - validatingwebhookconfigurations
+                - storageclasses
               verbs:
-                - create
-                - delete
                 - get
                 - list
-                - patch
-                - update
                 - watch
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - create
-                - get
-            - apiGroups:
-                - apps
-              resources:
-                - deployments
-              verbs:
-                - create
-                - get
             - apiGroups:
                 - kubernetes.crossplane.io
                 - ibmcloud.crossplane.io
@@ -319,24 +370,30 @@ spec:
                       - name: OPERATOR_NAME
                         value: ibm-common-service-operator
                       - name: IBM_CS_WEBHOOK_IMAGE
-                        value: quay.io/opencloudio/ibm-cs-webhook:1.5.0
+                        value: quay.io/opencloudio/ibm-cs-webhook:1.10.0
                       - name: IBM_SECRETSHARE_OPERATOR_IMAGE
-                        value: quay.io/opencloudio/ibm-secretshare-operator:1.6.0
+                        value: quay.io/opencloudio/ibm-secretshare-operator:1.11.0
+                      - name: IBM_ZEN_OPERATOR_IMAGE
+                        value: quay.io/opencloudio/ibm-zen-operator:1.5.0
                     image: quay.io/opencloudio/common-service-operator:latest
                     imagePullPolicy: Always
-                    name: ibm-common-service-operator
-                    readinessProbe:
+                    livenessProbe:
+                      failureThreshold: 10
                       httpGet:
                         path: /healthz
                         port: 8081
-                      initialDelaySeconds: 2
-                      periodSeconds: 3
-                    livenessProbe:
+                      initialDelaySeconds: 120
+                      periodSeconds: 60
+                      timeoutSeconds: 10
+                    name: ibm-common-service-operator
+                    readinessProbe:
+                      failureThreshold: 10
                       httpGet:
                         path: /readyz
                         port: 8081
-                      initialDelaySeconds: 2
-                      periodSeconds: 5
+                      initialDelaySeconds: 3
+                      periodSeconds: 20
+                      timeoutSeconds: 3
                     resources:
                       limits:
                         cpu: 500m
@@ -389,8 +446,15 @@ spec:
     - email: support@ibm.com
       name: IBM Support
   maturity: alpha
-  minKubeVersion: "1.19.0"
+  minKubeVersion: 1.19.0
   provider:
     name: IBM
-  replaces: ibm-common-service-operator.v3.9.0
-  version: 3.9.1
+  relatedImages:
+    - image: quay.io/opencloudio/common-service-operator:3.15.0
+      name: COMMON_SERVICE_OPERATOR_IMAGE
+    - image: quay.io/opencloudio/ibm-cs-webhook:1.11.0
+      name: IBM_CS_WEBHOOK_IMAGE
+    - image: quay.io/opencloudio/ibm-secretshare-operator:1.12.0
+      name: IBM_SECRETSHARE_OPERATOR_IMAGE
+  replaces: ibm-common-service-operator.v3.14.0
+  version: 3.15.0

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
             "name": "example-commonservice"
           },
           "spec": {
-            "size": "starterset"
+            "size": "small"
           }
         }
       ]
@@ -24,12 +24,11 @@ metadata:
     containerImage: quay.io/opencloudio/common-service-operator:latest
     createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
-    olm.skipRange: ">=3.3.0 <3.15.0"
+    olm.skipRange: ">=3.3.0 <3.9.1"
     operatorChannel: v3
-    operatorVersion: 3.15.0
-    operators.operatorframework.io/builder: operator-sdk-v1.11.0
+    operatorVersion: 3.9.1
+    operators.operatorframework.io/builder: operator-sdk-v1.8.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    nss.operator.ibm.com/managed-operators: cloud-native-postgresql
     repository: https://github.com/IBM/ibm-common-service-operator
     support: IBM
   labels:
@@ -37,13 +36,13 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: ibm-common-service-operator.v3.15.0
+  name: ibm-common-service-operator.v3.9.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: CommonService is the Schema for the commonservices API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      - description: CommonService is the Schema for the commonservices API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license 
         displayName: CommonService
         kind: CommonService
         name: commonservices.operator.ibm.com
@@ -52,34 +51,9 @@ spec:
             displayName: Size
             path: size
             x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:select:starterset
-              - urn:alm:descriptor:com.tectonic.ui:select:starter
               - urn:alm:descriptor:com.tectonic.ui:select:small
               - urn:alm:descriptor:com.tectonic.ui:select:medium
               - urn:alm:descriptor:com.tectonic.ui:select:large
-              - urn:alm:descriptor:com.tectonic.ui:select:production
-        statusDescriptors:
-          - description: Installed Bedrock Operator Name
-            displayName: Name
-            path: bedrockOperators[0].name
-          - description: Installed Bedrock Operator InstallPlan Name
-            displayName: InstallPlanName
-            path: bedrockOperators[0].installPlanName
-          - description: Installed Bedrock Operator Status
-            displayName: OperatorStatus
-            path: bedrockOperators[0].operatorStatus
-          - description: Installed Bedrock Operator Subscription Status
-            displayName: SubscriptionStatus
-            path: bedrockOperators[0].subscriptionStatus
-          - description: Installed Bedrock Operator Version
-            displayName: Version
-            path: bedrockOperators[0].version
-          - description: Installed Bedrock Operator Troubleshooting
-            displayName: Troubleshooting
-            path: bedrockOperators[0].troubleshooting
-          - description: The Overall Status Of All Installed Bedrock Operators
-            displayName: OverallStatus
-            path: overallStatus
         version: v3
   description: |-
     # Introduction
@@ -107,7 +81,7 @@ spec:
 
     ## Operator versions
 
-     - 3.15.0
+     - 3.9.1
 
     ## Prerequisites
 
@@ -123,7 +97,7 @@ spec:
     | -------------------------- | ----------- | ----------- | --------- | ------ |
     | ibm common service operator | 200          | 0.2        | 1          | worker |
     | **Total**                  | 200         | 0.2         | 1         |        |
-
+  
     ## Documentation
 
     - If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak. For a list of IBM Cloud Paks, see [IBM Cloud Paks that use IBM Cloud Pak foundational services](http://ibm.biz/cpcs_cloudpaks).
@@ -214,8 +188,8 @@ spec:
                 - rbac.authorization.k8s.io
               resources:
                 - clusterroles
-                - roles
                 - clusterrolebindings
+                - roles
                 - rolebindings
               verbs:
                 - create
@@ -224,58 +198,14 @@ spec:
                 - list
                 - update
                 - watch
-                - escalate
-                - bind
             - apiGroups:
                 - ""
-              resourceNames:
-                - common-service-maps
-                - ibm-common-services-status
-                - odlm-scope
-                - namespace-scope
               resources:
+                - events
                 - configmaps
-              verbs:
-                - delete
-                - update
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - create
-                - get
-                - update
-            - apiGroups:
-                - apps
-              resources:
-                - deployments
-              verbs:
-                - create
-                - get
-            - apiGroups:
-                - apps
-              resourceNames:
-                - ibm-common-service-webhook
-                - secretshare
-              resources:
-                - deployments
-              verbs:
-                - update
-            - apiGroups:
-                - pkg.ibm.crossplane.io
-              resources:
-                - locks
-                - configurations
+                - secrets
+                - pods
+                - services
               verbs:
                 - create
                 - delete
@@ -311,12 +241,44 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - storage.k8s.io
+                - admissionregistration.k8s.io
               resources:
-                - storageclasses
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
               verbs:
+                - create
+                - delete
                 - get
                 - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - create
+                - get
+            - apiGroups:
+                - kubernetes.crossplane.io
+                - ibmcloud.crossplane.io
+              resources:
+                - providerconfigs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
                 - watch
           serviceAccountName: ibm-common-service-operator
       deployments:
@@ -357,30 +319,24 @@ spec:
                       - name: OPERATOR_NAME
                         value: ibm-common-service-operator
                       - name: IBM_CS_WEBHOOK_IMAGE
-                        value: quay.io/opencloudio/ibm-cs-webhook:1.10.0
+                        value: quay.io/opencloudio/ibm-cs-webhook:1.5.0
                       - name: IBM_SECRETSHARE_OPERATOR_IMAGE
-                        value: quay.io/opencloudio/ibm-secretshare-operator:1.11.0
-                      - name: IBM_ZEN_OPERATOR_IMAGE
-                        value: quay.io/opencloudio/ibm-zen-operator:1.5.0
+                        value: quay.io/opencloudio/ibm-secretshare-operator:1.6.0
                     image: quay.io/opencloudio/common-service-operator:latest
                     imagePullPolicy: Always
-                    livenessProbe:
-                      failureThreshold: 10
+                    name: ibm-common-service-operator
+                    readinessProbe:
                       httpGet:
                         path: /healthz
                         port: 8081
-                      initialDelaySeconds: 120
-                      periodSeconds: 60
-                      timeoutSeconds: 10
-                    name: ibm-common-service-operator
-                    readinessProbe:
-                      failureThreshold: 10
+                      initialDelaySeconds: 2
+                      periodSeconds: 3
+                    livenessProbe:
                       httpGet:
                         path: /readyz
                         port: 8081
-                      initialDelaySeconds: 3
-                      periodSeconds: 20
-                      timeoutSeconds: 3
+                      initialDelaySeconds: 2
+                      periodSeconds: 5
                     resources:
                       limits:
                         cpu: 500m
@@ -433,15 +389,8 @@ spec:
     - email: support@ibm.com
       name: IBM Support
   maturity: alpha
-  minKubeVersion: 1.19.0
+  minKubeVersion: "1.19.0"
   provider:
     name: IBM
-  relatedImages:
-    - image: quay.io/opencloudio/common-service-operator:3.15.0
-      name: COMMON_SERVICE_OPERATOR_IMAGE
-    - image: quay.io/opencloudio/ibm-cs-webhook:1.11.0
-      name: IBM_CS_WEBHOOK_IMAGE
-    - image: quay.io/opencloudio/ibm-secretshare-operator:1.12.0
-      name: IBM_SECRETSHARE_OPERATOR_IMAGE
-  replaces: ibm-common-service-operator.v3.14.0
-  version: 3.15.0
+  replaces: ibm-common-service-operator.v3.9.0
+  version: 3.9.1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -139,6 +139,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - kubernetes.crossplane.io
+  - ibmcloud.crossplane.io
+  resources:
+  - providerconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ibmcpcs.ibm.com
   resources:
   - secretshares

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -199,7 +199,7 @@ func (b *Bootstrap) CrossplaneOperatorProviderOperator(instance *apiv3.CommonSer
 		if b.SaasEnable {
 			b.CSData.CrossplaneProvider = "ibmcloud"
 		}
-		
+
 		if err := b.installCrossplaneOperator(); err != nil {
 			return err
 		}

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -194,14 +194,14 @@ func (b *Bootstrap) CrossplaneOperatorProviderOperator(instance *apiv3.CommonSer
 	}
 
 	if bedrockshim {
-		if err := b.installCrossplaneOperator(); err != nil {
-			return err
-		}
-
 		b.CSData.CrossplaneProvider = "odlm"
 
 		if b.SaasEnable {
 			b.CSData.CrossplaneProvider = "ibmcloud"
+		}
+		
+		if err := b.installCrossplaneOperator(); err != nil {
+			return err
 		}
 
 		switch b.CSData.CrossplaneProvider {

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -139,7 +139,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonServic
 
 	if inScope {
 		if err := r.Bootstrap.CrossplaneOperatorProviderOperator(instance); err != nil {
-			klog.Errorf("Failed to install crossplane or cloud operator: %v", err)
+			klog.Errorf("Failed to install crossplane or provider operator: %v", err)
 			if err := r.updatePhase(instance, CRFailed); err != nil {
 				klog.Error(err)
 			}
@@ -217,7 +217,7 @@ func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonServi
 
 	if inScope {
 		if err := r.Bootstrap.CrossplaneOperatorProviderOperator(instance); err != nil {
-			klog.Errorf("Failed to install crossplane or cloud operator: %v", err)
+			klog.Errorf("Failed to install crossplane or provider operator: %v", err)
 			if err := r.updatePhase(instance, CRFailed); err != nil {
 				klog.Error(err)
 			}


### PR DESCRIPTION
Needed because of this error 
```
E0117 09:13:49.496830       1 commonservice_controller.go:142] Failed to install crossplane or cloud operator: 
providerconfigs.kubernetes.crossplane.io "kubernetes-provider" is forbidden: User "system:serviceaccount:ibm-common-services:ibm-common-service-operator" 
cannot get resource "providerconfigs" in API group "kubernetes.crossplane.io" at the cluster scope
```

Order of Crossplane installation has been changed - variable needs to be set earlier for update scenario