### PR TITLE
fixed isolate.sh to properly exclude namespaces

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -246,7 +246,7 @@ function gather_csmaps_ns() {
     tenant_scope=$(echo "${tenant_scope//,/$'\n'}" | sort -u)
 
     # adding excluded namespaces to the list allows uniq -u to remove duplicates
-    tenant_scope="${tenant_scope},${EXCLUDED_NS}"
+    tenant_scope="${tenant_scope},${EXCLUDED_NS},${EXCLUDED_NS}"
     tenant_scope=$(echo "${tenant_scope//,/$'\n'}" | sort | uniq -u)
     echo "$tenant_scope"
 }


### PR DESCRIPTION
- excluding namespaces made the assumption that the provided namespace(s) were already within the scope of the tenant
- bad assumption because if the provided exclude-ns namespace(s) were not within scope, then isolate would actually add in those namespaces to the scope
- fixed by intentionally duplicating EXCLUDED_NS to the scope variable before passing it though the duplicate removal pipe, so that excluded-ns will always be removed from scope, whether they exist in namespace-scope CM or not