### PR TITLE
licensing-enhancement

### DIFF
--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -23,6 +23,7 @@ LICENSING_SOURCE="ibm-licensing-catalog"
 CERT_MANAGER_NAMESPACE="ibm-cert-manager"
 LICENSING_NAMESPACE="ibm-licensing"
 
+CUSTOMIZED_LICENSING_NAMESPACE=0
 SKIP_INSTALL=0
 CHECK_LICENSING_ONLY=0
 
@@ -94,6 +95,7 @@ function parse_arguments() {
         -licensingNs | --licensing-namespace)
             shift
             LICENSING_NAMESPACE=$1
+            CUSTOMIZED_LICENSING_NAMESPACE=1
             ;;
         -c | --channel)
             shift
@@ -210,8 +212,12 @@ function pre_req() {
     else
         MIGRATE_SINGLETON=1
         get_and_validate_arguments
-        if [[ "$CONTROL_NS" != "$LICENSING_NAMESPACE" ]] && [[ "$ENABLE_LICENSING" == 1 ]]; then
-            error "Licensing Migration could only be done in controlNamespace, please set parameter '-licensingNs $CONTROL_NS'"
+        if [[ "$ENABLE_LICENSING" == 1 ]];then
+            if [[ "$CUSTOMIZED_LICENSING_NAMESPACE" -eq 1 ]] && [[ "$CONTROL_NS" != "$LICENSING_NAMESPACE" ]]; then
+                error "Licensing Migration could only be done in $CONTROL_NS, please do not set parameter '-licensingNs $LICENSING_NAMESPACE'"
+            else 
+                LICENSING_NAMESPACE="${CONTROL_NS}"
+            fi
         fi
     fi
 }


### PR DESCRIPTION
enhancement for ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58360#issuecomment-56394033
If `operator-namespace` is set: 
1. without `--enable-licensing` to only migrate cert-manager
2. with `--enable-licensing` , means we need to migrate licensing. So`--licensingNs` will be optional, but it have to be control-namespace

Test result:

```
root@axe1:~/projects/go/src/ibm-common-service-operator/cp3pt0-deployment# ./setup_singleton.sh --operator-namespace ibm-common-services --enable-licensing -licensingNs cs-control
[✔] oc command available
[✔] oc command logged in as kube:admin
check pass
root@axe1:~/projects/go/src/ibm-common-service-operator/cp3pt0-deployment# ./setup_singleton.sh --operator-namespace ibm-common-services --enable-licensing -licensingNs kube-public
[✔] oc command available
[✔] oc command logged in as kube:admin
[✘] Licensing Migration could only be done in cs-control, please do not set parameter '-licensingNs kube-public'
root@axe1:~/projects/go/src/ibm-common-service-operator/cp3pt0-deployment# ./setup_singleton.sh --operator-namespace ibm-common-services --enable-licensing
[✔] oc command available
[✔] oc command logged in as kube:admin
check pass
root@axe1:~/projects/go/src/ibm-common-service-operator/cp3pt0-deployment# ./setup_singleton.sh --operator-namespace ibm-common-services
[✔] oc command available
[✔] oc command logged in as kube:admin
check pass
```

