### PR TITLE
[wip] add zen refresh logic to rollback

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -261,7 +261,7 @@ function check_healthy() {
 
     sleep 10
 
-    retries=20
+    retries=70
     sleep_time=15
     total_time_mins=$(( sleep_time * retries / 60))
     info "Waiting for IBM Common Services CR is Succeeded"


### PR DESCRIPTION
After rolling back from a multi instance cluster to a shared cluster, whatever cloud pak namespaces were using new cs instances need to redirect their login screen back to the original cp-console instead of cp-console-<new cs instance ns> (because cp-console-<new cs instance ns> no longer exists at this point). This problem is proving more difficult to resolve than simply reconciling the zenservice again as we are doing in https://github.com/IBM/ibm-common-service-operator/pull/1057.

To test:
- setup environment with two cloudpaks sharing cs instance
- convert to multi instance using version of the conversion script from #1057 
- login with the new default admin credentials from new cs instance to the cloudpak instance mapped to the new cs instance
- run uninstall script (uninstall-dedicated-cs-instances.sh) for the second instance of cs with -f (easier that way)
- run this version of rollback script
- attempt to access cpd-<ns of cloud pak that used the new cs instance)
    - if you are redirected to the now deleted `cp-console-<new cs instance ns>` login page, it did not work
    - if you are redirected to cp-console login page, it worked
