### PR TITLE
Update common-service-maps ConfigMap

### DIFF
--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -536,7 +536,7 @@ func GetCatalogSource(packageName, ns string, r client.Reader) (CatalogSourceNam
 }
 
 // UpdateCsMaps will update namespaceMapping in common-service-maps
-func UpdateCsMaps(cm *corev1.ConfigMap, requestNs string, servicesNS string) error {
+func UpdateCsMaps(cm *corev1.ConfigMap, requestNsList, servicesNS, operatorNs string) error {
 	commonServiceMaps, ok := cm.Data["common-service-maps.yaml"]
 	if !ok {
 		return fmt.Errorf("there is no common-service-maps.yaml in configmap kube-public/common-service-maps")
@@ -551,17 +551,16 @@ func UpdateCsMaps(cm *corev1.ConfigMap, requestNs string, servicesNS string) err
 	var newnsMapping nsMapping
 	var count int
 
-	watchNsSlice := strings.Split(requestNs, ",")
-	for _, watchNs := range watchNsSlice {
-		newnsMapping.RequestNs = append(newnsMapping.RequestNs, watchNs)
-	}
+	newnsMapping.RequestNs = append(newnsMapping.RequestNs, strings.Split(requestNsList, ",")...)
 	newnsMapping.CsNs = servicesNS
 
 	for _, nsMapping := range cmData.NsMappingList {
-		if servicesNS == nsMapping.CsNs {
-			// ServiceNs already exists in the common-service-maps
-			alreadyExists = true
-			cmData.NsMappingList[count] = newnsMapping
+		for _, ns := range nsMapping.RequestNs {
+			if operatorNs == ns {
+				// OperatorNs already exists in the common-service-maps
+				alreadyExists = true
+				cmData.NsMappingList[count] = newnsMapping
+			}
 		}
 		count++
 	}
@@ -576,6 +575,12 @@ func UpdateCsMaps(cm *corev1.ConfigMap, requestNs string, servicesNS string) err
 		return fmt.Errorf("failed to fetch data of configmap common-service-maps: %v", error)
 	}
 	cm.Data["common-service-maps.yaml"] = string(commonServiceMap)
+
+	if !(cm.Labels != nil && cm.Labels[constant.CsManagedLabel] == "true") {
+		EnsureLabelsForConfigMap(cm, map[string]string{
+			constant.CsManagedLabel: "true",
+		})
+	}
 	return nil
 }
 

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -535,6 +535,50 @@ func GetCatalogSource(packageName, ns string, r client.Reader) (CatalogSourceNam
 	return subscriptions[0].Spec.CatalogSource, subscriptions[0].Spec.CatalogSourceNamespace
 }
 
+// UpdateCsMaps will update namespaceMapping in common-service-maps
+func UpdateCsMaps(cm *corev1.ConfigMap, requestNs string, servicesNS string) error {
+	commonServiceMaps, ok := cm.Data["common-service-maps.yaml"]
+	if !ok {
+		return fmt.Errorf("there is no common-service-maps.yaml in configmap kube-public/common-service-maps")
+	}
+
+	var cmData CsMaps
+	if err := utilyaml.Unmarshal([]byte(commonServiceMaps), &cmData); err != nil {
+		return fmt.Errorf("failed to fetch data of configmap common-service-maps: %v", err)
+	}
+
+	var alreadyExists bool
+	var newnsMapping nsMapping
+	var count int
+
+	watchNsSlice := strings.Split(requestNs, ",")
+	for _, watchNs := range watchNsSlice {
+		newnsMapping.RequestNs = append(newnsMapping.RequestNs, watchNs)
+	}
+	newnsMapping.CsNs = servicesNS
+
+	for _, nsMapping := range cmData.NsMappingList {
+		if servicesNS == nsMapping.CsNs {
+			// ServiceNs already exists in the common-service-maps
+			alreadyExists = true
+			cmData.NsMappingList[count] = newnsMapping
+		}
+		count++
+	}
+
+	// Create a new namespaceMapping
+	if !alreadyExists {
+		cmData.NsMappingList = append(cmData.NsMappingList, newnsMapping)
+	}
+
+	commonServiceMap, error := utilyaml.Marshal(&cmData)
+	if error != nil {
+		return fmt.Errorf("failed to fetch data of configmap common-service-maps: %v", error)
+	}
+	cm.Data["common-service-maps.yaml"] = string(commonServiceMap)
+	return nil
+}
+
 // ValidateCsMaps checks common-service-maps has no scope overlapping
 func ValidateCsMaps(cm *corev1.ConfigMap) error {
 	commonServiceMaps, ok := cm.Data["common-service-maps.yaml"]

--- a/main.go
+++ b/main.go
@@ -165,7 +165,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		cm, err := util.GetCmOfMapCs(mgr.GetAPIReader())
+		cm, err := util.GetCmOfMapCs(bs.Reader)
 		if err != nil {
 			// Create new common-service-maps
 			if errors.IsNotFound(err) {
@@ -191,7 +191,7 @@ func main() {
 				os.Exit(1)
 			}
 
-			if err := mgr.GetClient().Update(context.TODO(), cm); err != nil {
+			if err := bs.Client.Update(context.TODO(), cm); err != nil {
 				klog.Errorf("Failed to update namespaceMapping in common-service-maps: %v", err)
 				os.Exit(1)
 			}

--- a/main.go
+++ b/main.go
@@ -179,19 +179,21 @@ func main() {
 				os.Exit(1)
 			}
 		} else {
+			// Update common-service-maps
+			if err := util.UpdateCsMaps(cm, bs.CSData.WatchNamespaces, bs.CSData.ServicesNs, bs.CSData.OperatorNs); err != nil {
+				klog.Errorf("Failed to update common-service-maps: %v", err)
+				os.Exit(1)
+			}
+
 			// Validate common-service-maps
 			if err := util.ValidateCsMaps(cm); err != nil {
 				klog.Errorf("Unsupported common-service-maps: %v", err)
 				os.Exit(1)
 			}
-			if !(cm.Labels != nil && cm.Labels[constant.CsManagedLabel] == "true") {
-				util.EnsureLabelsForConfigMap(cm, map[string]string{
-					constant.CsManagedLabel: "true",
-				})
-				if err := mgr.GetClient().Update(context.TODO(), cm); err != nil {
-					klog.Errorf("Failed to update labels for common-service-maps: %v", err)
-					os.Exit(1)
-				}
+
+			if err := mgr.GetClient().Update(context.TODO(), cm); err != nil {
+				klog.Errorf("Failed to update namespaceMapping in common-service-maps: %v", err)
+				os.Exit(1)
 			}
 		}
 


### PR DESCRIPTION
### Context
When a new ibm-common-services-operator (v4) is installed, the existent `common-service-maps` ConfigMap will be updated in `namespaceMapping` with new `WATCH_NAMESPACE` to `ServicesNs` by checking `operatorNs`.

### How to test
1. Install new IBM Cloud Pak foundational services (v4.0) by using the same namespace for `servicesNs` and `operatorNs`
2. Apply the image `quay.io/yuchen_shen/cs_operator:csmaps_update`
3. Update NSS CR to include several namespaces
```yaml
spec:
  csvInjector:
    enable: true
  namespaceMembers:
    - cloudpak-control
    - cloudpak-data
    - cloudpak-cp4i
    - cloudpak-cp4ba
```
4. Change `ServiceNs` to different one
```yaml
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
  namespace: cloudpak-control
spec:
  operatorNamespace: cloudpak-control
  servicesNamespace: cloudpak-data
  size: small
```
### Result
common-service-maps updated:
before:
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: common-service-maps
  namespace: kube-public
data:
  common-service-maps.yaml: |
    controlNamespace: ""
    namespaceMapping:
    - map-to-common-service-namespace: cloudpak-control
      requested-from-namespace:
      - cloudpak-control
```
after:
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: common-service-maps
  namespace: kube-public
data:
  common-service-maps.yaml: |
    controlNamespace: ""
    namespaceMapping:
    - map-to-common-service-namespace: cloudpak-data
      requested-from-namespace:
      - cloudpak-cp4ba
      - cloudpak-control
      - cloudpak-data
      - cloudpak-cp4i
```
