### PR TITLE
Consolidate migrate_singleton.sh and setup_singleton.sh script

### DIFF
--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -14,16 +14,8 @@ OC=oc
 YQ=yq
 OPERATOR_NS=""
 CONTROL_NS=""
-CHANNEL="v4.0"
-CERT_MANAGER_SOURCE="ibm-cert-manager-catalog"
-LICENSING_SOURCE="ibm-licensing-catalog"
 SOURCE_NS="openshift-marketplace"
-INSTALL_MODE="Automatic"
-CERT_MANAGER_NAMESPACE="ibm-cert-manager"
-LICENSING_NAMESPACE="ibm-licensing"
 ENABLE_LICENSING=0
-ENABLE_PRIVATE_CATALOG=0
-SKIP_SETUP_SINGLETON=0
 NEW_MAPPING=""
 NEW_TENANT=0
 DEBUG=0
@@ -39,13 +31,11 @@ STEP=0
 
 # ---------- Main functions ----------
 
-. ${BASE_DIR}/common/utils.sh
+. ${BASE_DIR}/utils.sh
 
 function main() {
     parse_arguments "$@"
     pre_req
-
-    local arguments=""
 
     if [ "$CONTROL_NS" == "$OPERATOR_NS" ]; then
         # Delete CP2.0 Cert-Manager CR
@@ -54,35 +44,17 @@ function main() {
         delete_operator "ibm-cert-manager-operator" "$CONTROL_NS"
     else
         # Delgation of CP2 Cert Manager
-        ${BASE_DIR}/common/delegate_cp2_cert_manager.sh --control-namespace $CONTROL_NS "--skip-user-vertify"
+        ${BASE_DIR}/delegate_cp2_cert_manager.sh --control-namespace $CONTROL_NS "--skip-user-vertify"
     fi
     
     if [[ $ENABLE_LICENSING -eq 1 ]] && [[ "$CONTROL_NS" == "$OPERATOR_NS" ]]; then
         # Migrate Licensing Services Data
-        ${BASE_DIR}/common/migrate_cp2_licensing.sh --control-namespace $CONTROL_NS "--skip-user-vertify"
+        ${BASE_DIR}/migrate_cp2_licensing.sh --control-namespace $CONTROL_NS "--skip-user-vertify"
         # Delete IBM Licensing Service instance
         ${OC} delete --ignore-not-found ibmlicensing instance
         # Delete licensing csv/subscriptions
         delete_operator "ibm-licensing-operator" "$CONTROL_NS"
 
-        arguments+=" --enable-licensing"
-    fi
-
-    if [[ $ENABLE_PRIVATE_CATALOG -eq 1 ]]; then
-        arguments+=" --enable-private-catalog"
-    fi
-
-    arguments+=" --cert-manager-source $CERT_MANAGER_SOURCE"
-    arguments+=" --licensing-source $LICENSING_SOURCE"
-    arguments+=" -c $CHANNEL"
-    arguments+=" -cmNs $CERT_MANAGER_NAMESPACE"
-    arguments+=" -licensingNs $LICENSING_NAMESPACE" 
-    if [[ $SKIP_SETUP_SINGLETON -eq 0 ]]; then
-        # Install New CertManager and Licensing, supporting new CatalogSource
-        ${BASE_DIR}/setup_singleton.sh "$arguments"
-        if [ $? -ne 0 ]; then
-            error "Migration is failed when setting up signleton services\n"
-        fi
     fi
 
     success "Migration is completed for Cloud Pak 3.0 Foundational singleton services."
@@ -106,32 +78,6 @@ function parse_arguments() {
             ;;
         --enable-licensing)
             ENABLE_LICENSING=1
-            ;;
-        --enable-private-catalog)
-            ENABLE_PRIVATE_CATALOG=1
-            ;;
-        --skip-setup-signleton)
-            SKIP_SETUP_SINGLETON=1
-            ;;
-        -c | --channel)
-            shift
-            CHANNEL=$1
-            ;;
-        --cert-manager-source)
-            shift
-            CERT_MANAGER_SOURCE=$1
-            ;;
-        --licensing-source)
-            shift
-            LICENSING_SOURCE=$1
-            ;;
-        -cmNs | --cert-manager-namespace)
-            shift
-            CERT_MANAGER_NAMESPACE=$1
-            ;;
-        -licensingNs | --licensing-namespace)
-            shift
-            LICENSING_NAMESPACE=$1
             ;;
         -v | --debug)
             shift
