### PR TITLE
ensure ldaps secret exists in target namespace after restore

### DIFF
--- a/backup_restore_mongo.sh
+++ b/backup_restore_mongo.sh
@@ -384,8 +384,8 @@ function check_ldap_secret() {
     exists=$(${OC} get secret -n $TARGET_NAMESPACE | (grep platform-auth-ldaps-ca-cert || echo fail))
     if [[ $exists != "fail" ]]; then
         certificate=$(${OC} get secret -n $TARGET_NAMESPACE platform-auth-ldaps-ca-cert -o yaml | yq '.data.certificate' )
-        if [[ $certificate == "" ]]; then
-            og_certificate=$(${OC} get secret -n $ORIGINAL_NAMESPACE platform-auth-ldaps-ca-cert -o yaml | yq '.data.certificate' )
+        og_certificate=$(${OC} get secret -n $ORIGINAL_NAMESPACE platform-auth-ldaps-ca-cert -o yaml | yq '.data.certificate' )
+        if [[ $certificate == "" ]] || [[ $certificate != $og_certificate ]]; then
             ${OC} patch secret -n $TARGET_NAMESPACE platform-auth-ldaps-ca-cert --type=merge -p '{"data": {"certificate":'$og_certificate'}}'
             info "Secret platform-auth-ldaps-ca-cert in $TARGET_NAMESPACE patched to match secret in $ORIGINAL_NAMESPACE"
         else

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -33,7 +33,8 @@ function main() {
     # run backup preload
     backup_preload_mongo
     # copy im credentials
-    copy_auth_idp_secret
+    copy_secret "platform-auth-idp-credentials"
+    copy_secret "platform-auth-ldaps-ca-cert"
     # any extra config
 }
 
@@ -97,8 +98,8 @@ function prereq() {
     fi
 }
 
-function copy_auth_idp_secret() {
-    local secret="platform-auth-idp-credentials"
+function copy_secret() {
+    local secret=$1
     title " Copying secret $secret from $FROM_NAMESPACE to $TO_NAMESPACE "   
     $OC get secret "$secret" -n $FROM_NAMESPACE -o yaml | \
         $YQ '


### PR DESCRIPTION
Replacing https://github.com/IBM/ibm-common-service-operator/pull/1197

When running either of the scripts for backing up and restoring mongo data into a new namespace, the ldaps secret can be created without the certificate filled in. This would disable the ability to log in using LDAP so we need to make sure this secret is there and matches the original.

Testing preload:
- install shared cluster with LDAP enabled and users created
- run preload script
- verify secret is copied over into new namespace and equals original
- convert cluster with new cs in target namespace from preload
- make sure LDAP login works with new cs instance

Testing backup_restore:
- install shared cluster with LDAP enabled and users created
- run conversion
- run backup restore script
- verify secret is present in new namespace and equals original
- make sure LDAP login works with new cs instance