### PR TITLE
update licensing ns for migration

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -57,7 +57,8 @@ function main() {
 
     # Migrate singleton services
     local arguments="--enable-licensing"
-    
+    arguments=" -licensingNs $CONTROL_NS"
+
     if [[ $ENABLE_PRIVATE_CATALOG -eq 1 ]]; then
         arguments+=" --enable-private-catalog"
     fi


### PR DESCRIPTION
To avoid error
```
./cp3pt0-deployment/migrate_tenant.sh --operator-namespace ibm-common-services
[✔] oc command available
[✔] yq command available
[✔] oc command logged in as kube:admin
[✘] Licensing Migration could only be done in controlNamespace, please set parameter '-licensingNs cs-control'
```