### PR TITLE
cleanup zen instances before conversion

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -316,11 +316,11 @@ function cleanupZenService(){
             info "iam-config-job not present in namespace ${namespace}. Moving on..."
         fi
 
-        #TODO may need to patch out finalizers in zen client
         # delete zen client
         return_value=$(${OC} get client -n ${namespace} || echo "failed")
         if [[ $return_value != "failed" ]]; then
             zenClient=$(${OC} get client -n ${namespace} | awk '{if (NR!=1) {print $1}}')
+            ${OC} patch client ${zenClient} -n ${namespace} --type=merge -p '{"metadata": {"finalizers":null}}'
             ${OC} delete client ${zenClient} -n ${namespace}
         else
             info "No zen client in ${namespace}. Moving on..."
@@ -351,6 +351,7 @@ function cleanupZenService(){
         return_value=$(${OC} get client -n ${namespace} || echo "failed")
         if [[ $return_value != "failed" ]]; then
             zenClient=$(${OC} get client -n ${namespace} | awk '{if (NR!=1) {print $1}}')
+            ${OC} patch client ${zenClient} -n ${namespace} --type=merge -p '{"metadata": {"finalizers":null}}'
             ${OC} delete client ${zenClient} -n ${namespace}
         else
             info "No zen client in ${namespace}. Moving on..."

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -364,6 +364,7 @@ function check_cm_ns_exist(){
         ${OC} create namespace $ns || info "$ns already exists, skipping..."
     done
     echo "all namespaces in $cm_name exist"
+}
 
 function removeNSS(){
     ${OC} get nss --all-namespaces | grep nss-managedby-odlm | while read -r line; do

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -367,26 +367,16 @@ function check_cm_ns_exist(){
 }
 
 function removeNSS(){
-    failcheck=$(${OC} get nss --all-namespaces | grep nss-managedby-odlm || echo "failed")
-    if [[ $failcheck != "failed" ]]; then
-        ${OC} get nss --all-namespaces | grep nss-managedby-odlm | while read -r line; do
-            local namespace=$(echo $line | awk '{print $1}')
-            info "deleting namespace scope nss-managedby-odlm in namespace $namespace"
-            ${OC} delete nss nss-managedby-odlm -n ${namespace} || error "unable to delete namespace scope nss-managedby-odlm in ${namespace}"
-        done
-    else
-        info "Namespace Scope CR \"nss-managedby-odlm\" not present. Moving on..."
-    fi
-    failcheck=$(${OC} get nss --all-namespaces | grep odlm-scope-managedby-odlm || echo "failed")
-    if [[ $failcheck != "failed" ]]; then
-        ${OC} get nss --all-namespaces | grep odlm-scope-managedby-odlm | while read -r line; do
-            local namespace=$(echo $line | awk '{print $1}')
-            info "deleting namespace scope odlm-scope-managedby-odlm in namespace $namespace"
-            ${OC} delete nss odlm-scope-managedby-odlm -n ${namespace} || error "unable to delete namespace scope odlm-scope-managedby-odlm in ${namespace}"
-        done
-    else
-        info "Namespace Scope CR \"odlm-scope-managedby-odlm\" not present. Moving on..."
-    fi
+    ${OC} get nss --all-namespaces | grep nss-managedby-odlm | while read -r line; do
+        local namespace=$(echo $line | awk '{print $1}')
+        info "deleting namespace scope nss-managedby-odlm in namespace $namespace"
+        ${OC} delete nss nss-managedby-odlm -n ${namespace} || error "unable to delete namespace scope nss-managedby-odlm in ${namespace}"
+    done
+    ${OC} get nss --all-namespaces | grep odlm-scope-managedby-odlm | while read -r line; do
+        local namespace=$(echo $line | awk '{print $1}')
+        info "deleting namespace scope odlm-scope-managedby-odlm in namespace $namespace"
+        ${OC} delete nss odlm-scope-managedby-odlm -n ${namespace} || error "unable to delete namespace scope odlm-scope-managedby-odlm in ${namespace}"
+    done
 }
 
 function msg() {

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -300,8 +300,8 @@ function cleanupZenService(){
     for namespace in $requestedNS
     do
         # remove cs namespace from zen service cr
-        return_value=$(${OC} get zenservice -n ${namespace} || echo "failed")
-        if [[ $return_value != "failed" ]]; then
+        return_value=$(${OC} get zenservice -n ${namespace})
+        if [[ $return_value != "" ]]; then
             zenServiceCR=$(${OC} get zenservice -n ${namespace} | awk '{if (NR!=1) {print $1}}')
             ${OC} patch zenservice ${zenServiceCR} -n ${namespace} --type json -p '[{ "op": "remove", "path": "/spec/csNamespace" }]' || info "CS Namespace not defined in ${zenServiceCR} in ${namespace}. Moving on..."
         else
@@ -317,8 +317,8 @@ function cleanupZenService(){
         fi
 
         # delete zen client
-        return_value=$(${OC} get client -n ${namespace} || echo "failed")
-        if [[ $return_value != "failed" ]]; then
+        return_value=$(${OC} get client -n ${namespace})
+        if [[ $return_value != "" ]]; then
             zenClient=$(${OC} get client -n ${namespace} | awk '{if (NR!=1) {print $1}}')
             ${OC} patch client ${zenClient} -n ${namespace} --type=merge -p '{"metadata": {"finalizers":null}}'
             ${OC} delete client ${zenClient} -n ${namespace}
@@ -330,8 +330,8 @@ function cleanupZenService(){
     for namespace in $mapToCSNS
     do
         # remove cs namespace from zen service cr
-        return_value=$(${OC} get zenservice -n ${namespace} || echo "failed")
-        if [[ $return_value != "failed" ]]; then
+        return_value=$(${OC} get zenservice -n ${namespace})
+        if [[ $return_value != "" ]]; then
             zenServiceCR=$(${OC} get zenservice -n ${namespace} | awk '{if (NR!=1) {print $1}}')
             ${OC} patch zenservice ${zenServiceCR} -n ${namespace} --type json -p '[{ "op": "remove", "path": "/spec/csNamespace" }]' || info "CS Namespace not defined in ${zenServiceCR} in ${namespace}. Moving on..."
         else
@@ -346,10 +346,9 @@ function cleanupZenService(){
             info "iam-config-job not present in namespace ${namespace}. Moving on..."
         fi
 
-        #TODO may need to patch out finalizers in zen client
         # delete zen client
-        return_value=$(${OC} get client -n ${namespace} || echo "failed")
-        if [[ $return_value != "failed" ]]; then
+        return_value=$(${OC} get client -n ${namespace})
+        if [[ $return_value != "" ]]; then
             zenClient=$(${OC} get client -n ${namespace} | awk '{if (NR!=1) {print $1}}')
             ${OC} patch client ${zenClient} -n ${namespace} --type=merge -p '{"metadata": {"finalizers":null}}'
             ${OC} delete client ${zenClient} -n ${namespace}

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -367,16 +367,26 @@ function check_cm_ns_exist(){
 }
 
 function removeNSS(){
-    ${OC} get nss --all-namespaces | grep nss-managedby-odlm | while read -r line; do
-        local namespace=$(echo $line | awk '{print $1}')
-        info "deleting namespace scope nss-managedby-odlm in namespace $namespace"
-        ${OC} delete nss nss-managedby-odlm -n ${namespace} || error "unable to delete namespace scope nss-managedby-odlm in ${namespace}"
-    done
-    ${OC} get nss --all-namespaces | grep odlm-scope-managedby-odlm | while read -r line; do
-        local namespace=$(echo $line | awk '{print $1}')
-        info "deleting namespace scope odlm-scope-managedby-odlm in namespace $namespace"
-        ${OC} delete nss odlm-scope-managedby-odlm -n ${namespace} || error "unable to delete namespace scope odlm-scope-managedby-odlm in ${namespace}"
-    done
+    failcheck=$(${OC} get nss --all-namespaces | grep nss-managedby-odlm || echo "failed")
+    if [[ $failcheck != "failed" ]]; then
+        ${OC} get nss --all-namespaces | grep nss-managedby-odlm | while read -r line; do
+            local namespace=$(echo $line | awk '{print $1}')
+            info "deleting namespace scope nss-managedby-odlm in namespace $namespace"
+            ${OC} delete nss nss-managedby-odlm -n ${namespace} || error "unable to delete namespace scope nss-managedby-odlm in ${namespace}"
+        done
+    else
+        info "Namespace Scope CR \"nss-managedby-odlm\" not present. Moving on..."
+    fi
+    failcheck=$(${OC} get nss --all-namespaces | grep odlm-scope-managedby-odlm || echo "failed")
+    if [[ $failcheck != "failed" ]]; then
+        ${OC} get nss --all-namespaces | grep odlm-scope-managedby-odlm | while read -r line; do
+            local namespace=$(echo $line | awk '{print $1}')
+            info "deleting namespace scope odlm-scope-managedby-odlm in namespace $namespace"
+            ${OC} delete nss odlm-scope-managedby-odlm -n ${namespace} || error "unable to delete namespace scope odlm-scope-managedby-odlm in ${namespace}"
+        done
+    else
+        info "Namespace Scope CR \"odlm-scope-managedby-odlm\" not present. Moving on..."
+    fi
 }
 
 function msg() {

--- a/upgrade_common_services.sh
+++ b/upgrade_common_services.sh
@@ -339,12 +339,19 @@ function switch_channel() {
     msg ""
     title "[${STEP}] Switching Zen operator channel in ${csNS} namespace..."
     msg "-----------------------------------------------------------------------"
-    compare_channel "ibm-zen-operator" "${csNS}" "${channel}" "${cur_channel}"
-    if [[ $CHANNEL_COMP == 1 ]]; then
+
+    zen_current=$(oc get sub -n ${csNS} --ignore-not-found | grep ibm-zen-operator | awk '{print $4}')
+    if [[ ! -z "${zen_current}" ]]; then
+        compare_channel "ibm-zen-operator" "${csNS}" "${channel}" "${zen_current}"
+        if [[ $CHANNEL_COMP == 1 ]]; then
+            msg ""
+            msg "Switching channel into ${channel}..."
+            switch_channel_operator "ibm-zen-operator" "${csNS}" "${channel}"
+        fi
+    else
+        msg "ibm-zen-operator in namespace ${csNS} not found, skipping..."
         msg ""
-        msg "Switching channel into ${channel}..."
-        switch_channel_operator "ibm-zen-operator" "${csNS}" "${channel}"
-    fi  
+    fi 
 
     info "Please wait a moment for ${subName} to upgrade all foundational services."
 }


### PR DESCRIPTION
Signed-off-by: Ben Luzarraga <luzarragaben@ibm.com>

Cleanup zen instances before conversion process by patching out the csNamespace key in zenservice and deleting the iam config job and the zen client in cloud pak namespace. 

Open to feedback, related to https://github.com/IBM/ibm-common-service-operator/pull/905 and https://github.com/IBM/ibm-common-service-operator/pull/909. Will likely be merge conflicts

Sample output:
```
zenservice.zen.cpd.ibm.com/iaf-zen-cpdservice patched
job.batch "iam-config-job" deleted
client.oidc.security.ibm.com "zenclient-cpns1" deleted
zenservice.zen.cpd.ibm.com/iaf-zen-cpdservice patched
[INFO] CS Namespace not defined in iaf-zen-cpdservice in cpns2. Moving on...
No zen client in cpns2. Moving on...
```