### PR TITLE
share ibm-cpp-config to all WATCH_NAMESPACE

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"text/template"
@@ -160,7 +161,7 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 
 func isOCP(mgr manager.Manager, ns string) (bool, error) {
 	config := &corev1.ConfigMap{}
-	if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: "ibm-cpp-config", Namespace: ns}, config); err != nil && !errors.IsNotFound(err) {
+	if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: constant.IBMCPPCONFIG, Namespace: ns}, config); err != nil && !errors.IsNotFound(err) {
 		return false, err
 	} else if errors.IsNotFound(err) {
 		return true, nil
@@ -928,13 +929,13 @@ func CheckClusterType(mgr manager.Manager, ns string) (bool, error) {
 	}
 
 	config := &corev1.ConfigMap{}
-	if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: "ibm-cpp-config", Namespace: ns}, config); err != nil && !errors.IsNotFound(err) {
+	if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: constant.IBMCPPCONFIG, Namespace: ns}, config); err != nil && !errors.IsNotFound(err) {
 		return false, err
 	} else if errors.IsNotFound(err) {
 		if isOCP {
 			return true, nil
 		}
-		klog.Errorf("Configmap %s/ibm-cpp-config is required", ns)
+		klog.Errorf("Configmap %s/%s is required", ns, constant.IBMCPPCONFIG)
 		return false, nil
 	} else {
 		if config.Data["kubernetes_cluster_type"] == "" {
@@ -945,7 +946,7 @@ func CheckClusterType(mgr manager.Manager, ns string) (bool, error) {
 			if isOCP {
 				ocpCluster = "an OCP"
 			}
-			klog.Errorf("cluster type isn't correct, kubernetes_cluster_type in configmap %s/ibm-cpp-config is %s, but the cluster is %s environment", ns, config.Data["kubernetes_cluster_type"], ocpCluster)
+			klog.Errorf("cluster type isn't correct, kubernetes_cluster_type in configmap %s/%s is %s, but the cluster is %s environment", ns, constant.IBMCPPCONFIG, config.Data["kubernetes_cluster_type"], ocpCluster)
 			return false, nil
 		}
 
@@ -1151,16 +1152,16 @@ func (b *Bootstrap) PropagateDefaultCR(instance *apiv3.CommonService) error {
 					csKey := types.NamespacedName{Name: constant.MasterCR, Namespace: watchNamespace}
 					existingCsInstance := &apiv3.CommonService{}
 					if err := b.Client.Get(ctx, csKey, existingCsInstance); err != nil {
-						return fmt.Errorf("could not get cloned CommonServiceCR in namespace %s: %v", watchNamespace, err)
+						return fmt.Errorf("Failed to get cloned CommonService CR in namespace %s: %v", watchNamespace, err)
 					}
 					if needUpdate := util.CompareCsCR(copiedCsInstance, existingCsInstance); needUpdate {
 						copiedCsInstance.SetResourceVersion(existingCsInstance.GetResourceVersion())
 						if err := b.Client.Update(ctx, copiedCsInstance); err != nil {
-							return fmt.Errorf("could not update cloned CommonServiceCR in namespace %s: %v", watchNamespace, err)
+							return fmt.Errorf("Failed to update cloned CommonService CR in namespace %s: %v", watchNamespace, err)
 						}
 					}
 				} else {
-					return fmt.Errorf("could not create cloned CommonServiceCR in namespace %s: %v", watchNamespace, err)
+					return fmt.Errorf("Failed to create cloned CommonService CR in namespace %s: %v", watchNamespace, err)
 				}
 			}
 		}
@@ -1183,4 +1184,47 @@ func IdentifyCPFSNs(r client.Reader, operatorNs string) (string, error) {
 		cpfsNs = csCR.Status.ConfigStatus.OperatorPlane.OperatorNamespace
 	}
 	return string(cpfsNs), nil
