### PR TITLE
removed cs-webhook and secretshare from relatedImages

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -357,10 +357,6 @@ spec:
   relatedImages:
     - image: icr.io/cpopen/common-service-operator:4.0.0
       name: COMMON_SERVICE_OPERATOR_IMAGE
-    - image: icr.io/cpopen/cpfs/ibm-cs-webhook:1.18.0
-      name: IBM_CS_WEBHOOK_IMAGE
-    - image: icr.io/cpopen/cpfs/ibm-secretshare-operator:1.19.0
-      name: IBM_SECRETSHARE_OPERATOR_IMAGE
     - image: icr.io/cpopen/cpfs/cpfs-utils:4.0.0
       name: CS_UTILS_IMAGE
   version: 4.0.0

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -182,10 +182,6 @@ spec:
   relatedImages:
   - image: icr.io/cpopen/common-service-operator
     name: COMMON_SERVICE_OPERATOR_IMAGE
-  - image: icr.io/cpopen/cpfs/ibm-cs-webhook:1.18.0
-    name: IBM_CS_WEBHOOK_IMAGE
-  - image: icr.io/cpopen/cpfs/ibm-secretshare-operator:1.19.0
-    name: IBM_SECRETSHARE_OPERATOR_IMAGE
   - image: icr.io/cpopen/ibm-zen-operator:1.7.0
     name: IBM_ZEN_OPERATOR_IMAGE
   - image: icr.io/cpopen/cpfs/cpfs-utils:4.0.0


### PR DESCRIPTION
Do we need to remove the zen operator image too?

```
  - image: icr.io/cpopen/ibm-zen-operator:1.7.0
    name: IBM_ZEN_OPERATOR_IMAGE
```