### PR TITLE
edit odlm sub in place

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -695,7 +695,6 @@ function isolate_odlm() {
         fi
         count=$((count + 1))
     done
-    debug1 "patch string $patch_string"
     #use the patch string to apply the isolate mode patch
     ${OC} patch subscription.operators.coreos.com ${sub_name} -n ${ns} --type=merge -p '{"spec": {"config": {"env": ['"${patch_string}"']}}}'
     if [[ $? -ne 0 ]]; then

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -666,25 +666,41 @@ function check_topology() {
 }
 
 function isolate_odlm() {
-    package_name=$1
-    ns=$2
+    local package_name=$1
+    local ns=$2
     # get subscription of ODLM based on namespace 
-    sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${package_name}.${ns}='' --no-headers | awk '{print $1}')
+    local sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${package_name}.${ns}='' --no-headers | awk '{print $1}')
     if [ -z "$sub_name" ]; then
         warning "Not found subscription ${package_name} in ${ns}"
         return 0
     fi
-    ${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml > sub.yaml
-
-    # set ISOLATED_MODE to true
-    yq e '.spec.config.env |= (map(select(.name == "ISOLATED_MODE").value |= "true") + [{"name": "ISOLATED_MODE", "value": "true"}] | unique_by(.name))' sub.yaml -i
-
-    # apply updated subscription back to cluster
-    ${OC} apply -f sub.yaml
+    #merge patch overwrites the entire array if you update any values so we need to get any other value specified and make sure it is unchanged
+    #loop through all of the values specified in spec.config.env
+    env_range=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | yq '.spec.config.env[].name')
+    patch_string=""
+    count=0
+    for name in $env_range
+    do
+        #If isolated mode, set value to true. Otherwise keep name value pairs unchanged.
+        if [[ $name == "ISOLATED_MODE" ]]; then
+            env_value="true"
+        else
+            env_value=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | yq '.spec.config.env['"${count}"'].value')
+        fi
+        #Add name value pair in json format to the patch string
+        if [[ $patch_string == "" ]]; then
+            patch_string="{\"name\": \"$name\", \"value\": \"$env_value\"}"
+        else
+            patch_string="$patch_string, {\"name\": \"$name\", \"value\": \"$env_value\"}"
+        fi
+        count=$((count + 1))
+    done
+    debug1 "patch string $patch_string"
+    #use the patch string to apply the isolate mode patch
+    ${OC} patch subscription.operators.coreos.com ${sub_name} -n ${ns} --type=merge -p '{"spec": {"config": {"env": ['"${patch_string}"']}}}'
     if [[ $? -ne 0 ]]; then
         error "Failed to update subscription ${package_name} in ${ns}"
     fi
-    rm sub.yaml
 
     check_odlm_env "${ns}" 
 }

--- a/isolate.sh
+++ b/isolate.sh
@@ -451,17 +451,33 @@ function isolate_odlm() {
         warning "Not found subscription ${package_name} in ${ns}"
         return 0
     fi
-    ${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml > sub.yaml
-
-    # set ISOLATED_MODE to true
-    yq e '.spec.config.env |= (map(select(.name == "ISOLATED_MODE").value |= "true") + [{"name": "ISOLATED_MODE", "value": "true"}] | unique_by(.name))' sub.yaml -i
-
-    # apply updated subscription back to cluster
-    ${OC} apply -f sub.yaml
+    #merge patch overwrites the entire array if you update any values so we need to get any other value specified and make sure it is unchanged
+    #loop through all of the values specified in spec.config.env
+    env_range=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | yq '.spec.config.env[].name')
+    patch_string=""
+    count=0
+    for name in $env_range
+    do
+        #If isolated mode, set value to true. Otherwise keep name value pairs unchanged.
+        if [[ $name == "ISOLATED_MODE" ]]; then
+            env_value="true"
+        else
+            env_value=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | yq '.spec.config.env['"${count}"'].value')
+        fi
+        #Add name value pair in json format to the patch string
+        if [[ $patch_string == "" ]]; then
+            patch_string="{\"name\": \"$name\", \"value\": \"$env_value\"}"
+        else
+            patch_string="$patch_string, {\"name\": \"$name\", \"value\": \"$env_value\"}"
+        fi
+        count=$((count + 1))
+    done
+    debug1 "patch string $patch_string"
+    #use the patch string to apply the isolate mode patch
+    ${OC} patch subscription.operators.coreos.com ${sub_name} -n ${ns} --type=merge -p '{"spec": {"config": {"env": ['"${patch_string}"']}}}'
     if [[ $? -ne 0 ]]; then
         error "Failed to update subscription ${package_name} in ${ns}"
     fi
-    rm sub.yaml
 
     check_odlm_env "${ns}" 
 }

--- a/rollback-multi-instance.sh
+++ b/rollback-multi-instance.sh
@@ -24,6 +24,7 @@ CONTROL_NS=
 cm_name="common-service-maps"
 OC=oc
 YQ=yq
