### PR TITLE
temp hard code zen cpp @ v3.21 chan for cicd builds

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -427,7 +427,7 @@ spec:
     packageName: ibm-user-data-services-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-  - channel: {{ .Channel }}
+  - channel: v3.21
     name: ibm-zen-cpp-operator
     namespace: {{ .MasterNs }}
     packageName: zen-cpp-operator


### PR DESCRIPTION
CICD has asked us to change the channel for zen cpp operator to 3.21 as the zen team has not pushed an update to run on 3.22 channel. This fix will ultimately be reverted once zen team is ready.