### PR TITLE
Add faked multi entry for IAM/IM

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -37,6 +37,70 @@ spec:
     spec:
       mongoDB: {}
       operandRequest: {}
+  - name: ibm-im-operator
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+      operandBindInfo:
+        bindings:
+          protected-zen-serviceid:
+            secret: zen-serviceid-apikey-secret
+      operandRequest: {}
+  - name: ibm-im-operator-v4.0
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+      operandBindInfo:
+        bindings:
+          protected-zen-serviceid:
+            secret: zen-serviceid-apikey-secret
+      operandRequest: {}
+  - name: ibm-iam-operator-v3.22
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+      operandBindInfo:
+        bindings:
+          protected-zen-serviceid:
+            secret: zen-serviceid-apikey-secret
+      operandRequest: {}
+  - name: ibm-iam-operator-v3.21
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+      operandBindInfo:
+        bindings:
+          protected-zen-serviceid:
+            secret: zen-serviceid-apikey-secret
+      operandRequest: {}
   - name: ibm-iam-operator
     spec:
       authentication:
@@ -59,6 +123,18 @@ spec:
       mustgatherService: {}
       mustgatherConfig: {}
   - name: ibm-commonui-operator
+    spec:
+      commonWebUI: {}
+      switcheritem: {}
+      operandRequest: {}
+      navconfiguration: {}
+  - name: ibm-commonui-operator-v3.22
+    spec:
+      commonWebUI: {}
+      switcheritem: {}
+      operandRequest: {}
+      navconfiguration: {}
+  - name: ibm-commonui-operator-v3.21
     spec:
       commonWebUI: {}
       switcheritem: {}
@@ -272,6 +348,126 @@ spec:
         force: true
         kind: Job
         name: pre-zen-operand-config-job 
+  - name: ibm-zen-operator-v3.22
+    resources:
+      - apiVersion: batch/v1
+        data:
+          spec:
+            activeDeadlineSeconds: 600
+            backoffLimit: 5
+            template:
+              metadata:
+                annotations:
+                  productID: 068a62892a1e4db39641342e592daa25
+                  productMetric: FREE
+                  productName: IBM Cloud Platform Common Services
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - ppc64le
+                                - s390x
+                containers:
+                  - command:
+                      - bash
+                      - '-c'
+                      - bash /setup/pre-zen.sh
+                    env:
+                      - name: common_services_namespace
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: {{ .ZenOperatorImage }}
+                    name: pre-zen-job
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 50Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      privileged: false
+                      readOnlyRootFilesystem: false
+                restartPolicy: OnFailure
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccount: operand-deployment-lifecycle-manager
+                serviceAccountName: operand-deployment-lifecycle-manager
+                terminationGracePeriodSeconds: 30
+        force: true
+        kind: Job
+        name: pre-zen-operand-config-job
+  - name: ibm-zen-operator-v3.21
+    resources:
+      - apiVersion: batch/v1
+        data:
+          spec:
+            activeDeadlineSeconds: 600
+            backoffLimit: 5
+            template:
+              metadata:
+                annotations:
+                  productID: 068a62892a1e4db39641342e592daa25
+                  productMetric: FREE
+                  productName: IBM Cloud Platform Common Services
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - ppc64le
+                                - s390x
+                containers:
+                  - command:
+                      - bash
+                      - '-c'
+                      - bash /setup/pre-zen.sh
+                    env:
+                      - name: common_services_namespace
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: {{ .ZenOperatorImage }}
+                    name: pre-zen-job
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 50Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      privileged: false
+                      readOnlyRootFilesystem: false
+                restartPolicy: OnFailure
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccount: operand-deployment-lifecycle-manager
+                serviceAccountName: operand-deployment-lifecycle-manager
+                terminationGracePeriodSeconds: 30
+        force: true
+        kind: Job
+        name: pre-zen-operand-config-job 
   - name: redhat-marketplace-operator
     resources:
       - apiVersion: ibmcpcs.ibm.com/v1
@@ -322,7 +518,39 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-iam-operator-v3.22
+    namespace: {{ .CPFSNs }}
+    channel: v3.22
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-iam-operator-v3.21
+    namespace: {{ .CPFSNs }}
+    channel: v3.21
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }} 
   - name: ibm-iam-operator
+    namespace: {{ .CPFSNs }}
+    channel: v4.0
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-im-operator
+    namespace: {{ .CPFSNs }}
+    channel: v4.0
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-im-operator-v4.0
     namespace: {{ .CPFSNs }}
     channel: v4.0
     packageName: ibm-iam-operator
@@ -341,6 +569,22 @@ spec:
   - name: ibm-commonui-operator
     namespace: {{ .CPFSNs }}
     channel: v4.0
+    packageName: ibm-commonui-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-commonui-operator-v3.22
+    namespace: {{ .CPFSNs }}
+    channel: v3.22
+    packageName: ibm-commonui-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-commonui-operator-v3.21
+    namespace: {{ .CPFSNs }}
+    channel: v3.21
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
@@ -404,6 +648,22 @@ spec:
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: v3.23
     name: ibm-zen-operator
+    namespace: {{ .CPFSNs }}
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - channel: v3.22
+    name: ibm-zen-operator-v3.22
+    namespace: {{ .CPFSNs }}
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - channel: v3.21
+    name: ibm-zen-operator-v3.21
     namespace: {{ .CPFSNs }}
     packageName: ibm-zen-operator
     scope: public
