### PR TITLE
remove existing odlm managed nss crs

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -90,6 +90,9 @@ function prepare_cluster() {
     ${OC} delete operandregistry -n ${master_ns} --ignore-not-found common-service 
     ${OC} delete operandconfig -n ${master_ns} --ignore-not-found common-service
 
+    # remove existing namespace scope CRs
+    removeNSS
+
     # uninstall singleton services
     "${OC}" delete -n "${master_ns}" --ignore-not-found certmanager default
     "${OC}" delete -n "${master_ns}" --ignore-not-found sub ibm-cert-manager-operator
@@ -313,6 +316,21 @@ function check_CSCR() {
         fi
     done
 
+}
+
+function removeNSS(){
+    ${OC} get nss --all-namespaces | grep nss-managedby-odlm | while read -r line; do
+        local namespace=$(echo $line | awk '{print $1}')
+        info "patching and deleting namespace scope nss-managedby-odlm in namespace $namespace"
+        ${OC} patch nss nss-managedby-odlm -n ${namespace} --type=merge -p '{"metadata": {"finalizers":null}}'
+        ${OC} delete nss nss-managedby-odlm -n ${namespace} || error "unable to delete namespace scope nss-managedby-odlm in ${namespace}"
+    done
+    ${OC} get nss --all-namespaces | grep odlm-scope-managedby-odlm | while read -r line; do
+        local namespace=$(echo $line | awk '{print $1}')
+        info "patching and deleting namespace scope odlm-scope-managedby-odlm in namespace $namespace"
+        ${OC} patch nss odlm-scope-managedby-odlm -n ${namespace} --type=merge -p '{"metadata": {"finalizers":null}}'
+        ${OC} delete nss odlm-scope-managedby-odlm -n ${namespace} || error "unable to delete namespace scope odlm-scope-managedby-odlm in ${namespace}"
+    done
 }
 
 function msg() {

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -321,14 +321,12 @@ function check_CSCR() {
 function removeNSS(){
     ${OC} get nss --all-namespaces | grep nss-managedby-odlm | while read -r line; do
         local namespace=$(echo $line | awk '{print $1}')
-        info "patching and deleting namespace scope nss-managedby-odlm in namespace $namespace"
-        ${OC} patch nss nss-managedby-odlm -n ${namespace} --type=merge -p '{"metadata": {"finalizers":null}}'
+        info "deleting namespace scope nss-managedby-odlm in namespace $namespace"
         ${OC} delete nss nss-managedby-odlm -n ${namespace} || error "unable to delete namespace scope nss-managedby-odlm in ${namespace}"
     done
     ${OC} get nss --all-namespaces | grep odlm-scope-managedby-odlm | while read -r line; do
         local namespace=$(echo $line | awk '{print $1}')
-        info "patching and deleting namespace scope odlm-scope-managedby-odlm in namespace $namespace"
-        ${OC} patch nss odlm-scope-managedby-odlm -n ${namespace} --type=merge -p '{"metadata": {"finalizers":null}}'
+        info "deleting namespace scope odlm-scope-managedby-odlm in namespace $namespace"
         ${OC} delete nss odlm-scope-managedby-odlm -n ${namespace} || error "unable to delete namespace scope odlm-scope-managedby-odlm in ${namespace}"
     done
 }


### PR DESCRIPTION
Signed-off-by: Ben Luzarraga <luzarragaben@ibm.com>

For work item: 
> script should remove namespacescope CRs managed by ODLM (nss-managedby-odlm and odlm-scope-managedby-odlm), so that original instance does not have access to new instances

Open to conversation and feedback on implementation. I am not particularly familiar with how nss works or how these nss CRs get created/recreated (in my testing I manually created them after copying an existing one). I am mostly concerned with the placement of the `removeNSS` function. Right now it is called right after cs operator and odlm are scaled down.

Output looks like:
```
[INFO] patching and deleting namespace scope nss-managedby-odlm in namespace ibm-common-services
namespacescope.operator.ibm.com/nss-managedby-odlm patched
namespacescope.operator.ibm.com "nss-managedby-odlm" deleted
[INFO] patching and deleting namespace scope nss-managedby-odlm in namespace ibm-common-services2
namespacescope.operator.ibm.com/nss-managedby-odlm patched
namespacescope.operator.ibm.com "nss-managedby-odlm" deleted
[INFO] patching and deleting namespace scope odlm-scope-managedby-odlm in namespace ibm-common-services
namespacescope.operator.ibm.com/odlm-scope-managedby-odlm patched
namespacescope.operator.ibm.com "odlm-scope-managedby-odlm" deleted
[INFO] patching and deleting namespace scope odlm-scope-managedby-odlm in namespace ibm-common-services2
namespacescope.operator.ibm.com/odlm-scope-managedby-odlm patched
namespacescope.operator.ibm.com "odlm-scope-managedby-odlm" deleted
```

This will likely have some kind of merge conflict with https://github.com/IBM/ibm-common-service-operator/pull/905, but we'll cross that bridge when we get there.