### PR TITLE
change how cs op sub is found and updated

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -78,15 +78,15 @@ function prereq() {
     if [[ $return_value != "pass" ]]; then
         error "The ibm-common-service-operator must not be installed in AllNamespaces mode"
     fi
+}
+
+function prepare_cluster() {
 
     # TODO for more advanced checking
     # find all namespaces with cs-operator running
     # each namespace should be in configmap
     # all namespaces in configmap should exist
     check_cm_ns_exist $cm_name
-}
-
-function prepare_cluster() {
 
     ${OC} scale deployment -n ${master_ns} ibm-common-service-operator --replicas=0
     ${OC} scale deployment -n ${master_ns} operand-deployment-lifecycle-manager --replicas=0

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -82,6 +82,7 @@ function prereq() {
 
 function prepare_cluster() {
 
+    local cm_name="common-service-maps"
     # TODO for more advanced checking
     # find all namespaces with cs-operator running
     # each namespace should be in configmap

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -161,7 +161,7 @@ function migrate_lic_cms() {
             if [[ $return_value == $cm ]]; then
                 ${OC} get cm -n $namespace $cm -o yaml --ignore-not-found > tmp.yaml
                 #edit the file to change the namespace to controlNs
-                yq '.metadata.namespace = "'${controlNs}'"' tmp.yaml
+                yq -i '.metadata.namespace = "'${controlNs}'"' tmp.yaml
                 ${OC} apply -f tmp.yaml
                 info "Licensing configmap $cm copied from $namespace to $controlNs"
             fi
@@ -351,7 +351,7 @@ function cleanupCSOperators(){
         if [[ $return_value != "fail" ]]; then
             local sub=$(${OC} get sub -n ${namespace} | grep ibm-common-service-operator | awk '{print $1}')
             ${OC} get sub ${sub} -n ${namespace} -o yaml > tmp.yaml 
-            ${YQ} '.spec.source = "'${catalog_source}'"' tmp.yaml || error "Could not replace catalog source for CS operator in namespace ${namespace}"
+            ${YQ} -i '.spec.source = "'${catalog_source}'"' tmp.yaml || error "Could not replace catalog source for CS operator in namespace ${namespace}"
             ${OC} apply -f tmp.yaml
             info "Common Service Operator Subscription in namespace ${namespace} updated to use catalog source ${catalog_source}"
         else


### PR DESCRIPTION
Right now, we look for cs operator subscription based on the name of the sub. Cloud paks sometimes create the cs operator subscription under a different name (ie cp4i uses `ibm-common-service-operator-v3.23-ibm-operator-catalog-openshift-marketplace` as a sub name) which has caused the script to try to install a second instance of cs operator in a namespace that results in the second cs operator instance sitting in limbo. This has been updated in this pr.

Similarly, if the cs operator already exists in the cloud pak namespace, the version of common services installed will be determined by the subscription that is already present in the cloud pak namespace. This could cause some mix-ups in what catalog source is used and consequently what versions of services are available. This change presently enforces the original cs operator's catalog source to be used cluster wide.

To test
- setup environment with two cloud paks installed
- if possible, change catalog source for cs operator installed in cloud pak namespaces so it does not match common services catalog source
- change name of cs operator subs in cloud pak namespaces
- run this version of conversion script
- verify there is not a cs operator in limbo in the cloud pak namespaces
- verify the catalog sources match across cs operator subscriptions