### PR TITLE
find subscription via label in condition directly

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -325,8 +325,7 @@ function wait_for_operator_upgrade() {
     local namespace=$1
     local package_name=$2
     local channel=$3
-    local sub_name=$(${OC} get subscription.operators.coreos.com -n ${namespace} -l operators.coreos.com/${package_name}.${namespace}='' --no-headers | awk '{print $1}')
-    local condition="${OC} get subscription.operators.coreos.com ${sub_name} -n ${namespace} -o jsonpath='{.status.installedCSV}' | grep -w $channel"
+    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${package_name}.${namespace}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w $channel"
 
     local retries=10
     local sleep_time=30


### PR DESCRIPTION
Take ODLM as an example, ODLM is now deleted during the upgrade(need to further enhance it).

When we are executing the following cmd `wait_for_operator_upgrade "$OPERATOR_NS" "ibm-odlm" "$CHANNEL"`, it will look for ODLM's subscription name
```
local sub_name=$(${OC} get subscription.operators.coreos.com -n ${namespace} -l operators.coreos.com/${package_name}.${namespace}='' --no-headers | awk '{print $1}')
```

However, it will return empty `sub_name` if ODLM subscription does not exist, and it leads to a invalid condition check `oc get subscription.operators.coreos.com  <empty-string>`. And finally it is timeout.
```
No resources found in cloudpak-all-in-one namespace.
[INFO] Waiting for operator ibm-odlm to be upgraded
oc get subscription.operators.coreos.com <empty-string> -n cloudpak-all-in-one -o jsonpath='{.status.installedCSV}' | grep -w v4.0
[INFO] RETRYING: Waiting for operator ibm-odlm to be upgraded (10 left)
oc get subscription.operators.coreos.com  -n cloudpak-all-in-one -o jsonpath='{.status.installedCSV}' | grep -w v4.0
[INFO] RETRYING: Waiting for operator ibm-odlm to be upgraded (9 left)
```

The root case is that the cmd to get `sub_name` will not be evaluated every time when we evaluate the entire condition - `result=$(eval "${condition}")`.

As a workaround, we does not rely on `sub_name` anymore, instead we use label and package_name to get subscription directly
```
[INFO] Waiting for operator ibm-odlm to be upgraded
oc get subscription.operators.coreos.com -l operators.coreos.com/ibm-odlm.cloudpak-all-in-one='' -n cloudpak-all-in-one -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w v4.0
[INFO] RETRYING: Waiting for operator ibm-odlm to be upgraded (10 left)
oc get subscription.operators.coreos.com -l operators.coreos.com/ibm-odlm.cloudpak-all-in-one='' -n cloudpak-all-in-one -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w v4.0
[INFO] RETRYING: Waiting for operator ibm-odlm to be upgraded (9 left)
oc get subscription.operators.coreos.com -l operators.coreos.com/ibm-odlm.cloudpak-all-in-one='' -n cloudpak-all-in-one -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w v4.0
[✔] Operator ibm-odlm is upgraded to latest version in channel v4.0
```