### PR TITLE
deny updating in non master CommonService CR

### DIFF
--- a/controllers/webhooks/commonservice/validatingwebhook.go
+++ b/controllers/webhooks/commonservice/validatingwebhook.go
@@ -141,9 +141,8 @@ func (r *Defaulter) CheckNamespace(name string) (bool, error) {
 func (r *Defaulter) CheckConfig(config, parameter string) bool {
 	if config == "" {
 		return false
-	} else {
-		return config != parameter
 	}
+	return config != parameter
 }
 
 func (r *Defaulter) InjectDecoder(decoder *admission.Decoder) error {

--- a/controllers/webhooks/commonservice/validatingwebhook.go
+++ b/controllers/webhooks/commonservice/validatingwebhook.go
@@ -83,14 +83,14 @@ func (r *Defaulter) Handle(ctx context.Context, req admission.Request) admission
 		operatorNamespace := cs.Spec.OperatorNamespace
 		deniedOperatorNs := r.CheckConfig(string(operatorNamespace), r.Bootstrap.CSData.OperatorNs)
 		if deniedOperatorNs {
-			return admission.Denied(fmt.Sprintf("Operator Namespace: %v is not allowed to configured in namespace %v", operatorNamespace, req.AdmissionRequest.Namespace))
+			return admission.Denied(fmt.Sprintf("Operator Namespace: %v is not allowed to be configured in namespace %v", operatorNamespace, req.AdmissionRequest.Namespace))
 		}
 
 		// check ServicesNamespace
 		servicesNamespace := cs.Spec.ServicesNamespace
 		deniedServicesNs := r.CheckConfig(string(servicesNamespace), r.Bootstrap.CSData.ServicesNs)
 		if deniedServicesNs {
-			return admission.Denied(fmt.Sprintf("Services Namespace: %v is not allowed to configured in namespace %v", servicesNamespace, req.AdmissionRequest.Namespace))
+			return admission.Denied(fmt.Sprintf("Services Namespace: %v is not allowed to be configured in namespace %v", servicesNamespace, req.AdmissionRequest.Namespace))
 		}
 
 		// check CatalogName
@@ -98,14 +98,14 @@ func (r *Defaulter) Handle(ctx context.Context, req admission.Request) admission
 		catalogName := cs.Spec.CatalogName
 		deniedCatalog := r.CheckConfig(string(catalogName), r.Bootstrap.CSData.CatalogSourceName)
 		if deniedCatalog {
-			return admission.Denied(fmt.Sprintf("CatalogSource Name: %v is not allowed to configured in namespace %v", catalogName, req.AdmissionRequest.Namespace))
+			return admission.Denied(fmt.Sprintf("CatalogSource Name: %v is not allowed to be configured in namespace %v", catalogName, req.AdmissionRequest.Namespace))
 		}
 
 		// check CatalogNamespace
 		catalogNamespace := cs.Spec.CatalogNamespace
 		deniedCatalogNs := r.CheckConfig(string(catalogNamespace), r.Bootstrap.CSData.CatalogSourceNs)
 		if deniedCatalogNs {
-			return admission.Denied(fmt.Sprintf("CatalogSource Namespace: %v is not allowed to configured in namespace %v", catalogNamespace, req.AdmissionRequest.Namespace))
+			return admission.Denied(fmt.Sprintf("CatalogSource Namespace: %v is not allowed to be configured in namespace %v", catalogNamespace, req.AdmissionRequest.Namespace))
 		}
 	}
 


### PR DESCRIPTION
action plan implement: https://github.ibm.com/ibmprivatecloud/roadmap/issues/57413#issuecomment-56051304
#### Context

- Updates on the following four `Spec` parameters in non-master CommonService CRs in the scope is prohibited when the updated values are differed from the values in master/default CommonService CR.
- Validating Webhook will validate and deny updates when user are try to change those parameters in other CommonService CRs.

```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
 name: common-service
 namespace: cloudpak-control
spec:
 operatorNamespace: cloudpak-control
 servicesNamespace: cloudpak-data
 catalogName: ibm-operator-catalog
 catalogNamespace: openshift-marketplace
```
#### Test image
quay.io/yuchen_shen/cs_operator:config_status
#### Verified cases
1. Try to edit master/default CommonService CR, will be denied
2. Try to create/edit `Spec` for non master CS CR in the namespaces from `watch_namespace`, will be denied
#### Result screenshot:
 
<img width="1225" alt="Screen Shot 2023-04-21 at 4 17 33 PM" src="https://user-images.githubusercontent.com/59578388/233727059-1d6e2987-2bfc-449f-8c06-c6e4069ef442.png">

<img width="1041" alt="Screen Shot 2023-04-21 at 4 18 15 PM" src="https://user-images.githubusercontent.com/59578388/233727209-61d5f28a-8037-42c9-b952-ddb23f3ed9b4.png">
