### PR TITLE
Update status check on deployed services

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1024,18 +1024,12 @@ func (b *Bootstrap) Cleanup(operatorNs string, resource *Resource) error {
 	return nil
 }
 
-func (b *Bootstrap) CheckDeployStatus(ctx context.Context) (operatorDeployed bool, servicesDeployed bool, err error) {
-	opreg, err := b.GetOperandRegistry(ctx, "common-service", b.CSData.ServicesNs)
-	if err != nil {
-		return true, true, err
-	} else if opreg != nil && opreg.Status.Phase == odlm.RegistryRunning {
+func (b *Bootstrap) CheckDeployStatus(ctx context.Context) (operatorDeployed bool, servicesDeployed bool) {
+	if opreg, err := b.GetOperandRegistry(ctx, "common-service", b.CSData.ServicesNs); err == nil && opreg != nil && opreg.Status.Phase == odlm.RegistryRunning {
 		operatorDeployed = true
 	}
 
-	opconfig, err := b.GetOperandConfig(ctx, "common-service", b.CSData.ServicesNs)
-	if err != nil {
-		return true, true, err
-	} else if opreg != nil && opconfig.Status.Phase == odlm.ServiceRunning {
+	if opconfig, err := b.GetOperandConfig(ctx, "common-service", b.CSData.ServicesNs); err == nil && opconfig != nil && opconfig.Status.Phase == odlm.ServiceRunning {
 		servicesDeployed = true
 	}
 	return

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -90,10 +90,7 @@ func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instance *apiv3.CommonService) (ctrl.Result, error) {
 	originalInstance := instance.DeepCopy()
 
-	operatorDeployed, servicesDeployed, err := r.Bootstrap.CheckDeployStatus(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	operatorDeployed, servicesDeployed := r.Bootstrap.CheckDeployStatus(ctx)
 	instance.UpdateConfigStatus(&r.Bootstrap.CSData, operatorDeployed, servicesDeployed)
 
 	var forceUpdateODLMCRs bool


### PR DESCRIPTION
When any error happens on fetching OperandRegistry and OperandConfig, return `false` for `serviceDeployed` status.
It should not block any installation or namespace changing for `operatorNamespace` and `servicesNamespace`

Signed-off-by: Daniel Fan <fanyuchensx@gmail.com>