### PR TITLE
parse install mode command-line argument

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -150,6 +150,10 @@ function parse_arguments() {
             shift
             CHANNEL=$1
             ;;
+        -i | --install-mode)
+            shift
+            INSTALL_MODE=$1
+            ;;
         -s | --source)
             shift
             SOURCE=$1


### PR DESCRIPTION
Missing `INSTALL_MODE` argument in `parse_arguments` function, and add it back to the migration script