### PR TITLE
remove certmanager finalizer when it is stuck

### DIFF
--- a/cp3pt0-deployment/common/delegate_cp2_cert_manager.sh
+++ b/cp3pt0-deployment/common/delegate_cp2_cert_manager.sh
@@ -133,7 +133,11 @@ EOF
     msg ""
 
     info "Deleting existing Cert Manager CR..."
-    ${OC} delete certmanager.operator.ibm.com default --ignore-not-found
+    ${OC} delete certmanager.operator.ibm.com default --ignore-not-found --timeout=10s
+    if [ $? -ne 0 ]; then
+        wanring "Failed to delete Cert Manager CR, patching its finalizer to null..."
+        ${OC} patch certmanagers.operator.ibm.com default --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
+    fi
     msg ""
 
     info "Restarting IBM Cloud Pak 2.0 Cert Manager to provide cert-rotation only..."


### PR DESCRIPTION
In a old version of cert-manager, there is a finalizer blocking the deletion.

Update the script to remove this finalizer when it is stuck.

Test result
```
certmanager.operator.ibm.com "default" deleted

error: timed out waiting for the condition on certmanagers/default

Failed to delete Cert Manager CR, patching its finalizer to null...

certmanager.operator.ibm.com/default patched
```