### PR TITLE
Separate backup, restore, and cleanup processes

### DIFF
--- a/backup_restore_mongo.sh
+++ b/backup_restore_mongo.sh
@@ -99,7 +99,9 @@ function prereq() {
     if [[ -z $ORIGINAL_NAMESPACE ]] && [[ -z $TARGET_NAMESPACE ]]; then
         error "Neither backup nor restore namespaces were set. Use -h or --help to see script usage options"
     elif [[ -z $ORIGINAL_NAMESPACE ]] && [[ $cleanup == "false" ]]; then
-        error "Backup namespace not specified. Please specify backup namespace with --bns. Use -h or --help for script usage"
+        if [[ $backup == "true" || $restore == "true" ]]; then
+            error "Backup namespace not specified. Please specify backup namespace with --bns. Use -h or --help for script usage"
+        fi
     fi
     
     if [[ $backup == "false" ]] && [[ $restore == "false" ]] && [[ $cleanup == "false" ]]; then


### PR DESCRIPTION
Make it possible for the backup_restore_mongo.sh to run backup, restore, or cleanup independently or any combination of the three (though running cleanup after backup and before restore will remove the backup).

To test:
- create shared instance cluster
- create LDAP users for shared cs instance (can be done with cs-dev-tools)
- run this version of backup `./backup_restore_mongo.sh --bns <shared cs instance ns> -b`
- convert cluster to multi instance and install IAM in new cs instance
- wait for IAM pods to come ready
- run restore process `./backup_restore_mongo.sh --bns <shared cs instance ns> --rns <new cs instance ns> -r`
- login to new cp console instance with restored LDAP user
- cleanup resources with `./backup_restore_mongo.sh --bns <shared cs instance ns> --rns <new cs instance ns> -c`