### PR TITLE
remove WebhookConfiguration to unblock CR update

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -885,7 +885,10 @@ function scale_down() {
     
     # delete OperandRegistry
     msg "Deleting OperandRegistry common-service in ${services_ns} namespace..."
-    ${OC} delete operandregistry common-service -n ${services_ns} --ignore-not-found  
+    ${OC} delete operandregistry common-service -n ${services_ns} --ignore-not-found
+    # delete validatingwebhookconfiguration
+    msg "Deleting ValidatingWebhookConfiguration ibm-common-service-validating-webhook-${operator_ns} in ${operator_ns} namespace..."
+    ${OC} delete ValidatingWebhookConfiguration ibm-common-service-validating-webhook-${operator_ns} --ignore-not-found
     rm sub.yaml 
 }
 


### PR DESCRIPTION
If user execute the `migrate_tenant.sh` script after CS operator is upgraded, it will hit issue when updating CS CR because CS deployment is scaled down, but webhook configuration is looking for service endpoint.

In order to support run the script idempotent, delete CS CR validatingWebhookConfiguration when we scale down CS deployment.