### PR TITLE
use string in subscriptjion.spec.env

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -679,5 +679,5 @@ spec:
     - name: ISOLATED_MODE
       value: "{{ .IsolatedModeEnable }}"
     - name: OPERATORCHECKER_MODE
-      value: true
+      value: "true"
 `


### PR DESCRIPTION
```
I0214 16:46:39.948639       1 init.go:652] Creating resource with name: operand-deployment-lifecycle-manager-app, namespace: ibm-common-services, kind: Subscription, apiversion: operators.coreos.com/v1alpha1
E0214 16:46:39.950754       1 commonservice_controller.go:126] Failed to initialize resources: could not Create resource: Subscription.operators.coreos.com "operand-deployment-lifecycle-manager-app" is invalid: spec.config.env.value: Invalid value: "boolean": spec.config.env.value in body must be of type string: "boolean"
E0214 16:46:39.955922       1 commonservice_controller.go:130] Fail to reconcile ibm-common-services/common-service: could not Create resource: Subscription.operators.coreos.com "operand-deployment-lifecycle-manager-app" is invalid: spec.config.env.value: Invalid value: "boolean": spec.config.env.value in body must be of type string: "boolean"
```