@@ -160,40 +106,18 @@ function print_usage() {
     echo "   --oc string                                    File path to oc CLI. Default uses oc in your PATH"
     echo "   --yq string                                    File path to yq CLI. Default uses yq in your PATH"
     echo "   --operator-namespace string                    Required. Namespace to migrate Foundational services operator"
-    echo "   --enable-private-catalog                       Set this flag to use namespace scoped CatalogSource. Default is in openshift-marketplace namespace"
-    echo "   --cert-manager-source string                   CatalogSource name of ibm-cert-manager-operator. This assumes your CatalogSource is already created. Default is ibm-cert-manager-operator-catalog"
-    echo "   --licensing-source string                      CatalogSource name of ibm-licensing. This assumes your CatalogSource is already created. Default is ibm-licensing-catalog"
-    echo "   -cmNs, --cert-manager-namespace string         Set custom namespace for ibm-cert-manager-operator. Default is ibm-cert-manager"
-    echo "   -licensingNs, --licensing-namespace string     Set custom namespace for ibm-licensing-operator. Default is ibm-licensing"
-    echo "   --enable-licensing                             Set this flag to migrate ibm-licensing-operator"
-    echo "   -c, --channel string                           Channel for Subscription(s). Default is v4.0"   
-    echo "   -i, --install-mode string                      InstallPlan Approval Mode. Default is Automatic. Set to Manual for manual approval mode"
     echo "   -v, --debug integer                            Verbosity of logs. Default is 0. Set to 1 for debug logs."
     echo "   -h, --help                                     Print usage information"
     echo ""
 }
 
 function pre_req() {
-    check_command "${OC}"
-
-    # checking oc command logged in
-    user=$(${OC} whoami 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        error "You must be logged into the OpenShift Cluster from the oc command line"
-    else
-        success "oc command logged in as ${user}"
-    fi
-
     if [ "$OPERATOR_NS" == "" ]; then
         error "Must provide operator namespace"
     fi
 
     if [ "$CONTROL_NS" == "" ]; then
         CONTROL_NS=$OPERATOR_NS
-    fi
-
-    if [ $ENABLE_PRIVATE_CATALOG -eq 1 ]; then
-        SOURCE_NS=$OPERATOR_NS
     fi
     
     get_and_validate_arguments

--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -106,6 +106,7 @@ function print_usage() {
     echo "   --oc string                                    File path to oc CLI. Default uses oc in your PATH"
     echo "   --yq string                                    File path to yq CLI. Default uses yq in your PATH"
     echo "   --operator-namespace string                    Required. Namespace to migrate Foundational services operator"
+    echo "   --enable-licensing                             Set this flag to migrate ibm-licensing-operator"
     echo "   -v, --debug integer                            Verbosity of logs. Default is 0. Set to 1 for debug logs."
     echo "   -h, --help                                     Print usage information"
     echo ""

--- a/cp3pt0-deployment/migrate_singleton.sh
+++ b/cp3pt0-deployment/migrate_singleton.sh
@@ -23,6 +23,7 @@ CERT_MANAGER_NAMESPACE="ibm-cert-manager"
 LICENSING_NAMESPACE="ibm-licensing"
 ENABLE_LICENSING=0
 ENABLE_PRIVATE_CATALOG=0
+SKIP_SETUP_SINGLETON=0
 NEW_MAPPING=""
 NEW_TENANT=0
 DEBUG=0
@@ -76,11 +77,12 @@ function main() {
     arguments+=" -c $CHANNEL"
     arguments+=" -cmNs $CERT_MANAGER_NAMESPACE"
     arguments+=" -licensingNs $LICENSING_NAMESPACE" 
-
-    # Install New CertManager and Licensing, supporting new CatalogSource
-    ${BASE_DIR}/setup_singleton.sh "$arguments"
-    if [ $? -ne 0 ]; then
-        error "Migration is failed when setting up signleton services\n"
+    if [ $SKIP_SETUP_SINGLETON -eq 0]; then
+        # Install New CertManager and Licensing, supporting new CatalogSource
+        ${BASE_DIR}/setup_singleton.sh "$arguments"
+        if [ $? -ne 0 ]; then
+            error "Migration is failed when setting up signleton services\n"
+        fi
     fi
 
     success "Migration is completed for Cloud Pak 3.0 Foundational singleton services."
@@ -107,6 +109,9 @@ function parse_arguments() {
             ;;
         --enable-private-catalog)
             ENABLE_PRIVATE_CATALOG=1
+            ;;
+        --skip-setup-signleton)
+            SKIP_SETUP_SINGLETON=1
             ;;
         -c | --channel)
             shift

--- a/cp3pt0-deployment/migrate_singleton.sh
+++ b/cp3pt0-deployment/migrate_singleton.sh
@@ -77,7 +77,7 @@ function main() {
     arguments+=" -c $CHANNEL"
     arguments+=" -cmNs $CERT_MANAGER_NAMESPACE"
     arguments+=" -licensingNs $LICENSING_NAMESPACE" 
-    if [ $SKIP_SETUP_SINGLETON -eq 0]; then
+    if [[ $SKIP_SETUP_SINGLETON -eq 0 ]]; then
         # Install New CertManager and Licensing, supporting new CatalogSource
         ${BASE_DIR}/setup_singleton.sh "$arguments"
         if [ $? -ne 0 ]; then

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -42,6 +42,7 @@ function main() {
     parse_arguments "$@"
     pre_req
     if [ $MIGRATE_SINGLETON -eq 1 ]; then
+        info "found parameter "--operator-namespace", migrating singleton services"
         ${BASE_DIR}/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" "-c" "$CHANNEL" "--cert-manager-source" "$CERT_MANAGER_SOURCE" "--licensing-source" "$LICENSING_SOURCE" "--skip-setup-signleton" "$arguments"
     fi
 

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -42,8 +42,12 @@ function main() {
     parse_arguments "$@"
     pre_req
     if [ $MIGRATE_SINGLETON -eq 1 ]; then
-        info "Found parameter "--operator-namespace", migrating singleton services"
-        ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS"
+        info "Found parameter '--operator-namespace', migrating singleton services"
+        if [ $ENABLE_LICENSING -eq 1 ]; then
+            ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" "--enable-licensing"
+        else
+            ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" 
+        fi
     fi
 
     install_cert_manager

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -42,8 +42,8 @@ function main() {
     parse_arguments "$@"
     pre_req
     if [ $MIGRATE_SINGLETON -eq 1 ]; then
-        info "found parameter "--operator-namespace", migrating singleton services"
-        ${BASE_DIR}/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" "-c" "$CHANNEL" "--cert-manager-source" "$CERT_MANAGER_SOURCE" "--licensing-source" "$LICENSING_SOURCE" "--skip-setup-signleton" "$arguments"
+        info "Found parameter "--operator-namespace", migrating singleton services"
+        ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS"
     fi
 
     install_cert_manager


### PR DESCRIPTION
For ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58360

How to test it:
run `./setup_singleton.sh --operator-namespace <operator_ns>` 
it will get the control namespace and do the migration for CP2 Instance,