### PR TITLE
update cache for AllNamespace Installation mode

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -344,17 +344,15 @@ func (b *Bootstrap) CreateCsCR() error {
 			if errors.IsNotFound(err) {
 				ctx := context.Background()
 				ns := &corev1.Namespace{}
-				if err := b.Client.Get(ctx, types.NamespacedName{Name: constant.MasterNamespace}, ns); err != nil {
+				if err := b.Reader.Get(ctx, types.NamespacedName{Name: constant.MasterNamespace}, ns); err != nil {
 					if errors.IsNotFound(err) {
 						klog.Warningf("Not found well-known default namespace %v, please manually create the namespace", constant.MasterNamespace)
 						time.Sleep(10 * time.Second)
 						continue
-					} else if err != nil {
-						return err
 					}
-					b.CSData.ServicesNs = constant.MasterNamespace
+					return err
 				}
-				defaultCRReady = true
+				b.CSData.ServicesNs = constant.MasterNamespace
 				return b.renderTemplate(constant.CsCR, b.CSData)
 			} else if err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: Daniel Fan <fanyuchensx@gmail.com>

### Reproduce issue
1. deploy `future` CatalogSource in cluster
2. install foundational service in `openshitf-operators` namespace
3. `ibm-common-service-operator` does not get ready and is continuously crash with logs
```
E0207 02:26:39.841424 1 main.go:133] Failed to verify cluster type unable to get: openshift-operators/ibm-cpp-config because of unknown namespace for the cache
E0207 02:26:42.855054 1 main.go:133] Failed to verify cluster type unable to get: openshift-operators/ibm-cpp-config because of unknown namespace for the cache
```


### Patch the fix
1. `export REGISTRY="<your registry here, e.g. quay.io/daniel_fan>"`
2. run `make build-dev-image` to build own image
3. patch CS CSV under `openshift-operators` with latest build image `quay.io/daniel_fan/common-service-operator-amd64:dev`
5. The operator pod does not crash anymore, but it is not ready with logs
```
I0207 02:31:20.993389 1 main.go:174] Creating CommonService CR in the namespace openshift-operators
W0207 02:31:21.014141 1 init.go:349] Not found well-known default namespace ibm-common-services, please manually create the namespace
W0207 02:31:31.035061 1 init.go:349] Not found well-known default namespace ibm-common-services, please manually create the namespace
```
6. create well-known default `ibm-common-services` Namespace in the cluster
7. operator gets ready, and create `common-service` CommonService CR in `openshitf-operators` namespace with following configurations
```
spec:
  operatorNamespace: openshift-operators
  servicesNamespace: ibm-common-services
  size: starterset
```
8. OperandRegistry and OperandConfig `common-service` are placed in `ibm-common-services` ns.
```
➜  ~ oc get operandregistry -n ibm-common-services
NAME             AGE   PHASE                  CREATED AT
common-service   1s    Ready for Deployment   2023-02-07T02:32:42Z
➜  ~ oc get operandconfig -n ibm-common-services
NAME             AGE   PHASE         CREATED AT
common-service   12s   Initialized   2023-02-07T02:32:42Z
```