### PR TITLE
make sure three cert manger pods are deleted when deactivating cp2 cert manager

### DIFF
--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -40,6 +40,10 @@ function main() {
     if [ "$CONTROL_NS" == "$OPERATOR_NS" ]; then
         # Delete CP2.0 Cert-Manager CR
         ${OC} delete certmanager.operator.ibm.com default --ignore-not-found
+        
+        wait_for_no_pod ${CONTROL_NS} "cert-manager-cainjector"
+        wait_for_no_pod ${CONTROL_NS} "cert-manager-controller"
+        wait_for_no_pod ${CONTROL_NS} "cert-manager-webhook"
         # Delete cert-Manager
         delete_operator "ibm-cert-manager-operator" "$CONTROL_NS"
     else

--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -39,7 +39,12 @@ function main() {
 
     if [ "$CONTROL_NS" == "$OPERATOR_NS" ]; then
         # Delete CP2.0 Cert-Manager CR
-        ${OC} delete certmanager.operator.ibm.com default --ignore-not-found
+        ${OC} delete certmanager.operator.ibm.com default --ignore-not-found --timeout=10s
+        if [ $? -ne 0 ]; then
+            warning "Failed to delete Cert Manager CR, patching its finalizer to null..."
+            ${OC} patch certmanagers.operator.ibm.com default --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
+        fi
+        msg ""
         
         wait_for_no_pod ${CONTROL_NS} "cert-manager-cainjector"
         wait_for_no_pod ${CONTROL_NS} "cert-manager-controller"
@@ -47,7 +52,7 @@ function main() {
         # Delete cert-Manager
         delete_operator "ibm-cert-manager-operator" "$CONTROL_NS"
     else
-        # Delgation of CP2 Cert Manager
+        # Delegation of CP2 Cert Manager
         ${BASE_DIR}/delegate_cp2_cert_manager.sh --control-namespace $CONTROL_NS "--skip-user-vertify"
     fi
     


### PR DESCRIPTION
fix for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57978#issuecomment-56591582
#### Verify fix
1. install a cs 3.23 in `ibm-common-services` ns
2. running `./migrate_tenant.sh --enable-licensing     --operator-namespace ibm-common-services     --cert-manager-source ibm-cert-manager-operator-catalog     --licensing-source ibm-licensing-catalog     -c v4.0     -i Automatic
`
3. upgrade successfully without terminated
#### Output
```
certmanager.operator.ibm.com "default" deleted
[INFO] Waiting for pod cert-manager-cainjector in namespace ibm-common-services to be deleting
[✔] Pod cert-manager-cainjector in namespace ibm-common-services is deleted
[INFO] Waiting for pod cert-manager-controller in namespace ibm-common-services to be deleting
[✔] Pod cert-manager-controller in namespace ibm-common-services is deleted
[INFO] Waiting for pod cert-manager-webhook in namespace ibm-common-services to be deleting
[✔] Pod cert-manager-webhook in namespace ibm-common-services is deleted
# Deleting ibm-cert-manager-operator in namesapce ibm-common-services...
[1] Removing the subscription of ibm-cert-manager-operator in namesapce ibm-common-services ...
subscription.operators.coreos.com "ibm-cert-manager-operator" deleted
[2] Removing the csv of ibm-cert-manager-operator in namesapce ibm-common-services ...
clusterserviceversion.operators.coreos.com "ibm-cert-manager-operator.v3.25.2" deleted

[✔] Remove ibm-cert-manager-operator successfully.

[✔] Migration is completed for Cloud Pak 3.0 Foundational singleton services.
# Installing cert-manager

[INFO] Namespace ibm-cert-manager already exists. Skip creating
[INFO] Checking existing OperatorGroup in ibm-cert-manager:

[INFO] OperatorGroup already exists in ibm-cert-manager. Skip creating

[INFO] Creating following Subscription:

apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: ibm-cert-manager-operator
  namespace: ibm-cert-manager
spec:
  channel: v4.0
  installPlanApproval: Automatic
  name: ibm-cert-manager-operator
  source: ibm-cert-manager-operator-catalog
  sourceNamespace: openshift-marketplace
subscription.operators.coreos.com/ibm-cert-manager-operator created
[INFO] Waiting for operator ibm-cert-manager-operator in namespace ibm-cert-manager to be made available
[INFO] RETRYING: Waiting for operator ibm-cert-manager-operator in namespace ibm-cert-manager to be made available (50 left)
[INFO] RETRYING: Waiting for operator ibm-cert-manager-operator in namespace ibm-cert-manager to be made available (49 left)
[INFO] RETRYING: Waiting for operator ibm-cert-manager-operator in namespace ibm-cert-manager to be made available (48 left)
[✔] Operator ibm-cert-manager-operator in namespace ibm-cert-manager is available
...
...
...
namespacescope.operator.ibm.com/common-service configured
[✔] Preparation is completed for upgrading Cloud Pak 3.0
[INFO] Please update OperandRequest to upgrade foundational core services
```
