### PR TITLE
Allow all inboud traffic to EDB

### DIFF
--- a/networkpolicy/bedrock-access-to-edb-postgres.yaml
+++ b/networkpolicy/bedrock-access-to-edb-postgres.yaml
@@ -1,0 +1,16 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: access-to-edb-postgres
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchExpressions:
+      - key: k8s.enterprisedb.io/cluster
+        operator: Exists
+  ingress:
+  - {}
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/54033

In addition to the wide network policy allowing cross-namespaces traffic, adding a specialized network policy which allows all inbound traffic to EDB.