+DEBUG=0
 
 
 function main() {
@@ -43,6 +44,9 @@ function main() {
         "--control-ns")
             CONTROL_NS=$2
             shift
+            ;;
+        -v | --debug)
+            DEBUG=1
             ;;
         *)
             error "invalid option -- \`$1\`. Use the -h or --help option for usage info."
@@ -72,6 +76,7 @@ function usage() {
 	  -h, --help                    display this help and exit
       --original-cs-ns              specify the original common services namespace
       --control-ns                  specify the existing control namespace
+      -v, --debug integer           Verbosity of logs. Default is 0. Set to 1 for debug logs.
 	EOF
 }
 
@@ -533,6 +538,11 @@ function info() {
     msg "[INFO] ${1}"
 }
 
+function debug1() {
+    if [ $DEBUG -eq 1 ]; then
+        msg "[DEBUG] ${1}"
+    fi
+}
 # --- Run ---
 
 main $*

--- a/rollback-multi-instance.sh
+++ b/rollback-multi-instance.sh
@@ -400,25 +400,41 @@ function scale_up_pod() {
 }
 
 function un_isolate_odlm() {
-    package_name=$1
-    ns=$2
+    local package_name=$1
+    local ns=$2
     # get subscription of ODLM based on namespace 
-    sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${package_name}.${ns}='' --no-headers | awk '{print $1}')
+    local sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${package_name}.${ns}='' --no-headers | awk '{print $1}')
     if [ -z "$sub_name" ]; then
         warning "Not found subscription ${package_name} in ${ns}"
         return 0
     fi
-    ${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml > sub.yaml
-
-    # set ISOLATED_MODE to true
-    yq e '.spec.config.env |= (map(select(.name == "ISOLATED_MODE").value |= "false") + [{"name": "ISOLATED_MODE", "value": "false"}] | unique_by(.name))' sub.yaml -i
-
-    # apply updated subscription back to cluster
-    ${OC} apply -f sub.yaml
+    #merge patch overwrites the entire array if you update any values so we need to get any other value specified and make sure it is unchanged
+    #loop through all of the values specified in spec.config.env
+    env_range=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | yq '.spec.config.env[].name')
+    patch_string=""
+    count=0
+    for name in $env_range
+    do
+        #If isolated mode, set value to true. Otherwise keep name value pairs unchanged.
+        if [[ $name == "ISOLATED_MODE" ]]; then
+            env_value="false"
+        else
+            env_value=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | yq '.spec.config.env['"${count}"'].value')
+        fi
+        #Add name value pair in json format to the patch string
+        if [[ $patch_string == "" ]]; then
+            patch_string="{\"name\": \"$name\", \"value\": \"$env_value\"}"
+        else
+            patch_string="$patch_string, {\"name\": \"$name\", \"value\": \"$env_value\"}"
+        fi
+        count=$((count + 1))
+    done
+    debug1 "patch string $patch_string"
+    #use the patch string to apply the isolate mode patch
+    ${OC} patch subscription.operators.coreos.com ${sub_name} -n ${ns} --type=merge -p '{"spec": {"config": {"env": ['"${patch_string}"']}}}'
     if [[ $? -ne 0 ]]; then
         error "Failed to update subscription ${package_name} in ${ns}"
     fi
-    rm sub.yaml
 
     check_odlm_env "${ns}" 
 }


### PR DESCRIPTION
To avoid applying the changed subscription on top of the existing and possibly running into an error due to resourceVersion mismatches, we need to update the value in place in the `isolate_odlm` function. This function is called in the isolate, conversion, and rollback script so needs to be updated in all three locations.

To do this, I have added a patch statement to edit the existing subscription. Unfortunately, patches to an array completely overwrite the array. This means I cannot just update the `ISOLATE_MODE` value without wiping the values of the other `spec.config.env` variables. To get around this, I loop through the output of `spec.config.env[]` and add the name and value back to the subscription in the order they were read in. If the variable name is `ISOLATE_MODE`, the script makes sure it is set to "true" (false in the case of the rollback script). I was able to run the script a couple times and saw that the `patch_string` variable looked in line with the command I tested by hand and that the odlm subscription and deployment were being properly updated to reflect the new value. I have only tested the isolate script so far.

Testing isolate.sh:
- setup cluster with shared common services installed 
- run isolate.sh
- verify script completes successfully
- verify odlm sub spec.config.env[ISOLATED_MODE]=true

Testing conversion script:
- setup cluster with shared common services installed
- create cs maps, does not necessarily need more than one tenant defined
- run conversion script
- verify script completes successfully
- verify odlm sub spec.config.env[ISOLATED_MODE]=true

Testing rollback script:
- probably best to use the conversion cluster after successful test since rollback is the opposite
- uninstall new common service instances with the uninstall-dedicated-cs-instance.sh script (use -f flag)
- remove the controlNamespace value from the common-service-maps configmap and consolidate tenants into one (should only be one map-to-common-services-namespace)
- run rollback script
- verify script completes successfully
- verify odlm sub spec.config.env[ISOLATED_MODE]=*false*