### PR TITLE
throw out error when webhook server fail to set up

### DIFF
--- a/controllers/webhooks/operator_webhooks.go
+++ b/controllers/webhooks/operator_webhooks.go
@@ -245,7 +245,7 @@ func createService(ctx context.Context, client k8sclient.Client, owner ownerutil
 func (webhookConfig *CSWebhookConfig) setupCerts(ctx context.Context, client k8sclient.Client, serviceNamespace string) error {
 	// Wait for the secret to te created
 	secret := &corev1.Secret{}
-	err := wait.PollImmediate(time.Second*1, time.Second*30, func() (bool, error) {
+	err := wait.PollImmediate(time.Second*5, time.Minute*3, func() (bool, error) {
 		// it should be cs-ca-certificate-secret
 		err := client.Get(ctx, k8sclient.ObjectKey{Namespace: serviceNamespace, Name: caCertSecretName}, secret)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -256,7 +256,8 @@ func main() {
 		}
 		// Start up the webhook server if it is ocp
 		if err := webhooks.SetupWebhooks(mgr, bs); err != nil {
-			klog.Error(err, "Error setting up webhook server")
+			klog.Errorf("Error setting up webhook server: %v", err)
+			os.Exit(1)
 		}
 	} else {
 		klog.Infof("Common Service Operator goes dormant in the namespace %s", operatorNs)


### PR DESCRIPTION
- Exit code when webhook server is failed to stand up
- Extend wait time for CA cert secret to 3 minutes
- ~~Update annotation to inject CA from secret~~