### PR TITLE
enhance creation of csmaps for multiple RequestNs

### DIFF
--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -54,11 +54,11 @@ import (
 
 type CsMaps struct {
 	ControlNs     string      `json:"controlNamespace"`
-	NsMappingList []nsMapping `json:"namespaceMapping"`
+	NsMappingList []NsMapping `json:"namespaceMapping"`
 	// DefaultCsNs   string      `json:"defaultCsNs"`
 }
 
-type nsMapping struct {
+type NsMapping struct {
 	RequestNs []string `json:"requested-from-namespace"`
 	CsNs      string   `json:"map-to-common-service-namespace"`
 }
@@ -548,7 +548,7 @@ func UpdateCsMaps(cm *corev1.ConfigMap, requestNsList, servicesNS, operatorNs st
 	}
 
 	var alreadyExists bool
-	var newnsMapping nsMapping
+	var newnsMapping NsMapping
 	var count int
 
 	newnsMapping.RequestNs = append(newnsMapping.RequestNs, strings.Split(requestNsList, ",")...)


### PR DESCRIPTION
### Context
Enhance the creation of `common-service-maps` ConfigMap for multiple `RequestNs` case.
### How to test
1. Install a new IBM Cloud Pak foundational services (v4.0) for for Topology B or C 
2. Apply the image `quay.io/yuchen_shen/cs_operator:csmaps_requestns`
3. A new `common-service-maps` ConfigMap will be created. Ex:
```yaml
data:
  common-service-maps.yaml: |
    controlNamespace: ""
    namespaceMapping:
    - map-to-common-service-namespace: cloudpak-data
      requested-from-namespace:
      - cloudpak-control
      - cloudpak-data
```