### PR TITLE
fix webhook ns selector for all namespaces mode

### DIFF
--- a/controllers/webhooks/reconciler.go
+++ b/controllers/webhooks/reconciler.go
@@ -268,6 +268,17 @@ func SetupWebhooks(mgr manager.Manager, bs *bootstrap.Bootstrap) error {
 	klog.Info("Creating common service webhook configuration")
 	managedbyCSWebhookLabel := make(map[string]string)
 	managedbyCSWebhookLabel[constant.CsManagedLabel] = "true"
+
+	nsLabelSelector := &v1.LabelSelector{}
+	if bs.CSData.WatchNamespaces != "" {
+		nsLabelSelector.MatchExpressions = []v1.LabelSelectorRequirement{
+			{
+				Key:      "kubernetes.io/metadata.name",
+				Operator: v1.LabelSelectorOpIn,
+				Values:   strings.Split(bs.CSData.WatchNamespaces, ","),
+			},
+		}
+	}
 	if common.GetEnableOpreqWebhook() {
 		Config.AddWebhook(CSWebhook{
 			Name:        "ibm-operandrequest-webhook-configuration-" + bs.CSData.OperatorNs,
@@ -286,15 +297,7 @@ func SetupWebhooks(mgr manager.Manager, bs *bootstrap.Bootstrap) error {
 					},
 				},
 			},
-			NsSelector: v1.LabelSelector{
-				MatchExpressions: []v1.LabelSelectorRequirement{
-					{
-						Key:      "kubernetes.io/metadata.name",
-						Operator: v1.LabelSelectorOpIn,
-						Values:   strings.Split(bs.CSData.WatchNamespaces, ","),
-					},
-				},
-			},
+			NsSelector: *nsLabelSelector,
 		})
 	}
 


### PR DESCRIPTION
In Own Namespace Installation Mode, our webhook will have a Namespace selector in webhook configuration to constrain the scope inside `WATCH_NAMESPACE` list.
```
namespaceSelector:
  matchExpressions:
    - key: kubernetes.io/metadata.name
      operator: In
      values:
        - shared-services
```

In All Namespaces Installation Mode, our webhook should take effect for all namespaces across the cluster, so it has the NamespaceSelector empty
```
namespaceSelector: {}
```

### Re-produce issue
- Deploy `future` CatalogSource in the cluster
- Deploy foundational service in AllNamespace Mode under `openshift-operators` namespace
- Create `ibm-common-services` namespace
- Wait for ODLM is installed successfully
- Create following OperandRequest with hilarious `registryNamespace`
```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  name: example-service
  namespace: openshift-operators
spec:
  requests:
    - operands:
        - name: ibm-im-operator
      registry: common-service
      registryNamespace: xxxxxxxxxxxxxxxxxxxx
```
- The OperandRequest is `Pending` because no OperandRegistry is found in namespace `xxxxxxxxxxxxxxxxxxxx`

### Test workaround
- Update the foundational services CSV image
```
oc patch csv ibm-common-service-operator.v4.0.0 -n openshift-operators --type="json" -p '[{"op": "replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/image", "value":"quay.io/daniel_fan/common-service-operator-amd64:dev"}]'
```
- Check the MutatingWebhookConfiguration now has empty `namespaceSelector: {}`
- Check OperandRequest has correct `registryNamespace: ibm-common-services`