### PR TITLE
change cert manager check to just webhook, check for dupe deploys

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -87,11 +87,7 @@ function main() {
     check_cm_ns_exist "$ns_list $CONTROL_NS" # debating on turning this off by default since this technically falls outside the scope of isolate
     isolate_odlm "ibm-odlm" $MASTER_NS
     restart
-    if [[ $CERT_MANAGER_MIGRATED == "true" ]]; then
-        wait_for_certmanager "$CONTROL_NS"
-    else
-        info "Cert Manager not migrated, skipping wait."
-    fi
+    wait_for_certmanager "$CONTROL_NS"
     success "Isolation complete"
 }
 
@@ -298,10 +294,6 @@ function uninstall_singletons() {
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-cert-manager-operator
     local csv=$("${OC}" get -n "${MASTER_NS}" csv | (grep ibm-cert-manager-operator || echo "fail") | awk '{print $1}')
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found csv "${csv}"
-
-    wait_for_no_pod ${MASTER_NS} "cert-manager-cainjector"
-    wait_for_no_pod ${MASTER_NS} "cert-manager-controller"
-    wait_for_no_pod ${MASTER_NS} "cert-manager-webhook"
 
     migrate_lic_cms $MASTER_NS
     isExists=$("${OC}" get deployments -n "${MASTER_NS}" --ignore-not-found ibm-licensing-operator)

--- a/isolate.sh
+++ b/isolate.sh
@@ -87,7 +87,11 @@ function main() {
     check_cm_ns_exist "$ns_list $CONTROL_NS" # debating on turning this off by default since this technically falls outside the scope of isolate
     isolate_odlm "ibm-odlm" $MASTER_NS
     restart
-    wait_for_certmanager "$CONTROL_NS"
+    if [[ $CERT_MANAGER_MIGRATED == "true" ]]; then
+        wait_for_certmanager "$CONTROL_NS"
+    else
+        info "Cert Manager not migrated, skipping wait."
+    fi
     success "Isolation complete"
 }
 

--- a/isolate.sh
+++ b/isolate.sh
@@ -87,11 +87,7 @@ function main() {
     check_cm_ns_exist "$ns_list $CONTROL_NS" # debating on turning this off by default since this technically falls outside the scope of isolate
     isolate_odlm "ibm-odlm" $MASTER_NS
     restart
-    if [[ $CERT_MANAGER_MIGRATED == "true" ]]; then
-        wait_for_certmanager "$CONTROL_NS" "${ns_list}"
-    else
-        info "Cert Manager not migrated, skipping wait."
-    fi
+    wait_for_certmanager "$CONTROL_NS"
     success "Isolation complete"
 }
 
@@ -540,60 +536,10 @@ function cleanup_webhook() {
 
 }
 
-function check_if_certmanager_deployed() {
-    local namespace=$1
-    shift
-    local namespaces=$@
-    info "checking for cert manager deployed in scope."
-    local deployed="false"
-    for ns in $namespaces
-    do
-        opreqs=$(${OC} get opreq -n $ns --no-headers | awk '{print $1}' | tr '\n' ' ')
-        for opreq in $opreqs
-        do
-            local return_value=$(${OC} get opreq $opreq -n $ns -o yaml | ${YQ} '.spec.requests[]' | grep "name: ibm-cert-manager-operator" || echo "fail")
-            if [[ $return_value != "fail" ]]; then
-                deployed="true"
-                info "Cert manager requested in scope, moving on..."
-                break
-            fi
-        done
-    done
-
-    if [[ $deployed == "false" ]]; then
-        info "Cert manager not requested in scope, deploying..."
-        cat <<EOF > tmp-opreq.yaml
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRequest
-metadata:
-  labels:
-    app.kubernetes.io/instance: operand-deployment-lifecycle-manager
-    app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
-    app.kubernetes.io/name: odlm
-  name: ibm-cert-manager-operator
-  namespace: $namespace
-spec:
-  requests:
-    - operands:
-        - name: ibm-cert-manager-operator
-      registry: common-service
-      registryNamespace: $MASTER_NS
-EOF
-
-    oc apply -f tmp-opreq.yaml
-    rm -f tmp-opreq.yaml
-    fi
-
-}
-
 function wait_for_certmanager() {
     local namespace=$1
-    shift
-    local namespaces=$@
     title " Wait for Cert Manager pods to come ready in namespace $namespace "
     msg "-----------------------------------------------------------------------"
-    
-    check_if_certmanager_deployed "${namespace}" "${namespaces}"
 
     #check cert manager operator pod
     local name="ibm-cert-manager-operator"

--- a/isolate.sh
+++ b/isolate.sh
@@ -556,17 +556,17 @@ function check_if_certmanager_deployed() {
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRequest
 metadata:
-labels:
-    app.kubernetes.io/instance: operand-deployment-lifecycle-manager
-    app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
-    app.kubernetes.io/name: odlm
-name: ibm-cert-manager-operator
-namespace: $namespace
+    labels:
+        app.kubernetes.io/instance: operand-deployment-lifecycle-manager
+        app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
+        app.kubernetes.io/name: odlm
+    name: ibm-cert-manager-operator
+    namespace: $namespace
 spec:
 requests:
 - operands:
     - name: ibm-cert-manager-operator
-    registry: common-service
+  registry: common-service
 EOF
 
     oc apply -f tmp-opreq.yaml

--- a/isolate.sh
+++ b/isolate.sh
@@ -552,21 +552,23 @@ function check_if_certmanager_deployed() {
     done
 
     if [[ $deployed == "false" ]]; then
+        info "Cert manager not requested in scope, deploying..."
         cat <<EOF > tmp-opreq.yaml
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRequest
 metadata:
-    labels:
-        app.kubernetes.io/instance: operand-deployment-lifecycle-manager
-        app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
-        app.kubernetes.io/name: odlm
-    name: ibm-cert-manager-operator
-    namespace: $namespace
+  labels:
+    app.kubernetes.io/instance: operand-deployment-lifecycle-manager
+    app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
+    app.kubernetes.io/name: odlm
+  name: ibm-cert-manager-operator
+  namespace: $namespace
 spec:
-requests:
-- operands:
-    - name: ibm-cert-manager-operator
-  registry: common-service
+  requests:
+    - operands:
+        - name: ibm-cert-manager-operator
+      registry: common-service
+      registryNamespace: $MASTER_NS
 EOF
 
     oc apply -f tmp-opreq.yaml

--- a/isolate.sh
+++ b/isolate.sh
@@ -565,7 +565,8 @@ function wait_for_certmanager() {
     if [[ $webhook_deployments != "1" ]]; then
         error "More than one cert-manager-webhook deployment exists on the cluster."
     fi
-    success "Cert Manager ready in namespace $namespace."
+    webhook_ns=$(${OC} get deploy -A | grep cert-manager-webhook | awk '{print $1}')
+    success "Cert Manager ready in namespace $namespace. Cert Manager operands deployed in $webhook_ns"
 }
 
 function msg() {


### PR DESCRIPTION
If the cluster has a redhat cert manager deployed, the check for `cert-manager-controller` will fail because redhat names its controller pod and deployment just `cert-manager`. This would then cause the isolate.sh script to fail. Instead of checking for each of the three operands, change the check to only check for the webhook pod to be ready as well as check for no duplicate webhook deployments on the cluster.

Testing in case of open source cert manager deployed:
- install redhat cert manager on cluster
- setup shared cs environment, zen install a plus
- run isolate.sh, verify script completes successfully

~Testing in case of cert manager no longer requested:~
- ~install common services in ibm-common-services~
- ~create opreq for cert manager in a ns other than ibm-common-services (let's call it test-ns)~
    - ~make sure cert manager is only installed via this opreq~
- ~run isolate script excluding test-ns~
- ~make sure new opreq is created in control namespace for cert manager~
- ~make sure script completes successfully and cert manager is deployed~