### PR TITLE
add cluster permission for issuer and certificate

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -340,6 +340,17 @@ spec:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - certmanager.k8s.io
+              resources:
+                - issuers
+                - certificates
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
           serviceAccountName: ibm-common-service-operator
       deployments:
         - name: ibm-common-service-operator

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -186,6 +186,17 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - issuers
+  - certificates
+  verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/controllers/goroutines/namespacescope.go
+++ b/controllers/goroutines/namespacescope.go
@@ -109,6 +109,11 @@ func SyncUpNSSCR(bs *bootstrap.Bootstrap) {
 		scopeCR := &nssv1.NamespaceScope{}
 		odlmNsScopeKey := types.NamespacedName{Name: "odlm-scope-managedby-odlm", Namespace: bs.CSData.MasterNs}
 		if err := bs.Reader.Get(ctx, odlmNsScopeKey, scopeCR); err != nil {
+			if errors.IsNotFound(err) {
+				klog.Warningf("Not found NSS resource %s: %v, retry in 1 minute", targetNsScopeKey.String(), err)
+				time.Sleep(1 * time.Minute)
+				continue
+			}
 			klog.Errorf("Failed to get NSS resource %s: %v, retry again", targetNsScopeKey.String(), err)
 			continue
 		}


### PR DESCRIPTION
`odlm-scope-managedby-odlm` does not exist in multi instances scenario, in order to reduce the requests sent to server, sleep the goroutine when it is not found