### PR TITLE
only check for iam when a zenservice has requested it

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -255,7 +255,7 @@ function check_IAM(){
         do
             zenservice_exists=$(${OC} get zenservice -n $cp_namespace || echo fail)
             if [[ $zenservice_exists != "fail" ]] && [[ $zenservice_exists != "" ]]; then
-                iam_enabled=$(${OC} get zenservice -n $cp_namespace -o yaml | grep iam | awk '{print $2}')
+                iam_enabled=$(${OC} get zenservice -n $cp_namespace -o yaml | grep iamIntegration | awk '{print $2}')
                 if [[ $iam_enabled == "true" ]]; then
                     if [[ $namespaces == "" ]]; then
                         namespaces="$cs_namespace"
@@ -264,6 +264,8 @@ function check_IAM(){
                         namespaces="$namespaces $cs_namespace"
                         break
                     fi
+                else
+                    info "IAM not requested by zenservice in namespace $cp_namespace, skipping wait."
                 fi
             fi
         done


### PR DESCRIPTION
The conversion script waits for iam to come ready in order to reconcile zenservices with the new iam deployment. Ran into an issue during cp4d testing where a zen service did not enable iam so the script failed by timing out waiting for iam and consequently did not reconcile the zenservices that did request iam. This change makes it so we only wait for iam to come ready in the cs namespaces serving zenservices that enable iam.

Test pending