### PR TITLE
restart auth idp pod after restore

### DIFF
--- a/backup_restore_mongo.sh
+++ b/backup_restore_mongo.sh
@@ -33,6 +33,7 @@ function main() {
     prep_restore
     restore
     cleanup
+    refresh_auth_idp
 }
 
 # verify that all pre-requisite CLI tools exist and parameters set
@@ -292,6 +293,14 @@ function cleanup(){
 
     success "Cleanup complete."
 
+}
+
+function refresh_auth_idp(){
+    title " Restarting auth-idp pod in namespace $TARGET_NAMESPACE "
+    msg "-----------------------------------------------------------------------"
+    local auth_pod=$(${OC} get pods -n $TARGET_NAMESPACE | grep auth-idp | awk '{print $1}')
+    ${OC} delete pod $auth_pod -n $TARGET_NAMESPACE || error "Pod $auth_pod could not be deleted"
+    success "Pod $auth_pod deleted. Please allow a few minutes for it to restart."
 }
 
 function msg() {


### PR DESCRIPTION
After investigating 57624, we decided we would need to restart the auth idp pod as a part of the backup restore script. I tested it on my environment and it is working.

To test:
- install cs and instantiate LDAP users (easiest way is through cs dev tools)
- convert cluster to multi instance
- run this version of backup restore script, ensure it completes successfully
- verify can login to new cs instance cp-console with restored LDAP user 