### PR TITLE
Implement Concatenating OperandRegistry YAMLs

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -640,8 +640,9 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 		klog.Errorf("failed to concatenate registries CSV3SaasOperandRegistry: %v", err)
 	}
 
-	// Append CP3 operators into CP3 Saas OperandRegistry
+	// Append CP3 operators into CP3 SaaS OperandRegistry
 	Saasregistries := []string{
+		constant.MongoDBOpReg,
 		constant.IMOpReg,
 		constant.PlatformUIOpReg,
 	}
@@ -649,7 +650,7 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 	for _, reg := range Saasregistries {
 		constant.CSV3SaasOperandRegistry, err = constant.ConcatenateRegistries(constant.CSV3SaasOperandRegistry, reg, b.CSData)
 		if err != nil {
-			klog.Errorf("failed to append CP3 operators into Saas OperandRegistry: %v", err)
+			klog.Errorf("failed to append CP3 operators into SaaS OperandRegistry: %v", err)
 		}
 	}
 

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -620,9 +620,38 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 	if err != nil {
 		klog.Errorf("failed to concatenate registries CSV3OperandRegistry: %v", err)
 	}
+	// Append CP3 services into CP3 OprandRegistry
+	registries := []string{
+		constant.MongoDBOpReg,
+		constant.IMOpReg,
+		constant.IdpConfigUIOpReg,
+		constant.PlatformUIOpReg,
+	}
+
+	for _, reg := range registries {
+		constant.CSV3OperandRegistry, err = constant.ConcatenateRegistries(constant.CSV3OperandRegistry, reg, b.CSData)
+		if err != nil {
+			klog.Errorf("failed to append CP3 services into OprandRegistry: %v", err)
+		}
+	}
+
 	constant.CSV3SaasOperandRegistry, err = constant.ConcatenateRegistries(constant.CSV2SaasOpReg, constant.CSV3SaasOpReg, b.CSData)
 	if err != nil {
 		klog.Errorf("failed to concatenate registries CSV3SaasOperandRegistry: %v", err)
+	}
+
+	// Append CP3 services into CP3 Saas OprandRegistry
+	Saasregistries := []string{
+		constant.MongoDBOpReg,
+		constant.IMOpReg,
+		constant.IdpConfigUIOpReg,
+	}
+
+	for _, reg := range Saasregistries {
+		constant.CSV3SaasOperandRegistry, err = constant.ConcatenateRegistries(constant.CSV3SaasOperandRegistry, reg, b.CSData)
+		if err != nil {
+			klog.Errorf("failed to append CP3 services into Saas OprandRegistry: %v", err)
+		}
 	}
 
 	var obj []*unstructured.Unstructured

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -615,8 +615,17 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 		}
 	}
 
-	var obj []*unstructured.Unstructured
 	var err error
