### PR TITLE
update AllNamespaces Installations Mode

### DIFF
--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -102,8 +102,10 @@ metadata:
   annotations:
     version: "-1"
   name: common-service
-  namespace: placeholder
+  namespace: "{{ .OperatorNs }}"
 spec:
+  servicesNamespace:  "{{ .ServicesNs }}"
+  operatorNamespace: "{{ .CPFSNs }}"
   size: starterset
 `
 

--- a/controllers/goroutines/operator_status.go
+++ b/controllers/goroutines/operator_status.go
@@ -35,8 +35,10 @@ import (
 func UpdateCsCrStatus(bs *bootstrap.Bootstrap) {
 	for {
 		instance := &apiv3.CommonService{}
-		if err := bs.Reader.Get(ctx, types.NamespacedName{Name: "common-service", Namespace: MasterNamespace}, instance); err != nil {
-			klog.Warningf("Getting Common-service CR with error: %s", err)
+		if err := bs.Reader.Get(ctx, types.NamespacedName{Name: "common-service", Namespace: bs.CSData.OperatorNs}, instance); err != nil {
+			if !errors.IsNotFound(err) {
+				klog.Warningf("Faild to get CommonService CR %v/%v: %v", instance.GetNamespace(), instance.GetName(), err)
+			}
 			time.Sleep(5 * time.Second)
 			continue
 		}
@@ -53,7 +55,7 @@ func UpdateCsCrStatus(bs *bootstrap.Bootstrap) {
 
 		opreg, err := bs.GetOperandRegistry(ctx, "common-service", bs.CSData.ServicesNs)
 		if err != nil || opreg == nil {
-			klog.Warning("OperandRegistry common-service is not ready, retry in 5 seconds")
+			// klog.Warning("OperandRegistry common-service is not ready, retry in 5 seconds")
 			time.Sleep(5 * time.Second)
 			continue
 		}

--- a/controllers/webhook/operandrequest/mutatingwebhook.go
+++ b/controllers/webhook/operandrequest/mutatingwebhook.go
@@ -75,10 +75,10 @@ func (r *Defaulter) Handle(ctx context.Context, req admission.Request) admission
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Defaulter) Default(instance *odlm.OperandRequest) {
 	for i, req := range instance.Spec.Requests {
-		regNs := req.RegistryNamespace
-		if regNs == "" {
-			regNs = instance.Namespace
+		if req.RegistryNamespace == "" {
+			continue
 		}
+		regNs := req.RegistryNamespace
 		isDefaulting := false
 		// watchNamespace is empty in All namespace mode
 		if len(r.Bootstrap.CSData.WatchNamespaces) == 0 {
@@ -89,7 +89,7 @@ func (r *Defaulter) Default(instance *odlm.OperandRequest) {
 			}
 			if err := r.Client.Get(ctx, nsKey, ns); err != nil {
 				if errors.IsNotFound(err) {
-					klog.Infof("Not found registrySamespace %v for OperandRequest %v/%v", regNs, instance.Namespace, instance.Name)
+					klog.Infof("Not found registryNamespace %v for OperandRequest %v/%v", regNs, instance.Namespace, instance.Name)
 					isDefaulting = true
 				} else {
 					klog.Errorf("Failed to get namespace %v: %v", regNs, err)


### PR DESCRIPTION
1. User installs the CS operator cluster scoped.
2. If the `ibm-common-services` namespace is not there, the operator waits.
3. If it's there, it creates the CR in the same namespace as operator(openshift-operators) with
    ```
    servicesNamespace: ibm-common-services
    operatorNamespace: openshift-operators
    ```
4. If the user never creates `ibm-common-services` namespace, choose to create it own CommonService CR in the same namespace as operator(openshift-operators), cs-operator accept that and move on.

Signed-off-by: Daniel Fan <fanyuchensx@gmail.com>