### PR TITLE
feat: Remove Db2U from IBM common services

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -579,12 +579,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: v2.2
-    name: ibm-db2u-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: db2u-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
   - channel: stable
     name: cloud-native-postgresql
     namespace: "{{ .CPFSNs }}"


### PR DESCRIPTION
https://github.ibm.com/DB2/tracker/issues/32036

As of Cloud Pak 3.0, Db2U will no longer be included in the OperandRegistry for IBM Common Services.
* CP4D is already creating the subscription for Db2U operator instead of using Operand Requests
* CP4S (Guardium) will switch from using Operand Requests to explicitly creating a sub and using the standalone channels