### PR TITLE
Enhance migrate_tenant script

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -706,6 +706,11 @@ function update_operator_channel() {
     local install_mode=$6
     
     local sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${package_name}.${ns}='' --no-headers | awk '{print $1}')
+    if [ -z "$sub_name" ]; then
+        warning "Not found subscription ${package_name} in ${ns}"
+        return 0
+    fi
+
     ${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml > sub.yaml
     
     existing_channel=$(yq eval '.spec.channel' sub.yaml)


### PR DESCRIPTION
1. If users are using NSS restricted version before upgrade, the script will uninstall NSS restricted and re-install NSS v4.
2. If the subscription is not found in a namespace, script will ignore this subscription.
   - It is possible that cs-operator does not exist in some namespaces.