### PR TITLE
change backup image to existing mongo image

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -246,6 +246,8 @@ function dumpmongo() {
     error "Cannot switch to $FROM_NAMESPACE"
   fi
 
+  ibm_mongodb_image=$(oc get pod icp-mongodb-0 -n $FROM_NAMESPACE -o=jsonpath='{range .spec.containers[0]}{.image}{end}')
+
   cat <<EOF >$TEMPFILE
 apiVersion: batch/v1
 kind: Job
@@ -259,7 +261,7 @@ spec:
     spec:
       containers:
       - name: cs-mongodb-backup
-        image: quay.io/opencloudio/ibm-mongodb:4.0.24
+        image: $ibm_mongodb_image
         command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongodump --oplog --out /dump/dump --host mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem"]
         volumeMounts:
         - mountPath: "/work-dir"


### PR DESCRIPTION
For https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58594. In the function `dumpmongo` a mongodb-backup job is created using an image from quay (found https://github.com/IBM/ibm-common-service-operator/blob/scripts/preload_data.sh#L262). This image looks to be the same image that is used in mongodb so I have replaced the quay image with whatever the existing mongo in the original cs ns is using. I have run a preliminary test and the script was able to complete successfully and the data seems to have been transferred smoothly.

Testing:
- install a shared common services cluster with at least one instance of zen with iam enabled
- run preload_data.sh to preload data into target ns for new cs instance (aka services ns)
- edit common-service-maps to move whichever ns zen was installed into the new tenant
- run conversion script with zen using the new cs instance
- verify can login to zen's cpd route and that it redirects the login to `cp-console-<new cs instance ns>`