### PR TITLE
check that ns in cm exist, create them if they don't

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -324,17 +324,17 @@ function check_cm_ns_exist(){
     local cm_name=$1
 
     #this command gets all of the ns listed in requested from namesapce fields
-    requestedNSArray=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].requested-from-namespace' | awk '{print $2}'))
+    requestedNS=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].requested-from-namespace' | awk '{print $2}'))
 
     #this command gets all of the ns listed in map-to-common-service-namespace
-    mapToCSNSArray=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].map-to-common-service-namespace' | awk '{print}'))
+    mapToCSNS=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].map-to-common-service-namespace' | awk '{print}'))
 
-    for ns in "${requestedNSArray[@]}"
+    for ns in $requestedNS
     do
         echo "creating $ns"
         ${OC} create namespace $ns || info "$ns already exists, skipping..."
     done
-    for ns in "${mapToCSNSArray[@]}"
+    for ns in $mapToCSNS
     do
         echo "creating $ns"
         ${OC} create namespace $ns || info "$ns already exists, skipping..."

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -324,10 +324,10 @@ function check_cm_ns_exist(){
     local cm_name=$1
 
     #this command gets all of the ns listed in requested from namesapce fields
-    requestedNS=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].requested-from-namespace' | awk '{print $2}'))
+    requestedNS=$("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].requested-from-namespace' | awk '{print $2}')
 
     #this command gets all of the ns listed in map-to-common-service-namespace
-    mapToCSNS=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].map-to-common-service-namespace' | awk '{print}'))
+    mapToCSNS=$("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].map-to-common-service-namespace' | awk '{print}')
 
     for ns in $requestedNS
     do

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -84,7 +84,7 @@ function prepare_cluster() {
     # TODO for more advanced checking
     # find all namespaces with cs-operator running
     # each namespace should be in configmap
-    # all namesapces in configmap should exist
+    # all namespaces in configmap should exist
     check_cm_ns_exist $cm_name
 
     ${OC} scale deployment -n ${master_ns} ibm-common-service-operator --replicas=0
@@ -323,21 +323,26 @@ function check_CSCR() {
 function check_cm_ns_exist(){
     local cm_name=$1
    
-    #this command gets all of the ns listed in requested from namesapce fields
-    requestedNSArray=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].requested-from-namespace' | awk '{print $2}'))
-    
-    #this command gets all of the ns listed in map-to-common-service-namespace
-    mapToCSNSArray=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].map-to-common-service-namespace' | awk '{print}'))
-    
-    for ns in "${requestedNSArray[@]}"
-    do
-        echo "creating $ns"
-        ${OC} create namespace $ns || info "$ns already exists, skipping..."
-    done
-    for ns in "${mapToCSNSArray[@]}"
-    do
-        echo "creating $ns"
-        ${OC} create namespace $ns || info "$ns already exists, skipping..."
+    ${OC} get configmap ${cm_name} -n kube-public -o yaml | while read -r line; do
+        first_element=$(echo $line | awk '{print $1}')
+        
+        if [[ "${first_element}" == "-" ]]; then
+            namespace=$(echo $line | awk '{print $2}')
+            if [[ "${namespace}" != "requested-from-namespace:" ]]; then
+                if [[ "${namespace}" != "${master_ns}" ]]; then
+                    echo "creating namespace ${namespace}"
+                    ${OC} create namespace ${namespace} || info "$namespace already exists, skipping..."
+                fi
+            fi
+        fi
+        if [[ "${first_element}" == "map-to-common-service-namespace:" ]]; then
+            return_value=$("${OC}" get namespace ${namespace} || echo failed)
+            if [[ $return_value != "failed" ]]; then
+                namespace=$(echo $line | awk '{print $2}')
+                echo "creating namespace ${namespace}"
+                ${OC} create namespace ${namespace} || info "$namespace already exists, skipping..."
+            fi  
+        fi
     done
     echo "all namespaces in $cm_name exist"
 }

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -52,13 +52,13 @@ function prepare_cluster() {
     return_value="reset"
 
     # configmap should have control namespace specified
-    return_value=$("${OC}" get configmap -n kube-public -o yaml common-service-maps | yq '.data' | grep controlNamespace: > /dev/null || echo failed)
+    return_value=$("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data' | grep controlNamespace: > /dev/null || echo failed)
     if [[ $return_value == "failed" ]]; then
         error "Configmap: ${cm_name} did not specify 'controlNamespace' field. This must be configured before proceeding"
     fi
     return_value="reset"
 
-    controlNs=$("${OC}" get configmap -n kube-public -o yaml common-service-maps | yq '.data' | grep controlNamespace: | awk '{print $2}')
+    controlNs=$("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data' | grep controlNamespace: | awk '{print $2}')
     return_value=$("${OC}" get ns "${controlNs}" > /dev/null || echo failed)
     if [[ $return_value == "failed" ]]; then
         error "The namespace specified in controlNamespace does not exist"
@@ -84,6 +84,8 @@ function prepare_cluster() {
     # TODO for more advanced checking
     # find all namespaces with cs-operator running
     # each namespace should be in configmap
+    # all namesapces in configmap should exist
+    check_cm_ns_exist $cm_name
 
     ${OC} scale deployment -n ${master_ns} ibm-common-service-operator --replicas=0
     ${OC} scale deployment -n ${master_ns} operand-deployment-lifecycle-manager --replicas=0
@@ -313,6 +315,31 @@ function check_CSCR() {
         fi
     done
 
+}
+
+# check that all namespaces in common-service-maps cm exist. 
+# Create them if not already present 
+# Does not create cs-control namespace
+function check_cm_ns_exist(){
+    local cm_name=$1
+   
+    #this command gets all of the ns listed in requested from namesapce fields
+    requestedNSArray=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].requested-from-namespace' | awk '{print $2}'))
+    
+    #this command gets all of the ns listed in map-to-common-service-namespace
+    mapToCSNSArray=($("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].map-to-common-service-namespace' | awk '{print}'))
+    
+    for ns in "${requestedNSArray[@]}"
+    do
+        echo "creating $ns"
+        ${OC} create namespace $ns || info "$ns already exists, skipping..."
+    done
+    for ns in "${mapToCSNSArray[@]}"
+    do
+        echo "creating $ns"
+        ${OC} create namespace $ns || info "$ns already exists, skipping..."
+    done
+    echo "all namespaces in $cm_name exist"
 }
 
 function msg() {


### PR DESCRIPTION
Signed-off-by: Ben Luzarraga <luzarragaben@ibm.com>

Check that all of the namespaces referred to in common-service-maps configmap exist before running the rest of the script. Try to create all namespaces listed. It _does not_ create the cs-control namespace or check that field at all. The existence of that field is already checked earlier in the code and I think if that namespace does not exist yet we should encourage the user to review their topology before moving on.

Sample output from earlier testing:
```
creating ibm-common-services
Error from server (AlreadyExists): namespaces "ibm-common-services" already exists
ibm-common-services already exists, skipping...
creating ibm-common-services2
namespace/ibm-common-services2 created
creating cpns1
namespace/cpns1 created
creating ibm-common-services
Error from server (AlreadyExists): namespaces "ibm-common-services" already exists
ibm-common-services already exists, skipping...
creating cpns2
namespace/cpns2 created
all namespaces in common-service-maps exist
```

Open to conversation and feedback on implementation

This was the cm I used in my testing for reference:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: common-service-maps
  namespace: kube-public
data:
  common-service-maps.yaml: |
    controlNamespace: cs-control
    namespaceMapping:
    - requested-from-namespace:
      - ibm-common-services
      map-to-common-service-namespace: ibm-common-services
    - requested-from-namespace:
      - ibm-common-services2
      - cpns1
      map-to-common-service-namespace: cpns2
```