### PR TITLE
Add checking singleton exists or not and skipping install

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -208,6 +208,9 @@ function wait_for_operator() {
     local operator_name=$2
     local condition="${OC} -n ${namespace} get csv --no-headers --ignore-not-found | egrep 'Succeeded' | grep ^${operator_name}"
     local retries=50
+    if [ "x$3" != "x" ]; then
+        retries=$3
+    fi
     local sleep_time=10
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for operator ${operator_name} in namespace ${namespace} to be made available"

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -18,7 +18,8 @@ INSTALL_MODE="Automatic"
 CERT_MANAGER_SOURCE="ibm-cert-manager-operator-catalog"
 LICENSING_SOURCE="ibm-licensing-catalog"
 
-SKIP_INSTALL=false
+SKIP_INSTALL=0
+CHECK_LICENSING_ONLY=0
 
 # ---------- Command variables ----------
 
@@ -66,11 +67,11 @@ function parse_arguments() {
             LICENSING_SOURCE=$1
             ;;
         --check-cert-manager)
-            SKIP_INSTALL=true
+            SKIP_INSTALL=1
             ;;
         --check-licensing)
             CHECK_LICENSING_ONLY=1
-            SKIP_INSTALL=true           
+            SKIP_INSTALL=1           
             ;;
         -h | --help)
             print_usage
@@ -126,7 +127,7 @@ function install_cert_manager() {
         SOURCE_NS="ibm-cert-manager"
     fi
 
-    if [ $SKIP_INSTALL = true ]; then
+    if [ $SKIP_INSTALL -eq 1 ]; then
         wait_for_operator "ibm-cert-manager" "ibm-cert-manager-operator" 6 # only wait 1 min by retrying 6 times
         return
     fi
@@ -154,7 +155,7 @@ function install_licensing() {
         SOURCE_NS="ibm-licensing"
     fi
 
-    if [ $SKIP_INSTALL = true ]; then
+    if [ $SKIP_INSTALL -eq 1 ]; then
         wait_for_operator "ibm-licensing" "ibm-licensing-operator" 6 # only wait 1 min by retrying 6 times
         return
     fi


### PR DESCRIPTION
1. Introduced two flags `--check-cert-manager` and `--check-licensing` to implement singleton checking and skipping installation.
2. The two flags are not included in the usage so that they are not exposed to other users.
3. Olm-utils side could directly call `setup_singleton.sh --check-cert-manager` to check whether cert manager is installed or not. The scripts will exit with 1 if no operator found after one minute waiting.
