### PR TITLE
move webhook cleanup to immediately after pause

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -78,6 +78,7 @@ function main() {
     prereq
     local ns_list=$(gather_csmaps_ns)
     pause
+    cleanup_webhook
     create_empty_csmaps
     insert_control_ns
     update_tenant "${MASTER_NS}" "${ns_list}"
@@ -317,10 +318,9 @@ function uninstall_singletons() {
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found csv "${csv}"
     csv=$("${OC}" get -n "${MASTER_NS}" csv | (grep ibm-crossplane-provider-kubernetes-operator || echo "fail") | awk '{print $1}')
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found csv "${csv}"
-
-    cleanup_webhook
+    
     cleanup_deployment "secretshare" "$MASTER_NS"
-
+    
     success "Singletons successfully uninstalled"
 }
 


### PR DESCRIPTION
Issue 9446 in CPD quality repo seems to be experiencing a problem with the webhooks not being present stopping the creation of common-service-maps configmap. We ran into this problem previously w/ https://github.com/IBM/ibm-common-service-operator/pull/1167 but moved the uninstall_singletons again in https://github.com/IBM/ibm-common-service-operator/pull/1188 to prevent deleting anything before creating csmaps. This pr would change it so only the webhooks are cleaned up right after the pause, everything else will be uninstalled/deleted right before the restart.

I have run the script several times on my own environment and have not seen any issues with the webhook not being there to create or edit the common-service-maps cm. However, I did not see the issue using the previous version either so it's hard to say this fixed it.