### PR TITLE
apply approval mode change in control namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,8 +179,6 @@ func main() {
 				klog.Errorf("Failed to create OperatorGroup for IBM Common Services in control namespace: %v", err)
 				os.Exit(1)
 			}
-		} else {
-			bs.CSData.ControlNs = bs.CSData.MasterNs
 		}
 
 		klog.Info("Creating ConfigMap for operators")


### PR DESCRIPTION
How to verify it:
1. install a mutli-instance mode cs-operator
2. add `installPlanApproval: Manual` to CommonService CR
3. check if the approval mode of crossplane operators and NSS are `manual` in Control NS