### PR TITLE
create common service maps with cp3.0 installation

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -676,6 +676,15 @@ func (b *Bootstrap) CreateNsScopeConfigmap() error {
 	return nil
 }
 
+// CreateCsMaps will create a new common-service-maps configmap if not exists
+func (b *Bootstrap) CreateCsMaps() error {
+	cmRes := constant.CommonServiceMaps
+	if err := b.renderTemplate(cmRes, b.CSData, false); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (b *Bootstrap) deleteSubscription(name, namespace string) error {
 	key := types.NamespacedName{Name: name, Namespace: namespace}
 	sub := &olmv1alpha1.Subscription{}

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -261,7 +261,7 @@ func GetServicesNamespace(r client.Reader) (servicesNamespace string) {
 	return
 }
 
-// GetWatchNamespace returns the Namespace of the operator
+// GetWatchNamespace returns the list of namespaces that the operator watches
 func GetWatchNamespace() string {
 	ns, found := os.LookupEnv("WATCH_NAMESPACE")
 	if !found {

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -121,3 +121,18 @@ metadata:
 spec:
   size: as-is
 `
+
+// CommonServiceMaps is the default common service maps ConfigMap
+const CommonServiceMaps = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: common-service-maps
+  namespace: kube-public
+data:
+  common-service-maps.yaml: |
+    namespaceMapping:
+    - requested-from-namespace:
+      - "{{ .OperatorNs }}"
+      map-to-common-service-namespace: "{{ .ServicesNs }}"
+`


### PR DESCRIPTION
### Context
When a new ibm-common-services-operator (v4) is installed, `common-service-maps` ConfigMap will be created automatically in the `kube-piblic` if it does not exist. In the default `common-service-maps` template, the `namesoaceMapping` requests from `OperatorNs` mapping to `ServicesNs`.

### How to test
1. Remove the existing `common-service-maps` ConfigMap
2. Install new IBM Cloud Pak foundational services (v4.0) with image `quay.io/yuchen_shen/cs_operator:csmaps`
3. A new `common-service-maps` ConfigMap will be created in `kube-public`
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: common-service-maps
  namespace: kube-public
data:
  common-service-maps.yaml: |
    namespaceMapping:
    - requested-from-namespace:
      - "{{ .OperatorNs }}"
      map-to-common-service-namespace: "{{ .ServicesNs }}"
```