### PR TITLE
Revert "revert crossplane channel to unblock canary (#947)"

### DIFF
--- a/controllers/constant/crossplane.go
+++ b/controllers/constant/crossplane.go
@@ -29,7 +29,7 @@ metadata:
   name: {{ .ICPOperator }}
   namespace: {{ .ControlNs }}
 spec:
-  channel: v3.22
+  channel: {{ .Channel }}
   installPlanApproval: {{ .ApprovalMode }}
   name: {{ .ICPOperator }}
   source: {{ .CatalogSourceName }}
@@ -66,7 +66,7 @@ metadata:
   name: {{ .ICPPKOperator}}
   namespace: {{ .ControlNs }}
 spec:
-  channel: v3.22
+  channel: {{ .Channel }}
   installPlanApproval: {{ .ApprovalMode }}
   name: {{ .ICPPKOperator }}
   source: {{ .CatalogSourceName }}
@@ -92,7 +92,7 @@ metadata:
   name: {{ .ICPPICOperator }}
   namespace: {{ .ControlNs }}
 spec:
-  channel: v3.22
+  channel: {{ .Channel }}
   installPlanApproval: {{ .ApprovalMode }}
   name: {{ .ICPPICOperator }}
   source: {{ .CatalogSourceName }}


### PR DESCRIPTION
This reverts commit 13e8622110d1fdbb5e14d21d8cadbd942e3e3ef7.