### PR TITLE
Pass in a correct source name for cert manager argument

### DIFF
--- a/cp3pt0-deployment/migrate_singleton.sh
+++ b/cp3pt0-deployment/migrate_singleton.sh
@@ -71,11 +71,11 @@ function main() {
         arguments+=" --enable-private-catalog"
     fi
 
-    argument+=" --cert-manager-source $CERT_MANAGER_SOURCE"
-    argument+=" --licensing-source $LICENSING_SOURCE"
-    argument+=" -c $CHANNEL"
-    argument+=" -cmNs $CERT_MANAGER_NAMESPACE"
-    argument+=" -licensingNs $LICENSING_NAMESPACE" 
+    arguments+=" --cert-manager-source $CERT_MANAGER_SOURCE"
+    arguments+=" --licensing-source $LICENSING_SOURCE"
+    arguments+=" -c $CHANNEL"
+    arguments+=" -cmNs $CERT_MANAGER_NAMESPACE"
+    arguments+=" -licensingNs $LICENSING_NAMESPACE" 
 
     # Install New CertManager and Licensing, supporting new CatalogSource
     ${BASE_DIR}/setup_singleton.sh "$arguments"


### PR DESCRIPTION
fix for the issue: [57978](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57978#issuecomment-55822700)
When there is a value of `--cert-manager-source` passed in, but cert-manager subscription did not create with a expected source name.