### PR TITLE
update zen networkpolicies

### DIFF
--- a/networkpolicy/egress/zen-egress-diagnostics-job.yaml
+++ b/networkpolicy/egress/zen-egress-diagnostics-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-diagnostics-job
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      icpdsupport/app: "diagnostics-job"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-dsx-influxdb-set-auth.yaml
+++ b/networkpolicy/egress/zen-egress-dsx-influxdb-set-auth.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-dsx-influxdb-set-auth
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "dsx-influxdb-auth-job"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-iam-config-job.yaml
+++ b/networkpolicy/egress/zen-egress-iam-config-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-iam-config-job
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "iam-config-job"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-nginx-tester.yaml
+++ b/networkpolicy/egress/zen-egress-nginx-tester.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-nginx-tester
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "ibm-nginx-tester"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-nginx.yaml
+++ b/networkpolicy/egress/zen-egress-nginx.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-nginx
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "ibm-nginx"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-usermgmt.yaml
+++ b/networkpolicy/egress/zen-egress-usermgmt.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-usermgmt
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "usermgmt"
+  policyTypes:
+  - Egress 
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-volumes.yaml
+++ b/networkpolicy/egress/zen-egress-volumes.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-volumes
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      icpdsupport/app: volumes
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-watchdog-cronjob.yaml
+++ b/networkpolicy/egress/zen-egress-watchdog-cronjob.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-watchdog-cronjob
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      icpdsupport/app: "watchdog-cronjob"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-zen-core-api.yaml
+++ b/networkpolicy/egress/zen-egress-zen-core-api.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-zen-core-api
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-core-api"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-zen-core.yaml
+++ b/networkpolicy/egress/zen-egress-zen-core.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-zen-core
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-core"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-zen-metastore-backup-cron-job.yaml
+++ b/networkpolicy/egress/zen-egress-zen-metastore-backup-cron-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-zen-metastoredb-init-job
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-metastore-backup-cron-job"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-zen-metastoredb-init-job.yaml
+++ b/networkpolicy/egress/zen-egress-zen-metastoredb-init-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-zen-metastoredb-init-job
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "metastoredb-init-job"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-zen-metastoredb.yaml
+++ b/networkpolicy/egress/zen-egress-zen-metastoredb.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-zen-metastoredb
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-metastoredb"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-zen-pre-requisite-job.yaml
+++ b/networkpolicy/egress/zen-egress-zen-pre-requisite-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-zen-pre-requisite-job
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-pre-requisite-job"
+  policyTypes:
+  - Egress
+  egress:
+  - {} 

--- a/networkpolicy/egress/zen-egress-zen-watchdog.yaml
+++ b/networkpolicy/egress/zen-egress-zen-watchdog.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-zen-watchdog
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-watchdog"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/egress/zen-egress-zen-watcher.yaml
+++ b/networkpolicy/egress/zen-egress-zen-watcher.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: egress-zen-watcher
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-watcher"
+  policyTypes:
+  - Egress
+  egress:
+  - {}

--- a/networkpolicy/install_networkpolicy.sh
+++ b/networkpolicy/install_networkpolicy.sh
@@ -92,6 +92,7 @@ function print_usage() {
     echo "   -n, --namespace string       IBM Common Services namespace. Default is same namespace as IBM Common Services"
     echo "   -z, --zen-namespace string   Zen namespace. Default is same namespace as IBM Common Services"
     echo "   -u, --uninstall              Uninstall IBM Common Services Network Policies"
+    echo "   -e, --egress                 Deploy egress NetworkPolicies"
     echo "   -h, --help                   Print usage information"
     echo ""
 }
@@ -111,6 +112,10 @@ function parse_arguments() {
         -u | --uninstall)
             shift
             UNINSTALL=true
+            ;;
+        -e | --egress)
+            shift
+            EGRESS=true
             ;;
         -h | --help)
             print_usage
