### PR TITLE
add turbo profile controller for common service

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -26,8 +26,9 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 type ServiceConfig struct {
-	Name string                          `json:"name"`
-	Spec map[string]runtime.RawExtension `json:"spec"`
+	Name               string                          `json:"name"`
+	Spec               map[string]runtime.RawExtension `json:"spec"`
+	ManagementStrategy string                          `json:"managementStrategy,omitempty"`
 }
 
 // CommonServiceSpec defines the desired state of CommonService
@@ -43,6 +44,7 @@ type CommonServiceSpec struct {
 	Services            []ServiceConfig      `json:"services,omitempty"`
 	StorageClass        string               `json:"storageClass,omitempty"`
 	BYOCACertificate    bool                 `json:"BYOCACertificate,omitempty"`
+	ProfileController   string               `json:"profileController,omitempty"`
 }
 
 // Features defines the configurations of Cloud Pak Services

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     olm.skipRange: ">=3.3.0 <3.16.0"
     operatorChannel: v3
     operatorVersion: 3.16.0
-    operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.16.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/ibm-common-service-operator
     support: IBM
@@ -58,6 +58,14 @@ spec:
               - urn:alm:descriptor:com.tectonic.ui:select:medium
               - urn:alm:descriptor:com.tectonic.ui:select:large
               - urn:alm:descriptor:com.tectonic.ui:select:production
+          - description: The profile controller for IBM Cloud Pak foundational services
+            displayName: ProfileController
+            path: profileController
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:select:default
+              - urn:alm:descriptor:com.tectonic.ui:select:commonservice
+              - urn:alm:descriptor:com.tectonic.ui:select:turbonomic
+              - urn:alm:descriptor:com.tectonic.ui:select:vpa
         statusDescriptors:
           - description: Installed Bedrock Operator Name
             displayName: Name

--- a/bundle/manifests/operator.ibm.com_commonservices.yaml
+++ b/bundle/manifests/operator.ibm.com_commonservices.yaml
@@ -62,11 +62,15 @@ spec:
                 type: string
               manualManagement:
                 type: boolean
+              profileController:
+                type: string
               routeHost:
                 type: string
               services:
                 items:
                   properties:
+                    managementStrategy:
+                      type: string
                     name:
                       type: string
                     spec:

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -55,11 +55,15 @@ spec:
                 type: string
               manualManagement:
                 type: boolean
+              profileController:
+                type: string
               routeHost:
                 type: string
               services:
                 items:
                   properties:
+                    managementStrategy:
+                      type: string
                     name:
                       type: string
                     spec:

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -44,6 +44,14 @@ spec:
         - urn:alm:descriptor:com.tectonic.ui:select:medium
         - urn:alm:descriptor:com.tectonic.ui:select:large
         - urn:alm:descriptor:com.tectonic.ui:select:production
+      - description: The profile controller for IBM Cloud Pak foundational services
+        displayName: ProfileController
+        path: profileController
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:default
+        - urn:alm:descriptor:com.tectonic.ui:select:commonservice
+        - urn:alm:descriptor:com.tectonic.ui:select:turbonomic
+        - urn:alm:descriptor:com.tectonic.ui:select:vpa
       statusDescriptors:
       - description: Installed Bedrock Operator Name
         displayName: Name

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -310,7 +310,7 @@ func GetMasterNs(r client.Reader) (masterNs string) {
 	}
 
 	for _, nsMapping := range cmData.NsMappingList {
-		if findNamespace(nsMapping.RequestNs, operatorNs) {
+		if Contains(nsMapping.RequestNs, operatorNs) {
 			masterNs = nsMapping.CsNs
 			break
 		}
@@ -372,15 +372,6 @@ func UpdateNSList(r client.Reader, c client.Client, cm *corev1.ConfigMap, nssKey
 	}
 
 	return nil
-}
-
-func findNamespace(nsList []string, nsName string) (exist bool) {
-	for _, ns := range nsList {
-		if ns == nsName {
-			return true
-		}
-	}
-	return
 }
 
 // CheckSaas checks whether it is a SaaS deployment for Common Services

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -98,7 +98,7 @@ func (r *CommonServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 			if err := r.Bootstrap.DeployCertManagerCR(); err != nil {
 				return ctrl.Result{}, err
 			}
-			klog.Info("Finished reconciling to delete CommonService: %s/%s", req.NamespacedName.Namespace, req.NamespacedName.Name)
+			klog.Infof("Finished reconciling to delete CommonService: %s/%s", req.NamespacedName.Namespace, req.NamespacedName.Name)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -163,7 +163,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonServic
 		}
 	}
 
