### PR TITLE
fipsEnable should be consistent with previous name

### DIFF
--- a/controllers/constant/fipsEnable.go
+++ b/controllers/constant/fipsEnable.go
@@ -25,7 +25,7 @@ const FipsEnabledTemplate = `
 - name: ibm-ingress-nginx-operator
   spec:
     nginxIngress:
-      fipsEnabled: placeholder
+      fips_enabled: placeholder
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:


### PR DESCRIPTION
fix for issue [ibm-ingress-nginx operator fips param should be consistent with previous name](https://github.ibm.com/ibmprivatecloud/roadmap/issues/55809)

Signed-off-by: qpdpQ <liyuchen223@gmail.com>