+}
+
+func (b *Bootstrap) PropagateCPPConfig(instance *corev1.ConfigMap) error {
+	// Copy Master CR into namespace in WATCH_NAMESPACE list
+	watchNamespaceList := strings.Split(b.CSData.WatchNamespaces, ",")
+
+	// Do not copy ibm-cpp-config in AllNamespace Mode
+	if len(watchNamespaceList) > 1 {
+		for _, watchNamespace := range watchNamespaceList {
+			if watchNamespace == instance.Namespace {
+				continue
+			}
+			copiedCPPConfigMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constant.IBMCPPCONFIG,
+					Namespace: watchNamespace,
+				},
+				Data: instance.Data,
+			}
+
+			if err := b.Client.Create(ctx, copiedCPPConfigMap); err != nil {
+				if errors.IsAlreadyExists(err) {
+					cmKey := types.NamespacedName{Name: constant.IBMCPPCONFIG, Namespace: watchNamespace}
+					existingCM := &corev1.ConfigMap{}
+					if err := b.Client.Get(ctx, cmKey, existingCM); err != nil {
+						return fmt.Errorf("Failed to get %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
+					}
+					if !reflect.DeepEqual(copiedCPPConfigMap.Data, existingCM.Data) {
+						copiedCPPConfigMap.SetResourceVersion(existingCM.GetResourceVersion())
+						if err := b.Client.Update(ctx, copiedCPPConfigMap); err != nil {
+							return fmt.Errorf("Failed to update %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
+						}
+						klog.Infof("Global CPP config %s/%s is updated", watchNamespace, constant.IBMCPPCONFIG)
+					}
+				} else {
+					return fmt.Errorf("Failed to create cloned %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
+				}
+			} else {
+				klog.Infof("Global CPP config %s/%s is propagated to namespace %s", b.CSData.ServicesNs, constant.IBMCPPCONFIG, watchNamespace)
+			}
+		}
+	}
+	return nil
 }

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1152,16 +1152,16 @@ func (b *Bootstrap) PropagateDefaultCR(instance *apiv3.CommonService) error {
 					csKey := types.NamespacedName{Name: constant.MasterCR, Namespace: watchNamespace}
 					existingCsInstance := &apiv3.CommonService{}
 					if err := b.Client.Get(ctx, csKey, existingCsInstance); err != nil {
-						return fmt.Errorf("Failed to get cloned CommonService CR in namespace %s: %v", watchNamespace, err)
+						return fmt.Errorf("failed to get cloned CommonService CR in namespace %s: %v", watchNamespace, err)
 					}
 					if needUpdate := util.CompareCsCR(copiedCsInstance, existingCsInstance); needUpdate {
 						copiedCsInstance.SetResourceVersion(existingCsInstance.GetResourceVersion())
 						if err := b.Client.Update(ctx, copiedCsInstance); err != nil {
-							return fmt.Errorf("Failed to update cloned CommonService CR in namespace %s: %v", watchNamespace, err)
+							return fmt.Errorf("failed to update cloned CommonService CR in namespace %s: %v", watchNamespace, err)
 						}
 					}
 				} else {
-					return fmt.Errorf("Failed to create cloned CommonService CR in namespace %s: %v", watchNamespace, err)
+					return fmt.Errorf("failed to create cloned CommonService CR in namespace %s: %v", watchNamespace, err)
 				}
 			}
 		}
