### PR TITLE
Specify a default admin username for IM/IAM

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -52,20 +52,21 @@ type CommonServiceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	Features            *Features            `json:"features,omitempty"`
-	InstallPlanApproval olmv1alpha1.Approval `json:"installPlanApproval,omitempty"`
-	ManualManagement    bool                 `json:"manualManagement,omitempty"`
-	FipsEnabled         bool                 `json:"fipsEnabled,omitempty"`
-	RouteHost           string               `json:"routeHost,omitempty"`
-	Size                string               `json:"size,omitempty"`
-	Services            []ServiceConfig      `json:"services,omitempty"`
-	StorageClass        string               `json:"storageClass,omitempty"`
-	BYOCACertificate    bool                 `json:"BYOCACertificate,omitempty"`
-	ProfileController   string               `json:"profileController,omitempty"`
-	ServicesNamespace   ServicesNamespace    `json:"servicesNamespace,omitempty"`
-	OperatorNamespace   OperatorNamespace    `json:"operatorNamespace,omitempty"`
-	CatalogName         CatalogName          `json:"catalogName,omitempty"`
-	CatalogNamespace    CatalogNamespace     `json:"catalogNamespace,omitempty"`
+	Features             *Features            `json:"features,omitempty"`
+	InstallPlanApproval  olmv1alpha1.Approval `json:"installPlanApproval,omitempty"`
+	ManualManagement     bool                 `json:"manualManagement,omitempty"`
+	FipsEnabled          bool                 `json:"fipsEnabled,omitempty"`
+	RouteHost            string               `json:"routeHost,omitempty"`
+	Size                 string               `json:"size,omitempty"`
+	Services             []ServiceConfig      `json:"services,omitempty"`
+	StorageClass         string               `json:"storageClass,omitempty"`
+	BYOCACertificate     bool                 `json:"BYOCACertificate,omitempty"`
+	ProfileController    string               `json:"profileController,omitempty"`
+	ServicesNamespace    ServicesNamespace    `json:"servicesNamespace,omitempty"`
+	OperatorNamespace    OperatorNamespace    `json:"operatorNamespace,omitempty"`
+	CatalogName          CatalogName          `json:"catalogName,omitempty"`
+	CatalogNamespace     CatalogNamespace     `json:"catalogNamespace,omitempty"`
+	DefaultAdminUsername string               `json:"defaultAdminUsername,omitempty"`
 
 	// +optional
 	License LicenseList `json:"license"`

--- a/bundle/manifests/operator.ibm.com_commonservices.yaml
+++ b/bundle/manifests/operator.ibm.com_commonservices.yaml
@@ -44,6 +44,8 @@ spec:
                 type: string
               catalogNamespace:
                 type: string
+              defaultAdminUsername:
+                type: string
               features:
                 description: Features defines the configurations of Cloud Pak Services
                 properties:

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -42,6 +42,8 @@ spec:
                 type: string
               catalogNamespace:
                 type: string
+              defaultAdminUsername:
+                type: string
               features:
                 description: Features defines the configurations of Cloud Pak Services
                 properties:

--- a/controllers/constant/defaultAdminUser.go
+++ b/controllers/constant/defaultAdminUser.go
@@ -27,9 +27,4 @@ const DefaultAdminUserTemplate = `
     authentication:
       config:
         defaultAdminUser: placeholder
-- name: ibm-iam-operator
-  spec:
-    authentication:
-      config:
-        defaultAdminUser: placeholder
 `

--- a/controllers/constant/defaultAdminUser.go
+++ b/controllers/constant/defaultAdminUser.go
@@ -1,0 +1,35 @@
+//
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package constant
+
+const DefaultAdminUserTemplate = `
+- name: ibm-im-operator
+  spec:
+    authentication:
+      config:
+        defaultAdminUser: placeholder
+- name: ibm-im-operator-v4.0
+  spec:
+    authentication:
+      config:
+        defaultAdminUser: placeholder
+- name: ibm-iam-operator
+  spec:
+    authentication:
+      config:
+        defaultAdminUser: placeholder
+`

