### PR TITLE
continue to run the in-place upgrade script even the sub was updated

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -674,25 +674,25 @@ function compare_semantic_version() {
     # Compare the versions
     if [[ $major1 -gt $major2 ]]; then
         info "$1 is greater than $2"
-        return 0
+        return 1
     elif [[ $major1 -lt $major2 ]]; then
         info "$1 is less than $2"
         return 2
     elif [[ $minor1 -gt $minor2 ]]; then
         info "$1 is greater than $2"
-        return 0
+        return 1
     elif [[ $minor1 -lt $minor2 ]]; then
         info "$1 is less than $2"
         return 2
     elif [[ $patch1 -gt $patch2 ]]; then
         info "$1 is greater than $2"
-        return 0
+        return 1
     elif [[ $patch1 -lt $patch2 ]]; then
         info "$1 is less than $2"
         return 2
     else
         info "$1 is equal to $2"
-        return 3
+        return 0
     fi
 }
 
@@ -727,18 +727,17 @@ function update_operator() {
     existing_catalogsource=$(yq eval '.spec.source' sub.yaml)
 
     compare_semantic_version $existing_channel $channel
-    return_value1=$?
+    return_channel_value=$?
 
     compare_catalogsource $existing_catalogsource $source
-    return_value2=$?
+    return_catsrc_value=$?
 
-    if [[ $return_value1 -eq 0 || $return_value2 -eq 1 ]]; then
-        info "$package_name is ready for updaing the subscription."
-    elif [[ $return_value1 -ne 2 ]]; then
+    if [[ $return_channel_value -eq 1 ]]; then
         error "Failed to update channel subscription ${package_name} in ${ns}"
-    elif [[ $return_value1 -eq 3 && $return_value2 -eq 0 ]]; then
-        info "$package_name already has updated channel $existing_channel and catalogsource $existing_catalogsource in the subscription."
-        return 0
+    elif [[ $return_channel_value -eq 2 || $return_catsrc_value -eq 1 ]]; then
+        info "$package_name is ready for updaing the subscription."      
+    elif [[ $return_channel_value -eq 0 && $return_catsrc_value -eq 0 ]]; then
+        info "$package_name has already updated channel $existing_channel and catalogsource $existing_catalogsource in the subscription."
     fi
 
     yq -i eval 'select(.kind == "Subscription") | .spec += {"channel": "'${channel}'"}' sub.yaml

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -244,16 +244,16 @@ function scale_down_cs() {
     existing_channel=$(yq eval '.spec.channel' sub.yaml)
     existing_catalogsource=$(yq eval '.spec.source' sub.yaml)
     compare_semantic_version $existing_channel $CHANNEL
-    return_value1=$?
+    return_channel_value=$?
 
     compare_catalogsource $existing_catalogsource $SOURCE
-    return_value2=$?
+    return_catsrc_value=$?
 
-    if [[ $return_value1 -eq 0 || $return_value2 -eq 1 ]]; then
+    if [[ $return_channel_value -eq 1 ]]; then 
+        error "Must provide correct channel. The channel $CHANNEl is less than $existing_channel found in subscription ibm-common-service-operator in $OPERATOR_NS"
+    elif [[ $return_channel_value -eq 2 || $return_catsrc_value -eq 1 ]]; then
         info "$package_name is ready for scaling down."
-    elif [[ $return_value1 -ne 2 ]]; then
-        error "Must provide correct channel. The channel $existing_channel is found in subscription ibm-common-service-operator in $OPERATOR_NS"
-    elif [[ $return_value1 -eq 3 && $return_value2 -eq 0 ]]; then
+    elif [[ $return_channel_value -eq 0 && $return_catsrc_value -eq 0 ]]; then
         info "$package_name already has updated channel $existing_channel and catalogsource $existing_catalogsource in the subscription."
         return 0
     fi


### PR DESCRIPTION
for the issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57978#issuecomment-55770004
#### Verify the fix
Given the same channel and catalogsource info as the existing one, upgrade will continue
log:
```
[INFO] v4.0 is equal to v4.0
[INFO] catalogsource opencloud-operators is the same as opencloud-operators
[INFO] ibm-common-service-operator has already updated channel v4.0 and catalogsource opencloud-operators in the subscription.
subscription.operators.coreos.com/ibm-common-service-operator configured
```