@@ -1209,17 +1209,17 @@ func (b *Bootstrap) PropagateCPPConfig(instance *corev1.ConfigMap) error {
 					cmKey := types.NamespacedName{Name: constant.IBMCPPCONFIG, Namespace: watchNamespace}
 					existingCM := &corev1.ConfigMap{}
 					if err := b.Client.Get(ctx, cmKey, existingCM); err != nil {
-						return fmt.Errorf("Failed to get %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
+						return fmt.Errorf("failed to get %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
 					}
 					if !reflect.DeepEqual(copiedCPPConfigMap.Data, existingCM.Data) {
 						copiedCPPConfigMap.SetResourceVersion(existingCM.GetResourceVersion())
 						if err := b.Client.Update(ctx, copiedCPPConfigMap); err != nil {
-							return fmt.Errorf("Failed to update %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
+							return fmt.Errorf("failed to update %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
 						}
 						klog.Infof("Global CPP config %s/%s is updated", watchNamespace, constant.IBMCPPCONFIG)
 					}
 				} else {
-					return fmt.Errorf("Failed to create cloned %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
+					return fmt.Errorf("failed to create cloned %s ConfigMap in namespace %s: %v", constant.IBMCPPCONFIG, watchNamespace, err)
 				}
 			} else {
 				klog.Infof("Global CPP config %s/%s is propagated to namespace %s", b.CSData.ServicesNs, constant.IBMCPPCONFIG, watchNamespace)

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -82,8 +82,10 @@ const (
 	CSCACertificate = "cs-ca-certificate"
 	// CertManagerSub is the name of ibm-cert-manager-operator subscription
 	CertManagerSub = "ibm-cert-manager-operator"
-	//CsClonedFromLabel is the label used to label the CommonService CR are cloned from the default CR in operatorNamespace
+	// CsClonedFromLabel is the label used to label the CommonService CR are cloned from the default CR in operatorNamespace
 	CsClonedFromLabel = "operator.ibm.com/common-services.cloned-from"
+	// IBMCPPCONFIG is the name of ibm-cpp-config ConfigMap
+	IBMCPPCONFIG = "ibm-cpp-config"
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/controllers/goroutines/cppConfig.go
+++ b/controllers/goroutines/cppConfig.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
 	collector "github.com/IBM/ibm-common-service-operator/controllers/configurationCollector"
+	"github.com/IBM/ibm-common-service-operator/controllers/constant"
 )
 
 // CreateUpdateConfig deploys config builder for global cpp configmap
@@ -35,10 +36,10 @@ func CreateUpdateConfig(bs *bootstrap.Bootstrap) {
 
 	for {
 		config := &corev1.ConfigMap{}
-		if err := bs.Client.Get(context.TODO(), types.NamespacedName{Name: "ibm-cpp-config", Namespace: bs.CSData.ServicesNs}, config); err != nil && !errors.IsNotFound(err) {
+		if err := bs.Client.Get(context.TODO(), types.NamespacedName{Name: constant.IBMCPPCONFIG, Namespace: bs.CSData.ServicesNs}, config); err != nil && !errors.IsNotFound(err) {
 			continue
 		} else if errors.IsNotFound(err) {
-			config.ObjectMeta.Name = "ibm-cpp-config"
+			config.ObjectMeta.Name = constant.IBMCPPCONFIG
 			config.ObjectMeta.Namespace = bs.CSData.ServicesNs
 			config.Data = make(map[string]string)
 			config.Data = collector.Buildconfig(config.Data, bs)
@@ -46,7 +47,7 @@ func CreateUpdateConfig(bs *bootstrap.Bootstrap) {
 				time.Sleep(1 * time.Second)
 				continue
 			}
-			klog.Infof("Global CPP config %s/%s is created", "ibm-cpp-config", bs.CSData.ServicesNs)
+			klog.Infof("Global CPP config %s/%s is created", bs.CSData.ServicesNs, constant.IBMCPPCONFIG)
 		} else {
 			orgConfig := config.DeepCopy()
 			config.Data = collector.Buildconfig(config.Data, bs)
@@ -55,9 +56,13 @@ func CreateUpdateConfig(bs *bootstrap.Bootstrap) {
 					time.Sleep(1 * time.Second)
 					continue
 				}
-				klog.Infof("Global CPP config %s/%s is updated", "ibm-cpp-config", bs.CSData.ServicesNs)
+				klog.Infof("Global CPP config %s/%s is updated", bs.CSData.ServicesNs, constant.IBMCPPCONFIG)
 			}
-
+			if err := bs.PropagateCPPConfig(config); err != nil {
+				klog.Error(err)
+				time.Sleep(1 * time.Second)
+				continue
+			}
 		}
 		time.Sleep(10 * time.Minute)
 	}

--- a/controllers/goroutines/variables.go
+++ b/controllers/goroutines/variables.go
@@ -16,12 +16,14 @@
 
 package goroutines
 
+import "github.com/IBM/ibm-common-service-operator/controllers/constant"
+
 var (
 	OperatorAPIGroupVersion = "operator.ibm.com/v1"
 
 	SecretShareAPIGroupVersion = "ibmcpcs.ibm.com/v1"
 	SecretShareKind            = "SecretShare"
-	SecretShareCppName         = "ibm-cpp-config"
+	SecretShareCppName         = constant.IBMCPPCONFIG
 
 	IAMSaaSDeployNames = []string{"platform-identity-management", "platform-identity-provider", "platform-auth-service"}
 	IAMDeployNames     = []string{"platform-identity-management", "platform-identity-provider", "platform-auth-service"}

--- a/main.go
+++ b/main.go
@@ -260,7 +260,7 @@ func main() {
 		}
 	} else {
 		klog.Infof("Common Service Operator goes dormant in the namespace %s", operatorNs)
-		klog.Infof("Common Service Operator in the namespace %s takes charge of resource managemet", cpfsNs)
+		klog.Infof("Common Service Operator in the namespace %s takes charge of resource management", cpfsNs)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
`ibm-cpp-config` will be copied from `servicesNamespace` to all other namespace in the `WATCH_NAMESPACE` list.

### How to test
1. Deploy `cd` CatalogSource
2. Install cert-manager cluster wide
3. Using `setup_tenant.sh` to install CS in advanced topology including different operator and service namespace, as well as other tethered(CloudPak) namespace
4. Replace CS operator image by `quay.io/daniel_fan/common-service-operator-amd64:dev`
5. We will observe the `ibm-cpp-config` showing up in all namespaces in the tenant.
6. If we manually change the content in `ibm-cpp-config` ConfigMap, it will propagate the changes to other namespaces in 10 min.