### PR TITLE
set ControlNs to cs-control when csmaps creating

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -690,6 +690,7 @@ func (b *Bootstrap) CreateCsMaps() error {
 
 	newnsMapping.RequestNs = append(newnsMapping.RequestNs, strings.Split(b.CSData.WatchNamespaces, ",")...)
 	newnsMapping.CsNs = b.CSData.ServicesNs
+	cmData.ControlNs = "cs-control"
 	cmData.NsMappingList = append(cmData.NsMappingList, newnsMapping)
 	commonServiceMap, error := utilyaml.Marshal(&cmData)
 	if error != nil {

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -553,6 +553,9 @@ func UpdateCsMaps(cm *corev1.ConfigMap, requestNsList, servicesNS, operatorNs st
 
 	newnsMapping.RequestNs = append(newnsMapping.RequestNs, strings.Split(requestNsList, ",")...)
 	newnsMapping.CsNs = servicesNS
+	if cmData.ControlNs == "" {
+		cmData.ControlNs = "cs-control"
+	}
 
 	for _, nsMapping := range cmData.NsMappingList {
 		// OperatorNs already exists in common service namespace

--- a/main.go
+++ b/main.go
@@ -182,6 +182,7 @@ func main() {
 				}
 			} else {
 				// Update common-service-maps
+				klog.Infof("Updating common-service-maps ConfigMap in kube-public")
 				if err := util.UpdateCsMaps(cm, bs.CSData.WatchNamespaces, bs.CSData.ServicesNs, bs.CSData.OperatorNs); err != nil {
 					klog.Errorf("Failed to update common-service-maps: %v", err)
 					os.Exit(1)


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57957
CP2 ODLM will automatically extend its permission to any namespace where OperandRequest exists if `controlNamespace:""` in csmaps
#### Issue reproduce
1. Install CP3.0 in `cloudpak-ns`, will see `controlNamespace` is empty `""` when `common-service-maps` is being created.
2. Install CP2.0 in default namespace `ibm-common-services`, and create a `OperandRequest` in `cloudpak-ns`, will see the CP2.0 ODLM  permission is extented to `cloudpak-ns`

- `ibm-common-services` namespace will be included in `namespace-scope` in `cloudpak-ns`
- those tombstone services will be installed in the CP3.0 ns
   ```
    kind: ConfigMap
    apiVersion: v1
    metadata:
      name: namespace-scope
      namespace: cloudpak-ns
    data:
      namespaces: 'ibm-common-services,cloudpak-ns'
   ```
#### Verify fix
1. Apply image `quay.io/yuchen_shen/cs_operator:control_ns`
2. Delete existent configmap `common-service-maps`, and restart cs operator pod in `cloudpak-ns`
3. New csmaps will be created with `controlNamespace: cs-control`
