### PR TITLE
Migrate License Service CMs during conversion process

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -147,7 +147,7 @@ function migrate_lic_cms() {
 
     for cm in ${POSSIBLE_CONFIGMAPS[@]}
     do
-        return_value=$(${OC} get cm -n $namespace --ignore-not-found | (grep $cm || echo "fail") awk '{print $1}')
+        return_value=$(${OC} get cm -n $namespace --ignore-not-found | (grep $cm || echo "fail") | awk '{print $1}')
         info "return value for $cm: $return_value"
         if [[ $return_value != "fail" ]]; then
             if [[ $return_value == $cm ]]; then

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -109,14 +109,12 @@ function prepare_cluster() {
         "${OC}" delete -n "${master_ns}" --ignore-not-found ibmlicensing instance
     fi
     return_value="reset"
-    licensing="false"
     #might need a more robust check for if licensing is installed
     "${OC}" delete -n "${master_ns}" --ignore-not-found sub ibm-licensing-operator
     csv=$("${OC}" get -n "${master_ns}" csv | (grep ibm-licensing-operator || echo "fail") | awk '{print $1}')
     if [[ $csv != "fail" ]]; then
+        migrate_lic_cms $master_ns $controlNs
         "${OC}" delete -n "${master_ns}" --ignore-not-found csv "${csv}"
-        #could trigger licensing flag here for backup/restore of licensing cms
-        licensing="true"
     fi
 
     "${OC}" delete -n "${master_ns}" --ignore-not-found sub ibm-crossplane-operator-app
@@ -125,10 +123,6 @@ function prepare_cluster() {
     "${OC}" delete -n "${master_ns}" --ignore-not-found csv "${csv}"
     csv=$("${OC}" get -n "${master_ns}" csv | (grep ibm-crossplane-provider-kubernetes-operator || echo "fail") | awk '{print $1}')
     "${OC}" delete -n "${master_ns}" --ignore-not-found csv "${csv}"
-
-    if [[ $licensing == "true" ]]; then
-        migrate_lic_cms $master_ns $controlNs
-    fi
 }
 
 function migrate_lic_cms() {

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -163,7 +163,7 @@ function migrate_lic_cms() {
             info "Licensing configmap $cm copied from $namespace to $controlNs"
         fi
     done
-    success "Licensing configmaps copied from $namespace to $controlNS"
+    success "Licensing configmaps copied from $namespace to $controlNs"
 }
 
 # scale back cs pod 

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -148,7 +148,6 @@ function migrate_lic_cms() {
     for cm in ${POSSIBLE_CONFIGMAPS[@]}
     do
         return_value=$(${OC} get cm -n $namespace --ignore-not-found | grep $cm || echo "fail")
-        info "return value for $cm: $return_value"
         if [[ $return_value != "fail" ]]; then
             ${OC} get cm -n $namespace $cm -o yaml --ignore-not-found > tmp.yaml
             #edit the file to change the namespace to controlNs

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -110,10 +110,11 @@ function prepare_cluster() {
     fi
     return_value="reset"
     #might need a more robust check for if licensing is installed
-    "${OC}" delete -n "${master_ns}" --ignore-not-found sub ibm-licensing-operator
+    #"${OC}" delete -n "${master_ns}" --ignore-not-found sub ibm-licensing-operator
     csv=$("${OC}" get -n "${master_ns}" csv | (grep ibm-licensing-operator || echo "fail") | awk '{print $1}')
     if [[ $csv != "fail" ]]; then
         migrate_lic_cms $master_ns $controlNs
+        "${OC}" delete -n "${master_ns}" --ignore-not-found sub ibm-licensing-operator
         "${OC}" delete -n "${master_ns}" --ignore-not-found csv "${csv}"
     fi
 


### PR DESCRIPTION
We need to migrate over LicenseService data. This data was specified in 57531 and consists of multiple configmaps that may or may not be on the cluster. 
- Iterate through the list check if present
- if present
    - output cm to a temp yaml file
    - edit the namespace to match the control from the common-service-maps
    - apply the new configmap
    - delete temp file

To test:
- Setup cluster with Licensing installed, check for configmaps specified in `POSSIBLE_CONFIGMAPS` list in cs namespace
- run this version of conversion script
- check output for cm related messages
- verify script converts cluster successfully
- check control namespace for any of the licensing configmaps in the `POSSIBLE_CONFIGMAPS` list

I have not tested these changes myself yet. Confirming with Licensing team that these steps are appropriate as well.