@@ -476,6 +736,70 @@ spec:
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}
+      operandRequest: {}
+  - name: ibm-im-operator
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+      operandBindInfo:
+        bindings:
+          protected-zen-serviceid:
+            secret: zen-serviceid-apikey-secret
+      operandRequest: {}
+  - name: ibm-im-operator-v4.0
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+      operandBindInfo:
+        bindings:
+          protected-zen-serviceid:
+            secret: zen-serviceid-apikey-secret
+      operandRequest: {}
+  - name: ibm-iam-operator-v3.22
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+      operandBindInfo:
+        bindings:
+          protected-zen-serviceid:
+            secret: zen-serviceid-apikey-secret
+      operandRequest: {}
+  - name: ibm-iam-operator-v3.21
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      oidcclientwatcher: {}
+      pap: {}
+      policycontroller: {}
+      policydecision: {}
+      secretwatcher: {}
+      securityonboarding: {}
+      operandBindInfo:
+        bindings:
+          protected-zen-serviceid:
+            secret: zen-serviceid-apikey-secret
       operandRequest: {}
   - name: ibm-iam-operator
     spec:
@@ -589,6 +913,126 @@ spec:
         force: true
         kind: Job
         name: pre-zen-operand-config-job
+  - name: ibm-zen-operator-v3.22
+    resources:
+      - apiVersion: batch/v1
+        data:
+          spec:
+            activeDeadlineSeconds: 600
+            backoffLimit: 5
+            template:
+              metadata:
+                annotations:
+                  productID: 068a62892a1e4db39641342e592daa25
+                  productMetric: FREE
+                  productName: IBM Cloud Platform Common Services
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - ppc64le
+                                - s390x
+                containers:
+                  - command:
+                      - bash
+                      - '-c'
+                      - bash /setup/pre-zen.sh
+                    env:
+                      - name: common_services_namespace
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: {{ .ZenOperatorImage }}
+                    name: pre-zen-job
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 50Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      privileged: false
+                      readOnlyRootFilesystem: false
+                restartPolicy: OnFailure
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccount: operand-deployment-lifecycle-manager
+                serviceAccountName: operand-deployment-lifecycle-manager
+                terminationGracePeriodSeconds: 30
+        force: true
+        kind: Job
+        name: pre-zen-operand-config-job
+  - name: ibm-zen-operator-v3.21
+    resources:
+      - apiVersion: batch/v1
+        data:
+          spec:
+            activeDeadlineSeconds: 600
+            backoffLimit: 5
+            template:
+              metadata:
+                annotations:
+                  productID: 068a62892a1e4db39641342e592daa25
+                  productMetric: FREE
+                  productName: IBM Cloud Platform Common Services
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - ppc64le
+                                - s390x
+                containers:
+                  - command:
+                      - bash
+                      - '-c'
+                      - bash /setup/pre-zen.sh
+                    env:
+                      - name: common_services_namespace
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: {{ .ZenOperatorImage }}
+                    name: pre-zen-job
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 50Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      privileged: false
+                      readOnlyRootFilesystem: false
+                restartPolicy: OnFailure
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccount: operand-deployment-lifecycle-manager
+                serviceAccountName: operand-deployment-lifecycle-manager
+                terminationGracePeriodSeconds: 30
+        force: true
+        kind: Job
+        name: pre-zen-operand-config-job 
   - name: redhat-marketplace-operator
     resources:
       - apiVersion: ibmcpcs.ibm.com/v1
@@ -639,7 +1083,39 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-iam-operator-v3.22
+    namespace: {{ .CPFSNs }}
+    channel: v3.22
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-iam-operator-v3.21
+    namespace: {{ .CPFSNs }}
+    channel: v3.21
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }} 
   - name: ibm-iam-operator
+    namespace: {{ .CPFSNs }}
+    channel: v4.0
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-im-operator
+    namespace: {{ .CPFSNs }}
+    channel: v4.0
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - name: ibm-im-operator-v4.0
     namespace: {{ .CPFSNs }}
     channel: v4.0
     packageName: ibm-iam-operator
@@ -673,6 +1149,22 @@ spec:
     sourceNamespace: {{ .CatalogSourceNs }}
   - channel: v3.23
     name: ibm-zen-operator
+    namespace: {{ .CPFSNs }}
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - channel: v3.22
+    name: ibm-zen-operator-v3.22
+    namespace: {{ .CPFSNs }}
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: {{ .CatalogSourceNs }}
+  - channel: v3.21
+    name: ibm-zen-operator-v3.21
     namespace: {{ .CPFSNs }}
     packageName: ibm-zen-operator
     scope: public


### PR DESCRIPTION
Add historic entries with different suffix for playback purpose only
- `ibm-im-operator`
- `ibm-im-operator-v4.0`
- `ibm-iam-operator-v3.22`
- `ibm-iam-operator-v3.21`
- `ibm-commonui-operator-v3.22`
- `ibm-commonui-operator-v3.21`
- `ibm-zen-operator-v3.22`
- `ibm-zen-operator-v3.21`

Signed-off-by: Daniel Fan <fanyuchensx@gmail.com>