-	newConfigs, err := r.getNewConfigs(cs, inScope)
+	newConfigs, serviceControllerMapping, err := r.getNewConfigs(cs, inScope)
 	if err != nil {
 		if err := r.updatePhase(instance, CRFailed); err != nil {
 			klog.Error(err)
@@ -172,7 +172,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(instance *apiv3.CommonServic
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	isEqual, err := r.updateOperandConfig(newConfigs)
+	isEqual, err := r.updateOperandConfig(newConfigs, serviceControllerMapping)
 	if err != nil {
 		if err := r.updatePhase(instance, CRFailed); err != nil {
 			klog.Error(err)
@@ -250,7 +250,7 @@ func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonServi
 		}
 	}
 
-	newConfigs, err := r.getNewConfigs(cs, inScope)
+	newConfigs, serviceControllerMapping, err := r.getNewConfigs(cs, inScope)
 	if err != nil {
 		if err := r.updatePhase(instance, CRFailed); err != nil {
 			klog.Error(err)
@@ -259,7 +259,7 @@ func (r *CommonServiceReconciler) ReconcileGeneralCR(instance *apiv3.CommonServi
 		return ctrl.Result{}, err
 	}
 
-	isEqual, err := r.updateOperandConfig(newConfigs)
+	isEqual, err := r.updateOperandConfig(newConfigs, serviceControllerMapping)
 	if err != nil {
 		if err := r.updatePhase(instance, CRFailed); err != nil {
 			klog.Error(err)

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -30,7 +30,6 @@ spec:
     spec:
       IBMLicensing:
         datasource: datacollector
-      IBMLicenseServiceReporter: {}
       operandBindInfo: {}
   - name: ibm-mongodb-operator
     spec:
@@ -460,7 +459,6 @@ spec:
         datasource: datacollector
         routeEnabled: false
         logLevel: VERBOSE
-      IBMLicenseServiceReporter: {}
       operandBindInfo: {}
   - name: ibm-mongodb-operator
     spec:

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -30,6 +30,7 @@ spec:
     spec:
       IBMLicensing:
         datasource: datacollector
+      IBMLicenseServiceReporter: {}
       operandBindInfo: {}
   - name: ibm-mongodb-operator
     spec:
@@ -459,6 +460,7 @@ spec:
         datasource: datacollector
         routeEnabled: false
         logLevel: VERBOSE
+      IBMLicenseServiceReporter: {}
       operandBindInfo: {}
   - name: ibm-mongodb-operator
     spec:

--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -396,7 +396,6 @@ func (r *CommonServiceReconciler) getMinimalSizes(opconServices, ruleSlice []int
 		serviceControllerMappingSummary = mergeProfileController(serviceControllerMappingSummary, serviceControllerMapping)
 		tmpConfigsSlice[len(tmpConfigsSlice)] = csConfigs
 	}
-	klog.Infof("Get mapping %v", serviceControllerMappingSummary)
 	for _, csConfigs := range tmpConfigsSlice {
 		configSummary = mergeCSCRs(configSummary, csConfigs, ruleSlice, serviceControllerMappingSummary)
 	}

--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -411,12 +411,12 @@ func (r *CommonServiceReconciler) getMinimalSizes(opconServices, ruleSlice []int
 			serviceController = controller
 		}
 		for cr, spec := range opService.(map[string]interface{})["spec"].(map[string]interface{}) {
-			if crSummary == nil || crSummary.(map[string]interface{})["spec"] == nil || crSummary.(map[string]interface{})["spec"].(map[string]interface{})[cr] == nil {
-				continue
-			}
 			if _, ok := nonDefaultProfileController[serviceController]; ok {
 				// clean up OperandConfig
 				opService.(map[string]interface{})["spec"].(map[string]interface{})[cr] = resetResourceInTemplate(spec.(map[string]interface{}), cr, nil, false)
+				continue
+			}
+			if crSummary == nil || crSummary.(map[string]interface{})["spec"] == nil || crSummary.(map[string]interface{})["spec"].(map[string]interface{})[cr] == nil {
 				continue
 			}
 			serviceForCR := crSummary.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})

--- a/controllers/rules/resource_comparison.go
+++ b/controllers/rules/resource_comparison.go
@@ -88,59 +88,61 @@ func ResourceComparison(resourceA, resourceB interface{}) (interface{}, interfac
 
 func ResourceEqualComparison(resourceA interface{}, resourceB interface{}) bool {
 
-	klog.V(3).Infof("Kind of A %s", reflect.TypeOf(resourceA).Kind())
-	klog.V(3).Infof("Kind of B %s", reflect.TypeOf(resourceB).Kind())
+	if resourceA != nil && resourceB != nil {
+		klog.V(3).Infof("Kind of A %s", reflect.TypeOf(resourceA).Kind())
+		klog.V(3).Infof("Kind of B %s", reflect.TypeOf(resourceB).Kind())
 
-	isEqual := true
-	switch resourceA := resourceA.(type) {
-	case []interface{}:
-		if resourceB == nil {
-			isEqual = false
-		} else if resourceB, ok := resourceB.([]interface{}); ok {
-			if len(resourceA) != len(resourceB) {
-				isEqual = false
-			} else {
-				// TODO: need to find a better way to compare when the order of slice is not fixed
-				for index := range resourceA {
-					if !ResourceEqualComparison(resourceA[index], resourceB[index]) {
-						return false
+		isEqual := true
+		switch resourceA := resourceA.(type) {
+		case []interface{}:
+			if resourceB, ok := resourceB.([]interface{}); ok {
+				if len(resourceA) != len(resourceB) {
+					isEqual = false
+				} else {
+					// TODO: need to find a better way to compare when the order of slice is not fixed
+					for index := range resourceA {
+						if !ResourceEqualComparison(resourceA[index], resourceB[index]) {
+							return false
+						}
 					}
 				}
 			}
-		}
-		return isEqual
-	case map[string]interface{}:
-		if resourceB == nil {
-			isEqual = false
-		} else if _, ok := resourceB.(map[string]interface{}); ok { //Check that the changed map value is also a map[string]interface
-			resourceARef := resourceA
-			resourceBRef := resourceB.(map[string]interface{})
-			for newKey := range resourceARef {
-				isEqual = ResourceEqualComparison(resourceARef[newKey], resourceBRef[newKey])
-				if !isEqual {
-					break
+			return isEqual
+		case map[string]interface{}:
+			if _, ok := resourceB.(map[string]interface{}); ok { //Check that the changed map value is also a map[string]interface
+				resourceARef := resourceA
+				resourceBRef := resourceB.(map[string]interface{})
+				for newKey := range resourceARef {
+					isEqual = ResourceEqualComparison(resourceARef[newKey], resourceBRef[newKey])
+					if !isEqual {
+						break
+					}
 				}
 			}
-		}
-		return isEqual
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
-		strA := fmt.Sprintf("%v", resourceA)
-		strB := fmt.Sprintf("%v", resourceB)
+			return isEqual
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+			strA := fmt.Sprintf("%v", resourceA)
+			strB := fmt.Sprintf("%v", resourceB)
 
-		floatA, _ := strconv.ParseFloat(strA, 64)
-		floatB, _ := strconv.ParseFloat(strB, 64)
-		if floatA == floatB {
-			isEqual = true
-		} else {
-			isEqual = false
+			floatA, _ := strconv.ParseFloat(strA, 64)
+			floatB, _ := strconv.ParseFloat(strB, 64)
+			if floatA == floatB {
+				isEqual = true
+			} else {
+				isEqual = false
+			}
+			return isEqual
+		default:
+			if resourceA == resourceB {
+				isEqual = true
+			} else {
+				isEqual = false
+			}
+			return isEqual
 		}
-		return isEqual
-	default:
-		if resourceA == resourceB {
-			isEqual = true
-		} else {
-			isEqual = false
-		}
-		return isEqual
 	}
+	if resourceA == nil && resourceB == nil {
+		return true
+	}
+	return false
 }

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -64,6 +64,14 @@ const ConfigurationRules = `
         requests:
           cpu: LARGEST_VALUE
           memory: LARGEST_VALUE
+      metrics:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
 - name: ibm-iam-operator
   spec:
     authentication:


### PR DESCRIPTION
#### New Paratemers
1. Add `profileController` as the overall management strategy
2. Add `managementStrategy` as the management controller for individual service

#### Options for new parameters
Options for `profileController` and `managementStrategy` are `default`, `commonservice`, `turbo`, `turbonomic` and `vpa`.
1. `default` and `commonservice` options will keep the original logic where the `OperandConfig` is totally managed by common service CR.
2. `turbo` is the short name of  `turbonomic`.
3. `turbo`, `turbonomic` and `vpa` share the same logic where the resource section including `limit` and `request` will be cleaned up in `OperandConfig`. But it will keep other configuration unchanged, for example, `storageclass` and `routehost`.

#### Relationship between paramater
1. `profileController` will be co-existed with `size` parameter, but `profileController` could overwrite `size` setting.
For example, if `size = large` and `profileController = turbo`, then resource section in `OperandConfig` will still be cleaned up.
2. `managementStrategy` has the higher priority then `profileController` for individual services. For example, `cert-manager-operator` has `managementStrategy = default(or commonservice)` and `profileController = turbo`. then all other services is managed by `turbonomic` which `OpandConfig` is empty for those corresponding services, and `cert-manager-operator` is still managed by common service, which means size profile or `spec` section in CS CR for `cert-manager-opperator` is applied to `OperandConfig`.
3. When `size = as-is`, we will not apply any size template and keep `OperandConfig` as usual. The `OperandConfig` will be updated if we define individual service configuration(includes either specific value or `managementStrategy`) in CS CR(it is the same as before), also the `OperandConfig` will be emptied if `profileController = turbo`

Common Service CR example that `profileController = turbo`, `size = medium` and `managementStrategy = commonservice` for `ibm-mongodb-operator`:
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  labels:
    app.kubernetes.io/instance: ibm-common-service-operator
    app.kubernetes.io/managed-by: ibm-common-service-operator
    app.kubernetes.io/name: ibm-common-service-operator
  name: example-commonservice
  namespace: ibm-common-services
spec:
  profileController: turbo
  services:
    - managementStrategy: commonservice
      name: ibm-mongodb-operator
      spec:
        mongoDB:
          metrics:
            resources:
              limits:
                cpu: 1000m
                memory: 350Mi
              requests:
                cpu: 100m
                memory: 300Mi
          replicas: 3
          resources:
            limits:
              cpu: 3000m
              memory: 3Gi
            requests:
              cpu: 500m
              memory: 3Gi
  size: medium
status:
  phase: Succeeded
```

OperandConfig Example where `ibm-mongodb-operator` keeps `medium` profile and other services is emptied and managed by `turbonomic`:
```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandConfig
  name: common-service
  namespace: ibm-common-services
spec:
  services:
    - name: ibm-licensing-operator
      spec:
        IBMLicensing:
          datasource: datacollector
          resources:
            limits: {}
            requests: {}
        operandBindInfo: {}
    - name: ibm-mongodb-operator
      spec:
        mongoDB:
          replicas: 3
          resources:
            limits:
              cpu: 3000m
              memory: 3Gi
            requests:
              cpu: 500m
              memory: 3Gi
        operandRequest: {}
```