### PR TITLE
remove exit code for webhook server

### DIFF
--- a/controllers/webhooks/operator_webhooks.go
+++ b/controllers/webhooks/operator_webhooks.go
@@ -245,11 +245,12 @@ func createService(ctx context.Context, client k8sclient.Client, owner ownerutil
 func (webhookConfig *CSWebhookConfig) setupCerts(ctx context.Context, client k8sclient.Client, serviceNamespace string) error {
 	// Wait for the secret to te created
 	secret := &corev1.Secret{}
-	err := wait.PollImmediate(time.Second*5, time.Minute*3, func() (bool, error) {
+	err := wait.PollImmediateInfinite(time.Second*5, func() (bool, error) {
 		// it should be cs-ca-certificate-secret
 		err := client.Get(ctx, k8sclient.ObjectKey{Namespace: serviceNamespace, Name: caCertSecretName}, secret)
 		if err != nil {
 			if errors.IsNotFound(err) {
+				klog.Infof("wait for CA secret %v/%v", serviceNamespace, caCertSecretName)
 				return false, nil
 			}
 			return false, err

--- a/main.go
+++ b/main.go
@@ -257,7 +257,6 @@ func main() {
 		// Start up the webhook server if it is ocp
 		if err := webhooks.SetupWebhooks(mgr, bs); err != nil {
 			klog.Errorf("Error setting up webhook server: %v", err)
-			os.Exit(1)
 		}
 	} else {
 		klog.Infof("Common Service Operator goes dormant in the namespace %s", operatorNs)


### PR DESCRIPTION
We have a historic issue that it always returns error on webhook server setup.
```
E0420 17:28:39.632613 1 main.go:259] expected pointer, but got invalid kindError setting up webhook server
```

Check history here: https://github.com/IBM/ibm-common-service-operator/pull/1023#issuecomment-1432607872