### PR TITLE
remove Audit Logging from OperandConfig

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -95,7 +95,6 @@ spec:
       nginxIngress: {}
   - name: ibm-auditlogging-operator
     spec:
-      auditLogging: {}
       operandBindInfo: {}
       operandRequest: {}
   - name: ibm-platform-api-operator
@@ -701,7 +700,6 @@ spec:
       nginxIngress: {}
   - name: ibm-auditlogging-operator
     spec:
-      auditLogging: {}
       operandBindInfo: {}
       operandRequest: {}
   - name: ibm-platform-api-operator


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57882
CP3.0 ODLM will not manage cluster scope resources `auditLogging`
#### Verify fix

1. Install foundation service 4.0, remove `installMode: no-op` for `ibm-auditloggin-operator` in `OperandRegistry`
2. Request `ibm-auditlogging-operator`, will get error msg in `odlm` pod, and `common-service` OC failed
   ```
   failed to get the custom resource cloudpak-all-in-one/example-auditlogging: auditloggings.operator.ibm.com "example-auditlogging" is forbidden: 
   User "system:serviceaccount:cloudpak-all-in-one:operand-deployment-lifecycle-manager" cannot get resource "auditloggings" in API group "operator.ibm.com" at the cluster scope
   ```
3. Manually remove ` auditLogging: {}` in `OperandConfig`, `common-service` OC back to `running`.
