### PR TITLE
change cert manager cr to full name

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -107,7 +107,7 @@ function prepare_cluster() {
     cleanupZenService
 
     # uninstall singleton services
-    "${OC}" delete -n "${master_ns}" --ignore-not-found certmanager default
+    "${OC}" delete -n "${master_ns}" --ignore-not-found certmanagers.operator.ibm.com default
     "${OC}" delete -n "${master_ns}" --ignore-not-found sub ibm-cert-manager-operator
     csv=$("${OC}" get -n "${master_ns}" csv | (grep ibm-cert-manager-operator || echo "fail") | awk '{print $1}')
     "${OC}" delete -n "${master_ns}" --ignore-not-found csv "${csv}"

--- a/isolate.sh
+++ b/isolate.sh
@@ -290,7 +290,7 @@ function uninstall_singletons() {
 
     local isExists=$("${OC}" get deployments -n "${MASTER_NS}" --ignore-not-found ibm-cert-manager-operator)
     if [ ! -z "$isExists" ]; then
-        "${OC}" delete --ignore-not-found certmanager default
+        "${OC}" delete --ignore-not-found certmanagers.operator.ibm.com default
         CERT_MANAGER_MIGRATED="true"
         debug1 "Cert Manager marked for migration."
     fi

--- a/rollback-multi-instance.sh
+++ b/rollback-multi-instance.sh
@@ -113,7 +113,7 @@ function rollback() {
     ${OC} delete operandconfig -n ${MASTER_NS} --ignore-not-found common-service
     
     # uninstall singleton services
-    "${OC}" delete -n "${CONTROL_NS}" --ignore-not-found certmanager default
+    "${OC}" delete -n "${CONTROL_NS}" --ignore-not-found certmanagers.operator.ibm.com default
     "${OC}" delete -n "${CONTROL_NS}" --ignore-not-found sub ibm-cert-manager-operator
     csv=$("${OC}" get -n "${CONTROL_NS}" csv | (grep ibm-cert-manager-operator || echo "fail") | awk '{print $1}')
     "${OC}" delete -n "${CONTROL_NS}" --ignore-not-found csv "${csv}"


### PR DESCRIPTION
It's possible if multiple cert managers are or have been installed on a cluster that simply searching for `certmanager` to find the cert manager CR will not work:
```
[root@api.alex3.cp.fyre.ibm.com ~]# oc get certmanager
No resources found
[root@api.alex3.cp.fyre.ibm.com ~]# oc get certmanagers.operator.ibm.com 
NAME      AGE
default   4h15m
```
Specifying the full name of the cr always works and should be a safer, more consistent option.