### PR TITLE
yq not able to read json input causing line 633 to fail

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -623,7 +623,7 @@ function get_control_namespace() {
     local config_map_name="common-service-maps"
 
     # Get the ConfigMap data
-    config_map_data=$(${OC} get configmap "${config_map_name}" -n kube-public -o jsonpath='{.data.common-service-maps\.yaml}')
+    config_map_data=$(${OC} get configmap "${config_map_name}" -n kube-public -o yaml | yq '.data[]')
 
     # Check if the ConfigMap exists
     if [[ -z "${config_map_data}" ]]; then


### PR DESCRIPTION
Kaihua mentioned seeing this error:
```
root@stc1:~/ibm-common-service-operator# ./cp3pt0-deployment/migrate_singleton.sh --operator-namespace cs-control --enable-private-catalog
[✔] oc command available
[✔] oc command logged in as kube:admin
Error: unknown shorthand flag: 'r' in -r
Usage:
  yq [flags]
  yq [command]
```
The oc lines are from the prereq function, then the yq failure with -r is from line 633 in utils.sh as the `get_control_namespace` function is more or less the next thing executed in the script. It looks like we try to create the `config_map_data` variable using a jsonpath and then try to read it with yq with `yq -r '.controlNamespace'`. I think as long as we use yq we should stay consist in outputting files in yaml and not mix and matching with json.