### PR TITLE
update csmaps when operator ns is the same as cs ns

### DIFF
--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -555,18 +555,20 @@ func UpdateCsMaps(cm *corev1.ConfigMap, requestNsList, servicesNS, operatorNs st
 	newnsMapping.CsNs = servicesNS
 
 	for _, nsMapping := range cmData.NsMappingList {
+		if operatorNs == nsMapping.CsNs {
+			// OperatorNs already exists in common service namespace
+			alreadyExists = true
+			cmData.NsMappingList[count] = newnsMapping
+			break
+		}
+
 		for _, ns := range nsMapping.RequestNs {
 			if operatorNs == ns {
 				// OperatorNs already exists in request namespaces list
 				alreadyExists = true
 				cmData.NsMappingList[count] = newnsMapping
+				break
 			}
-		}
-
-		if operatorNs == nsMapping.CsNs {
-			// OperatorNs already exists in common service namespace
-			alreadyExists = true
-			cmData.NsMappingList[count] = newnsMapping
 		}
 		count++
 	}

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -557,10 +557,16 @@ func UpdateCsMaps(cm *corev1.ConfigMap, requestNsList, servicesNS, operatorNs st
 	for _, nsMapping := range cmData.NsMappingList {
 		for _, ns := range nsMapping.RequestNs {
 			if operatorNs == ns {
-				// OperatorNs already exists in the common-service-maps
+				// OperatorNs already exists in request namespaces list
 				alreadyExists = true
 				cmData.NsMappingList[count] = newnsMapping
 			}
+		}
+
+		if operatorNs == nsMapping.CsNs {
+			// OperatorNs already exists in common service namespace
+			alreadyExists = true
+			cmData.NsMappingList[count] = newnsMapping
 		}
 		count++
 	}


### PR DESCRIPTION
issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/57891
#### Context 
In CP2.0, I have following `common-service-maps` ConfigMap like 
```
data:
  common-service-maps.yaml: |
    controlNamespace: cs-control
    namespaceMapping:
    - map-to-common-service-namespace: ibm-common-services
      requested-from-namespace:
      - cloudpak-ns
```
When there is a CS operator v4.0 deployed/upgraded in  `ibm-common-services` namespace, and specify operator namespace in CommonService CR:
```
spec:
  operatorNamespace: ibm-common-services
  servicesNamespace: ibm-common-services
  size: starterset
```
will getting erros msg: 
```
Unsupported common-service-maps: invalid map-to-common-service-namespace: ibm-common-services

```
#### Enhancement
Add the condition check, if the operator namespace is the same as the existent common service namespace, will update the requestNs with given `WatchNamespaces` list.
#### Verify

1. Install Foundational Service v3, and create a `common-service-maps` ConfigMap, and upgrade to v4 operator and will see the above error msg in cs operator pod
   ```
    data:
      common-service-maps.yaml: |
        controlNamespace: cs-control
        namespaceMapping:
        - map-to-common-service-namespace: ibm-common-services
          requested-from-namespace:
          - cloudpak-ns
   ```
2. Apply testing image `quay.io/yuchen_shen/cs_operator:csmaps_csns`, and restart cs operator pod, no more error and configmap updated like:
    ```
    data:
      common-service-maps.yaml: |
        controlNamespace: cs-control
        namespaceMapping:
        - map-to-common-service-namespace: ibm-common-services
          requested-from-namespace:
          - cloudpak-ns
          - ibm-common-services   <------------------ new updated
   ```