--- a/controllers/render_template.go
+++ b/controllers/render_template.go
@@ -54,6 +54,16 @@ func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured, i
 		newConfigs = append(newConfigs, routeHostConfig...)
 	}
 
+	// Specify default Admin Username
+	if cs.Object["spec"].(map[string]interface{})["defaultAdminUsername"] != nil {
+		klog.Info("Changing the default admin username")
+		adminUsernameConfig, err := convertStringToSlice(strings.ReplaceAll(constant.DefaultAdminUserTemplate, "placeholder", cs.Object["spec"].(map[string]interface{})["defaultAdminUsername"].(string)))
+		if err != nil {
+			return nil, nil, err
+		}
+		newConfigs = append(newConfigs, adminUsernameConfig...)
+	}
+
 	// Update multipleInstancesEnabled when multi-instances
 	if r.Bootstrap.MultiInstancesEnable {
 		klog.Info("Applying multipleInstancesEnabled configuration")

--- a/controllers/render_template.go
+++ b/controllers/render_template.go
@@ -56,7 +56,7 @@ func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured, i
 
 	// Specify default Admin Username
 	if cs.Object["spec"].(map[string]interface{})["defaultAdminUsername"] != nil {
-		klog.Info("Changing the default admin username")
+		klog.Info("Applying the default admin username")
 		adminUsernameConfig, err := convertStringToSlice(strings.ReplaceAll(constant.DefaultAdminUserTemplate, "placeholder", cs.Object["spec"].(map[string]interface{})["defaultAdminUsername"].(string)))
 		if err != nil {
 			return nil, nil, err

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -69,7 +69,6 @@ const ConfigurationRules = `
     authentication:
       config:
         fipsEnabled: LARGEST_VALUE
-        defaultAdminUser: LARGEST_VALUE
       replicas: LARGEST_VALUE
       auditService:
         resources:
@@ -195,7 +194,6 @@ const ConfigurationRules = `
     authentication:
       config:
         fipsEnabled: LARGEST_VALUE
-        defaultAdminUser: LARGEST_VALUE
       replicas: LARGEST_VALUE
       auditService:
         resources:
@@ -242,7 +240,6 @@ const ConfigurationRules = `
     authentication:
       config:
         fipsEnabled: LARGEST_VALUE
-        defaultAdminUser: LARGEST_VALUE
       replicas: LARGEST_VALUE
       auditService:
         resources:

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -69,6 +69,7 @@ const ConfigurationRules = `
     authentication:
       config:
         fipsEnabled: LARGEST_VALUE
+        defaultAdminUser: LARGEST_VALUE
       replicas: LARGEST_VALUE
       auditService:
         resources:
@@ -194,6 +195,7 @@ const ConfigurationRules = `
     authentication:
       config:
         fipsEnabled: LARGEST_VALUE
+        defaultAdminUser: LARGEST_VALUE
       replicas: LARGEST_VALUE
       auditService:
         resources:
@@ -240,6 +242,7 @@ const ConfigurationRules = `
     authentication:
       config:
         fipsEnabled: LARGEST_VALUE
+        defaultAdminUser: LARGEST_VALUE
       replicas: LARGEST_VALUE
       auditService:
         resources:


### PR DESCRIPTION
Provide to specify a default admin username when there is IM/IAM installing
ticket: https://github.ibm.com/ibmprivatecloud/roadmap/issues/57144

#### Verify enhancement
1. Install foudational service v4.0 with image `quay.io/yuchen_shen/cs_operator:admin_username` applied
2. In `CommonService` CRD add property entry for `defaultAdminUsername`
    ```
    spec:
      properties:
        defaultAdminUsername:
          type: string
    ```
3. In `CommonService` CR, try to set an admin username for `defaultAdminUsername` into Spec:
    ```
    spec:
      defaultAdminUsername: admin123
      size: starterset
    ```
4. Check in OperandRegistry, new config will be set under ibm-im/iam-operator
    ```
    - name: ibm-im-operator
      spec:
        authentication:
          config:
            defaultAdminUser: admin123
            onPremMultipleDeploy: true
    ```