### PR TITLE
wait for licensing instance to be created before accepting license

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -936,6 +936,10 @@ function accept_license() {
     local kind=$1
     local namespace=$2
     local cr_name=$3
-    ${OC} patch "$kind" "$cr_name" -n "$namespace" --type='merge' -p '{"spec":{"license":{"accept":true}}}' || warning "Failed to update license acceptance for $kind CR $cr_name"
-    info "License accepted for $kind $cr_name."
+    ${OC} patch "$kind" "$cr_name" -n "$namespace" --type='merge' -p '{"spec":{"license":{"accept":true}}}' || export fail="true"
+    if [[ $fail == "true" ]]; then
+        warning "Failed to update license acceptance for $kind CR $cr_name"
+    else
+        info "License accepted for $kind $cr_name."
+    fi
 }

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -204,7 +204,19 @@ EOF
     create_operator_group "ibm-licensing-operator-app" "${LICENSING_NAMESPACE}" "$target"
     create_subscription "ibm-licensing-operator-app" "${LICENSING_NAMESPACE}" "$CHANNEL" "ibm-licensing-operator-app" "${LICENSING_SOURCE}" "${SOURCE_NS}" "${INSTALL_MODE}"
     wait_for_operator "${LICENSING_NAMESPACE}" "ibm-licensing-operator"
+    wait_for_license_instance
     accept_license "ibmlicensing" "" "instance"
+}
+
+function wait_for_license_instance() {
+    local name="instance"
+    local condition="${OC} get ibmlicensing -A --no-headers --ignore-not-found | grep ${name} || true"
+    local retries=20
+    local sleep_time=15
+    local total_time_mins=$(( sleep_time * retries / 60))
+    local success_message="ibmlicensing ${name} present"
+    local error_message="Timeout after ${total_time_mins} minutes waiting for ibmlicensing ${name} to be present."
+    wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
 }
 
 function pre_req() {


### PR DESCRIPTION
SERT team has consistently had trouble with the `--license-accept` option when running the `setup_singleton.sh` script. From the log output, it appears that the `ibmlicensing` instance is not created by the time the `accept_license` function attempts to edit it resulting in a warning and the license not being accepted. Logs look like the following:
```
[INFO] Waiting for operator ibm-licensing-operator in namespace cs-control-ns to be made available
[INFO] RETRYING: Waiting for operator ibm-licensing-operator in namespace cs-control-ns to be made available (50 left)
[INFO] RETRYING: Waiting for operator ibm-licensing-operator in namespace cs-control-ns to be made available (49 left)
[INFO] RETRYING: Waiting for operator ibm-licensing-operator in namespace cs-control-ns to be made available (48 left)
[✔] Operator ibm-licensing-operator in namespace cs-control-ns is available
Error from server (NotFound): ibmlicensings.operator.ibm.com "instance" not found
[✗] Failed to update license acceptance for ibmlicensing CR instance
[INFO] License accepted for ibmlicensing instance. 
```

Testing
- run setup singleton enabling licensing and accepting the license
- ensure script completes without seeing `[✗] Failed to update license acceptance for ibmlicensing CR instance`
- doublecheck the `ibmlicensing instance` for the license to be accepted