@@ -189,6 +194,10 @@ function install_networkpolicy() {
     info "Using IBM Common Services namespace: ${CS_NAMESPACE}"
     info "Using Zen namespace: ${ZEN_NAMESPACE}"
 
+    if [[ ${EGRESS} == "true" ]]; then
+        BASE_DIR="${BASE_DIR}/egress"
+    fi
+    
     for policyfile in `ls -1 ${BASE_DIR}/*.yaml`; do
         info "Installing `basename ${policyfile}` ..."
         cat ${policyfile} | sed -e "s/csNamespace/${CS_NAMESPACE}/g" | sed -e "s/zenNamespace/${ZEN_NAMESPACE}/g" | oc apply -f -

--- a/networkpolicy/zen-access-to-audit-svc.yaml
+++ b/networkpolicy/zen-access-to-audit-svc.yaml
@@ -12,4 +12,5 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - {}
+  - from:
+    - podSelector: {} 

--- a/networkpolicy/zen-access-to-dsx-influxdb.yaml
+++ b/networkpolicy/zen-access-to-dsx-influxdb.yaml
@@ -1,16 +1,16 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: access-to-zen-metastore
+  name: access-to-ibm-dsx-influxdb
   namespace: "zenNamespace"
   labels:
     component: cpfs
 spec:
   podSelector:
     matchLabels:
-      component: "zen-metastoredb"
+      component: "dsx-influxdb"
+  policyTypes:
+  - Ingress
   ingress:
   - from:
     - podSelector: {}
-  policyTypes:
-  - Ingress

--- a/networkpolicy/zen-access-to-nginx.yaml
+++ b/networkpolicy/zen-access-to-nginx.yaml
@@ -12,4 +12,11 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - {}
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-host-network
+    - namespaceSelector: 
+        matchLabels:
+          kubernetes.io/metadata.name: "csNamespace"
+    - podSelector: {}

--- a/networkpolicy/zen-access-to-usermgmt.yaml
+++ b/networkpolicy/zen-access-to-usermgmt.yaml
@@ -12,4 +12,8 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - {}
+  - from:
+    - namespaceSelector: 
+        matchLabels:
+          kubernetes.io/metadata.name: "csNamespace"
+    - podSelector: {}

--- a/networkpolicy/zen-access-to-zen-core-api.yaml
+++ b/networkpolicy/zen-access-to-zen-core-api.yaml
@@ -12,4 +12,8 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - {}
+  - from:
+    - namespaceSelector: 
+        matchLabels:
+          kubernetes.io/metadata.name: "csNamespace"
+    - podSelector: {}

--- a/networkpolicy/zen-access-to-zen-core.yaml
+++ b/networkpolicy/zen-access-to-zen-core.yaml
@@ -12,4 +12,5 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - {}
+  - from:
+    - podSelector: {}

--- a/networkpolicy/zen-access-to-zen-meta-api.yaml
+++ b/networkpolicy/zen-access-to-zen-meta-api.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: access-to-ibm-zen-meta-api
-  namespace: "zenNamespace"
+  namespace: "csNamespace"
   labels:
     component: cpfs
 spec:
@@ -12,4 +12,8 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - {}
+  - from:
+    - namespaceSelector: 
+        matchLabels:
+          kubernetes.io/metadata.name: "zenNamespace"
+    - podSelector: {}

--- a/networkpolicy/zen-access-to-zen-volumes.yaml
+++ b/networkpolicy/zen-access-to-zen-volumes.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-volumes
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      icpdsupport/app: volumes
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} 

--- a/networkpolicy/zen-access-to-zen-watchdog.yaml
+++ b/networkpolicy/zen-access-to-zen-watchdog.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-watchdog
+  namespace: "zenNamespace"
+  labels:
+    component: cpfs
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-watchdog"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} 

--- a/networkpolicy/zen-allow-iam-config-job.yaml
+++ b/networkpolicy/zen-allow-iam-config-job.yaml
@@ -12,4 +12,5 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - {}
+  - from:
+    - podSelector: {}


### PR DESCRIPTION
Updating networkpolicies for zen to make them more precise - instead of allowing all ingress, the resources will only allow ingress from required namespaces.

Fixing metadata for zen-meta-api as it resides in `csNamespace`, not `zenNamespace`