+	constant.CSV3OperandRegistry, err = constant.ConcatenateRegistries(constant.CSV2OpReg, constant.CSV3OpReg, b.CSData)
+	if err != nil {
+		klog.Errorf("failed to concatenate registries CSV3OperandRegistry: %v", err)
+	}
+	constant.CSV3SaasOperandRegistry, err = constant.ConcatenateRegistries(constant.CSV2SaasOpReg, constant.CSV3SaasOpReg, b.CSData)
+	if err != nil {
+		klog.Errorf("failed to concatenate registries CSV3SaasOperandRegistry: %v", err)
+	}
+
+	var obj []*unstructured.Unstructured
 	if b.SaasEnable {
 		// OperandRegistry for SaaS deployment
 		obj, err = b.GetObjs(constant.CSV3SaasOperandRegistry, b.CSData)

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -620,7 +620,7 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 	if err != nil {
 		klog.Errorf("failed to concatenate registries CSV3OperandRegistry: %v", err)
 	}
-	// Append CP3 services into CP3 OprandRegistry
+	// Append CP3 Operators into CP3 OperandRegistry
 	registries := []string{
 		constant.MongoDBOpReg,
 		constant.IMOpReg,
@@ -631,7 +631,7 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 	for _, reg := range registries {
 		constant.CSV3OperandRegistry, err = constant.ConcatenateRegistries(constant.CSV3OperandRegistry, reg, b.CSData)
 		if err != nil {
-			klog.Errorf("failed to append CP3 services into OprandRegistry: %v", err)
+			klog.Errorf("failed to append CP3 operators into OperandRegistry: %v", err)
 		}
 	}
 
@@ -640,17 +640,16 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 		klog.Errorf("failed to concatenate registries CSV3SaasOperandRegistry: %v", err)
 	}
 
-	// Append CP3 services into CP3 Saas OprandRegistry
+	// Append CP3 operators into CP3 Saas OperandRegistry
 	Saasregistries := []string{
-		constant.MongoDBOpReg,
 		constant.IMOpReg,
-		constant.IdpConfigUIOpReg,
+		constant.PlatformUIOpReg,
 	}
 
 	for _, reg := range Saasregistries {
 		constant.CSV3SaasOperandRegistry, err = constant.ConcatenateRegistries(constant.CSV3SaasOperandRegistry, reg, b.CSData)
 		if err != nil {
-			klog.Errorf("failed to append CP3 services into Saas OprandRegistry: %v", err)
+			klog.Errorf("failed to append CP3 operators into Saas OperandRegistry: %v", err)
 		}
 	}
 

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -125,6 +125,341 @@ spec:
 `
 )
 
+const (
+	CSV2OpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: "{{ .Version }}"
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-licensing-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-licensing-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-mongodb-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-cert-manager-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-cert-manager-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-iam-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-healthcheck-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-healthcheck-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-commonui-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-commonui-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-management-ingress-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-management-ingress-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-ingress-nginx-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-ingress-nginx-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-auditlogging-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-auditlogging-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-platform-api-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-platform-api-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - channel: v3.23
+    name: ibm-monitoring-grafana-operator
+    namespace: "{{ .ServicesNs }}"
+    packageName: ibm-monitoring-grafana-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - channel: v3.23
+    name: ibm-zen-operator
+    namespace: "{{ .ServicesNs }}"
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+`
+
+	CSV3OpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-im-operator
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - channel: v3
+    name: ibm-events-operator
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-events-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-platformui-operator
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - channel: stable
+    name: cloud-native-postgresql
+    namespace: "{{ .CPFSNs }}"
+    packageName: cloud-native-postgresql
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: alpha
+    name: ibm-user-data-services-operator
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-user-data-services-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: v3
+    name: ibm-bts-operator
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-bts-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: v1.3
+    name: ibm-automation-flink
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-automation-flink
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: v1.3
+    name: ibm-automation-elastic
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-automation-elastic
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: v3.23
+    name: ibm-zen-cpp-operator
+    namespace: "{{ .CPFSNs }}"
+    packageName: zen-cpp-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+`
+)
+
+const (
+	CSV2SaasOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-licensing-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-licensing-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-mongodb-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-cert-manager-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-cert-manager-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-iam-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-management-ingress-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-management-ingress-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-ingress-nginx-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-ingress-nginx-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - channel: v3.23
+    name: ibm-zen-operator
+    namespace: "{{ .ServicesNs }}"
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  `
+
+	CSV3SaasOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-im-operator
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - channel: v3
+    name: ibm-events-operator
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-events-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-platformui-operator
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - channel: v3
+    name: ibm-bts-operator
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-bts-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: v1.3
+    name: ibm-automation-flink
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-automation-flink
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: v1.3
+    name: ibm-automation-elastic
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-automation-elastic
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+`
+)
+
 const CSV3OperandConfig = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig
@@ -144,6 +479,10 @@ spec:
     spec:
       mongoDB: {}
       operandRequest: {}
+  - name: ibm-mongodb-operator-v4.0
+    spec:
+      mongoDB: {}
+      operandRequest: {}
   - name: ibm-im-operator
     spec:
       authentication:
@@ -155,8 +494,8 @@ spec:
       operandRequest: 
         requests:
           - operands:
-              - name: ibm-mongodb-operator
-              - name: ibm-idp-config-ui-operator
+              - name: ibm-mongodb-operator-{{ .Channel }}
+              - name: ibm-idp-config-ui-operator-{{ .Channel }}
             registry: common-service
   - name: ibm-im-operator-v4.0
     spec:
@@ -169,8 +508,8 @@ spec:
       operandRequest:
         requests:
           - operands:
-              - name: ibm-mongodb-operator
-              - name: ibm-idp-config-ui-operator
+              - name: ibm-mongodb-operator-v4.0
+              - name: ibm-idp-config-ui-operator-v4.0
             registry: common-service
   - name: ibm-iam-operator
     spec:
@@ -552,205 +891,6 @@ spec:
         namespace: "{{ .OperatorNs }}"
 `
 
-const (
-	CSV2OpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: "{{ .Version }}"
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
-spec:
-  operators:
-  - name: ibm-licensing-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-licensing-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-mongodb-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-mongodb-operator-app
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-cert-manager-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-cert-manager-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-iam-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-healthcheck-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-healthcheck-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-commonui-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-commonui-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-management-ingress-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-management-ingress-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-ingress-nginx-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-ingress-nginx-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-auditlogging-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-auditlogging-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-platform-api-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-platform-api-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - channel: v3.23
-    name: ibm-monitoring-grafana-operator
-    namespace: "{{ .ServicesNs }}"
-    packageName: ibm-monitoring-grafana-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - channel: v3.23
-    name: ibm-zen-operator
-    namespace: "{{ .ServicesNs }}"
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-`
-
-	CSV3OpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
-spec:
-  operators:
-  - name: ibm-im-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: v3
-    name: ibm-events-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-events-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-platformui-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: stable
-    name: cloud-native-postgresql
-    namespace: "{{ .CPFSNs }}"
-    packageName: cloud-native-postgresql
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-  - channel: alpha
-    name: ibm-user-data-services-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-user-data-services-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-  - channel: v3
-    name: ibm-bts-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-bts-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-  - channel: v1.3
-    name: ibm-automation-flink
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-automation-flink
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-  - channel: v1.3
-    name: ibm-automation-elastic
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-automation-elastic
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-  - channel: v3.23
-    name: ibm-zen-cpp-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: zen-cpp-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-`
-)
-
 const CSV3SaasOperandConfig = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig
@@ -770,6 +910,10 @@ spec:
     spec:
       mongoDB: {}
       operandRequest: {}
+  - name: ibm-mongodb-operator-v4.0
+    spec:
+      mongoDB: {}
+      operandRequest: {}
   - name: ibm-im-operator
     spec:
       authentication:
@@ -782,8 +926,8 @@ spec:
       operandRequest:
         requests:
           - operands:
-              - name: ibm-mongodb-operator
-              - name: ibm-idp-config-ui-operator
+              - name: ibm-mongodb-operator-{{ .Channel }}
+              - name: ibm-idp-config-ui-operator-{{ .Channel }}
             registry: common-service
   - name: ibm-im-operator-v4.0
     spec:
@@ -796,8 +940,8 @@ spec:
       operandRequest:
         requests:
           - operands:
-              - name: ibm-mongodb-operator
-              - name: ibm-idp-config-ui-operator
+              - name: ibm-mongodb-operator-v4.0
+              - name: ibm-idp-config-ui-operator-v4.0
             registry: common-service
   - name: ibm-iam-operator
     spec:
@@ -1051,142 +1195,6 @@ spec:
         name: pre-zen-operand-config-job
         namespace: "{{ .OperatorNs }}"
 `
-
-const (
-	CSV2SaasOpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
-spec:
-  operators:
-  - name: ibm-licensing-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-licensing-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-mongodb-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-mongodb-operator-app
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-cert-manager-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-cert-manager-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-iam-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-management-ingress-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-management-ingress-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-ingress-nginx-operator
-    namespace: "{{ .ServicesNs }}"
-    channel: v3.23
-    packageName: ibm-ingress-nginx-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - channel: v3.23
-    name: ibm-zen-operator
-    namespace: "{{ .ServicesNs }}"
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  `
-
-	CSV3SaasOpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
-spec:
-  operators:
-  - name: ibm-im-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: v3
-    name: ibm-events-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-events-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-platformui-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: v3
-    name: ibm-bts-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-bts-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-  - channel: v1.3
-    name: ibm-automation-flink
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-automation-flink
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-  - channel: v1.3
-    name: ibm-automation-elastic
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-automation-elastic
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-`
-)
 
 const ODLMSubscription = `
 apiVersion: operators.coreos.com/v1alpha1

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -32,6 +32,99 @@ var (
 	CSV3SaasOperandRegistry string
 )
 
+const (
+	MongoDBOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-mongodb-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+`
+
+	IMOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-im-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+`
+
+	IdpConfigUIOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-idp-config-ui-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-commonui-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+`
+
+	PlatformUIOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-platformui-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+`
+)
+
 const CSV3OperandConfig = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig
@@ -603,14 +696,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-idp-config-ui-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-commonui-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3
     name: ibm-events-operator
     namespace: "{{ .CPFSNs }}"
@@ -663,99 +748,6 @@ spec:
     packageName: zen-cpp-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-`
-)
-
-const (
-	MongoDBOpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
-spec:
-  operators:
-  - name: ibm-mongodb-operator-v4.0
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-mongodb-operator-app
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-`
-
-	IMOpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
-spec:
-  operators:
-  - name: ibm-im-operator-v4.0
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-`
-
-	IdpConfigUIOpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
-spec:
-  operators:
-  - name: ibm-idp-config-ui-operator-v4.0
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-commonui-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-`
-
-	PlatformUIOpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
-spec:
-  operators:
-  - name: ibm-platformui-operator-v4.0
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"html/template"
 
-	odlm "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
 	utilyaml "github.com/ghodss/yaml"
+
+	odlm "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
 )
 
 var (
@@ -1205,7 +1206,7 @@ func ConcatenateRegistries(baseRegistryTemplate, insertedRegistryTemplate string
 	return string(opregBytes), nil
 }
 
-func applyTemplate(objectTemplate string, data interface{}, alwaysUpdate ...bool) ([]byte, error) {
+func applyTemplate(objectTemplate string, data interface{}) ([]byte, error) {
 	var buffer bytes.Buffer
 	t := template.Must(template.New("newTemplate").Parse(objectTemplate))
 	if err := t.Execute(&buffer, data); err != nil {

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -595,33 +595,10 @@ metadata:
     excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
 spec:
   operators:
-  - name: ibm-mongodb-operator-v4.0
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-mongodb-operator-app
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
     packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-im-operator-v4.0
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-idp-config-ui-operator-v4.0
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
@@ -643,14 +620,6 @@ spec:
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-platformui-operator-v4.0
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
     packageName: ibm-zen-operator
@@ -694,6 +663,99 @@ spec:
     packageName: zen-cpp-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+`
+)
+
+const (
+	MongoDBOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-mongodb-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+`
+
+	IMOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-im-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+`
+
+	IdpConfigUIOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-idp-config-ui-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-commonui-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+`
+
+	PlatformUIOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-platformui-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -1089,22 +1151,7 @@ metadata:
     excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
 spec:
   operators:
-  - name: ibm-mongodb-operator-v4.0
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-mongodb-operator-app
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-im-operator-v4.0
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
     packageName: ibm-iam-operator
@@ -1121,14 +1168,6 @@ spec:
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-platformui-operator-v4.0
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
     packageName: ibm-zen-operator

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -16,6 +16,21 @@
 
 package constant
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+
+	odlm "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
+	utilyaml "github.com/ghodss/yaml"
+)
+
+var (
+	CSV3OperandRegistry     string
+	CSV3SaasOperandRegistry string
+)
+
 const CSV3OperandConfig = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig
@@ -443,7 +458,130 @@ spec:
         namespace: "{{ .OperatorNs }}"
 `
 
-const CSV3OperandRegistry = `
+const (
+	CSV2OpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: "{{ .Version }}"
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-licensing-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-licensing-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-mongodb-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-cert-manager-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-cert-manager-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-iam-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-healthcheck-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-healthcheck-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-commonui-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-commonui-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-management-ingress-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-management-ingress-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-ingress-nginx-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-ingress-nginx-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-auditlogging-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-auditlogging-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-platform-api-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-platform-api-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - channel: v3.23
+    name: ibm-monitoring-grafana-operator
+    namespace: "{{ .ServicesNs }}"
+    packageName: ibm-monitoring-grafana-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - channel: v3.23
+    name: ibm-zen-operator
+    namespace: "{{ .ServicesNs }}"
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+`
+
+	CSV3OpReg = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
@@ -456,40 +594,13 @@ metadata:
     excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
 spec:
   operators:
-  - name: ibm-licensing-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-licensing-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-mongodb-operator
+  - name: ibm-mongodb-operator-v4.0
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-cert-manager-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-cert-manager-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-iam-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-iam-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
   - name: ibm-im-operator
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
@@ -506,24 +617,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-healthcheck-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-healthcheck-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-commonui-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-commonui-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
   - name: ibm-idp-config-ui-operator-v4.0
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
@@ -540,51 +633,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-management-ingress-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-management-ingress-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-ingress-nginx-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-ingress-nginx-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-auditlogging-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-auditlogging-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-platform-api-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-platform-api-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - channel: v3.23
-    name: ibm-monitoring-grafana-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-monitoring-grafana-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
   - channel: v3
     name: ibm-events-operator
     namespace: "{{ .CPFSNs }}"
@@ -593,15 +641,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: v3.23
-    name: ibm-zen-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
@@ -630,12 +669,6 @@ spec:
     packageName: ibm-user-data-services-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-  - channel: v3.23
-    name: ibm-zen-cpp-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: zen-cpp-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
   - channel: v3
     name: ibm-bts-operator
     namespace: "{{ .CPFSNs }}"
@@ -654,7 +687,14 @@ spec:
     packageName: ibm-automation-elastic
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+  - channel: v3.23
+    name: ibm-zen-cpp-operator
+    namespace: "{{ .CPFSNs }}"
+    packageName: zen-cpp-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
 `
+)
 
 const CSV3SaasOperandConfig = `
 apiVersion: operator.ibm.com/v1alpha1
@@ -957,7 +997,8 @@ spec:
         namespace: "{{ .OperatorNs }}"
 `
 
-const CSV3SaasOperandRegistry = `
+const (
+	CSV2SaasOpReg = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
@@ -971,7 +1012,7 @@ metadata:
 spec:
   operators:
   - name: ibm-licensing-operator
-    namespace: "{{ .CPFSNs }}"
+    namespace: "{{ .ServicesNs }}"
     channel: v3.23
     packageName: ibm-licensing-operator-app
     scope: public
@@ -980,14 +1021,15 @@ spec:
     sourceNamespace: "{{ .CatalogSourceNs }}"
     installMode: no-op
   - name: ibm-mongodb-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
   - name: ibm-cert-manager-operator
-    namespace: "{{ .CPFSNs }}"
+    namespace: "{{ .ServicesNs }}"
     channel: v3.23
     packageName: ibm-cert-manager-operator
     scope: public
@@ -996,7 +1038,7 @@ spec:
     sourceNamespace: "{{ .CatalogSourceNs }}"
     installMode: no-op
   - name: ibm-iam-operator
-    namespace: "{{ .CPFSNs }}"
+    namespace: "{{ .ServicesNs }}"
     channel: v3.23
     packageName: ibm-iam-operator
     scope: public
@@ -1004,6 +1046,55 @@ spec:
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
     installMode: no-op
+  - name: ibm-management-ingress-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-management-ingress-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - name: ibm-ingress-nginx-operator
+    namespace: "{{ .ServicesNs }}"
+    channel: v3.23
+    packageName: ibm-ingress-nginx-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  - channel: v3.23
+    name: ibm-zen-operator
+    namespace: "{{ .ServicesNs }}"
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+    installMode: no-op
+  `
+
+	CSV3SaasOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators
+spec:
+  operators:
+  - name: ibm-mongodb-operator-v4.0
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
@@ -1020,24 +1111,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-management-ingress-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-management-ingress-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
-  - name: ibm-ingress-nginx-operator
-    namespace: "{{ .CPFSNs }}"
-    channel: v3.23
-    packageName: ibm-ingress-nginx-operator-app
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
   - channel: v3
     name: ibm-events-operator
     namespace: "{{ .CPFSNs }}"
@@ -1046,15 +1119,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: v3.23
-    name: ibm-zen-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
-    installMode: no-op
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
@@ -1090,6 +1154,7 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
 `
+)
 
 const ODLMSubscription = `
 apiVersion: operators.coreos.com/v1alpha1
@@ -1104,3 +1169,48 @@ spec:
   source: {{ .CatalogSourceName }}
   sourceNamespace: "{{ .CatalogSourceNs }}"
 `
+
+// ConcatenateRegistries concatenate the two YAML strings and return the new YAML string
+func ConcatenateRegistries(baseRegistryTemplate, insertedRegistryTemplate string, data interface{}) (string, error) {
+	baseRegistry := &odlm.OperandRegistry{}
+	var template []byte
+	var err error
+	// unmarshal first OprandRegistry
+	if template, err = applyTemplate(baseRegistryTemplate, data); err != nil {
+		return "", err
+	}
+	if err := utilyaml.Unmarshal(template, &baseRegistry); err != nil {
+		return "", fmt.Errorf("failed to fetch data of OprandRegistry %v: %v", baseRegistry, err)
+	}
+
+	// unmarshal second OprandRegistry
+	insertedRegistry := &odlm.OperandRegistry{}
+	if template, err = applyTemplate(insertedRegistryTemplate, data); err != nil {
+		return "", err
+	}
+	if err := utilyaml.Unmarshal(template, &insertedRegistry); err != nil {
+		return "", fmt.Errorf("failed to fetch data of OprandRegistry %v: %v", insertedRegistry, err)
+	}
+
+	var newOperators []odlm.Operator
+	newOperators = append(newOperators, baseRegistry.Spec.Operators...)
+	newOperators = append(newOperators, insertedRegistry.Spec.Operators...)
+
+	baseRegistry.Spec.Operators = newOperators
+	opregBytes, err := json.Marshal(baseRegistry)
+	if err != nil {
+		return "", err
+	}
+
+	return string(opregBytes), nil
+}
+
+func applyTemplate(objectTemplate string, data interface{}, alwaysUpdate ...bool) ([]byte, error) {
+	var buffer bytes.Buffer
+	t := template.Must(template.New("newTemplate").Parse(objectTemplate))
+	if err := t.Execute(&buffer, data); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -64,6 +64,25 @@ const ConfigurationRules = `
           limits:
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: LARGEST_VALUE
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+      metrics:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -371,26 +390,6 @@ const ConfigurationRules = `
               cpu: LARGEST_VALUE
               memory: LARGEST_VALUE
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: LARGEST_VALUE
-      resources:
-        requests:
-          memory: LARGEST_VALUE
-          cpu: LARGEST_VALUE
-        limits:
-          memory: LARGEST_VALUE
-          cpu: LARGEST_VALUE
-      commonWebUIConfig:
-        dashboardData:
-          resources:
-            limits:
-              cpu: LARGEST_VALUE
-              memory: LARGEST_VALUE
-            requests:
-              cpu: LARGEST_VALUE
-              memory: LARGEST_VALUE
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: LARGEST_VALUE

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -63,6 +63,25 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3Gi
+        requests:
+          cpu: 500m
+          memory: 3Gi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Large = `
           memory: 660Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 3
-      resources:
-        requests:
-          memory: 490Mi
-          cpu: 450m
-        limits:
-          memory: 660Mi
-          cpu: 1000m
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -63,6 +63,25 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3072Mi
+        requests:
+          cpu: 500m
+          memory: 3072Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Large = `
           cpu: 300m
           memory: 384Mi
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 3
-      resources:
-        limits:
-          cpu: 1000m
-          memory: 1225Mi
-        requests:
-          cpu: 300m
-          memory: 384Mi
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -63,6 +63,25 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3072Mi
+        requests:
+          cpu: 500m
+          memory: 3072Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Large = `
           cpu: 300m
           memory: 384Mi
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 3
-      resources:
-        limits:
-          cpu: 1000m
-          memory: 430Mi
-        requests:
-          cpu: 300m
-          memory: 384Mi
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -63,6 +63,25 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2Gi
+        requests:
+          cpu: 500m
+          memory: 2Gi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Medium = `
           memory: 660Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 2
-      resources:
-        requests:
-          memory: 480Mi
-          cpu: 450m
-        limits:
-          memory: 660Mi
-          cpu: 1000m
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -63,6 +63,25 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2048Mi
+        requests:
+          cpu: 500m
+          memory: 2048Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Medium = `
           cpu: 300m
           memory: 376Mi
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 2
-      resources:
-        limits:
-          cpu: 1000m
-          memory: 1225Mi
-        requests:
-          cpu: 300m
-          memory: 376Mi
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -63,6 +63,25 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2048Mi
+        requests:
+          cpu: 500m
+          memory: 2048Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Medium = `
           cpu: 300m
           memory: 376Mi
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 2
-      resources:
-        limits:
-          cpu: 1000m
-          memory: 430Mi
-        requests:
-          cpu: 300m
-          memory: 376Mi
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -63,6 +63,25 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 640Mi
+        requests:
+          cpu: 500m
+          memory: 640Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Small = `
           memory: 440Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 1
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 130m
-        limits:
-          memory: 440Mi
-          cpu: 1000m
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -63,6 +63,25 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Small = `
           memory: 800Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 1
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 150m
-        limits:
-          memory: 800Mi
-          cpu: 1000m
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -63,6 +63,25 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const Small = `
           memory: 440Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 1
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 150m
-        limits:
-          memory: 440Mi
-          cpu: 1000m
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -63,6 +63,25 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 640Mi
+        requests:
+          cpu: 500m
+          memory: 640Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const StarterSet = `
           memory: 440Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 1
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 130m
-        limits:
-          memory: 440Mi
-          cpu: 1000m
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -63,6 +63,25 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const StarterSet = `
           memory: 800Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 1
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 150m
-        limits:
-          memory: 800Mi
-          cpu: 1000m
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -63,6 +63,25 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -353,17 +372,6 @@ const StarterSet = `
           memory: 440Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
-  spec:
-    commonWebUI:
-      replicas: 1
-      resources:
-        requests:
-          memory: 256Mi
-          cpu: 150m
-        limits:
-          memory: 440Mi
-          cpu: 1000m
-- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1


### PR DESCRIPTION
Introduced a new function `ConcatenateRegistries` essentially combines the `Operators` from two OperandRegistry objects and returns the concatenated YAML representation of the modified OperandRegistry.

for issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/58224

####  The function performs the following steps:

- It creates two OperandRegistry objects: `baseRegistry` and `insertedRegistry` by unmarshaling the YAML templates using the applyTemplate function.
- It appends the `Operators` from `insertedRegistry` to the existing `Operators` in `baseRegistry`.
- It marshals the modified base object back to YAML format using json.Marshal.
- It returns the resulting YAML string and any error that occurred during the process.

#### Verify
test image: quay.io/yuchen_shen/cs_operator:split_opreg
delete origin OprandRegistry and it will create a new one with the entries of CP2 and followed by the entries of CP3.
