### PR TITLE
migrate_singleton.sh should exit script and return error

### DIFF
--- a/cp3pt0-deployment/migrate_singleton.sh
+++ b/cp3pt0-deployment/migrate_singleton.sh
@@ -79,6 +79,9 @@ function main() {
 
     # Install New CertManager and Licensing, supporting new CatalogSource
     ${BASE_DIR}/setup_singleton.sh "$arguments"
+    if [ $? -ne 0 ]; then
+        error "Migration is failed when setting up signleton services\n"
+    fi
 
     success "Migration is completed for Cloud Pak 3.0 Foundational singleton services."
 }


### PR DESCRIPTION
for ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58233
```
[INFO] Creating following Subscription:

apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: ibm-cert-manager-operator
  namespace: ibm-cert-manager
spec:
  channel: v4.0
  installPlanApproval: Automatic
  name: ibm-cert-manager-operator
  source: ibm-cert-manager-catalog
  sourceNamespace: openshift-marketplace
subscription.operators.coreos.com/ibm-cert-manager-operator created
[INFO] Waiting for operator ibm-cert-manager-operator in namespace ibm-cert-manager to be made available
[INFO] RETRYING: Waiting for operator ibm-cert-manager-operator in namespace ibm-cert-manager to be made available (1 left)
[✘] Timeout after 0 minutes waiting for ibm-cert-manager-operator in namespace ibm-cert-manager to become available
[✘] Migration is failed when setting up signleton services


```