### PR TITLE
add ignore not found flag to deleting operandregistry and config

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -87,8 +87,8 @@ function prepare_cluster() {
 
     ${OC} scale deployment -n ${master_ns} ibm-common-service-operator --replicas=0
     ${OC} scale deployment -n ${master_ns} operand-deployment-lifecycle-manager --replicas=0
-    ${OC} delete operandregistry -n ${master_ns} common-service
-    ${OC} delete operandconfig -n ${master_ns} common-service
+    ${OC} delete operandregistry -n ${master_ns} --ignore-not-found common-service 
+    ${OC} delete operandconfig -n ${master_ns} --ignore-not-found common-service
 
     # uninstall singleton services
     "${OC}" delete -n "${master_ns}" --ignore-not-found certmanager default


### PR DESCRIPTION
If, for some reason, the operandregistry and operandconfig are not present in the environment during runtime, the script will exit in error with the cs operator and odlm operator pods scaled to 0. This is not a clear situation to users and could be difficult to debug in a live environment. Considering these objects are being deleted, if they are not there, they should not force the script to exit.