### PR TITLE
make preload data roks compatible

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -359,24 +359,25 @@ function swapmongopvc() {
     error "Volume for pvc  cs-mongodump not found in $FROM_NAMESPACE"
   fi
 
-  IMAGE=$(oc get pod icp-mongodb-0 -n $FROM_NAMESPACE  -o=jsonpath='{range .spec.containers[0]}{.image}{end}')
-  if [[ -z "$IMAGE" ]]; then
-    error "IMAGE for pod icp-mongodb-0 not found in $FROM_NAMESPACE"
-  fi
-
   oc patch pv $VOL -p '{"spec": { "persistentVolumeReclaimPolicy" : "Retain" }}'
   oc patch pv $VOL --type=merge -p '{"spec": {"claimRef":null}}'
   oc patch pv $VOL --type json -p '[{ "op": "remove", "path": "/spec/claimRef" }]'
   
   oc delete pvc cs-mongodump -n $FROM_NAMESPACE --ignore-not-found --timeout=10s
-    if [ $? -ne 0 ]; then
-        info "Failed to delete pvc cs-mongodump, patching its finalizer to null..."
-        oc patch pvc cs-mongodump -n $FROM_NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
-    fi
+  if [ $? -ne 0 ]; then
+      info "Failed to delete pvc cs-mongodump, patching its finalizer to null..."
+      oc patch pvc cs-mongodump -n $FROM_NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
+  fi
 
-  stgclass=$(oc get pvc mongodbdir-icp-mongodb-0 -n $FROM_NAMESPACE -o=jsonpath='{.spec.storageClassName}')
-  if [[ -z $stgclass ]]; then
-    error "Cannnot get storage class name from PVC mongodbdir-icp-mongodb-0 in $FROM_NAMESPACE"
+  roks=$(oc cluster-info | grep 'containers.cloud.ibm.com')
+  if [[ -z $roks ]]; then
+    stgclass=$(oc get pvc mongodbdir-icp-mongodb-0 -n $FROM_NAMESPACE -o=jsonpath='{.spec.storageClassName}')
+    if [[ -z $stgclass ]]; then
+      error "Cannnot get storage class name from PVC mongodbdir-icp-mongodb-0 in $FROM_NAMESPACE"
+    fi
+  else
+    debug1 "Preload run on ROKS, not setting storageclass name"
+    stgclass=""
   fi
 
   cat <<EOF >$TEMPFILE
@@ -391,7 +392,7 @@ spec:
   resources:
     requests:
       storage: 20Gi
-  storageClassName: $stgclass
+  storageClassName: "$stgclass"
   volumeMode: Filesystem
   volumeName: $VOL
 EOF


### PR DESCRIPTION
The preload script was not roks compatible due to specifying the storageclass name in the PVC creation during the `swapmongopvc` function. I have not seen this issue myself but it was brought up by Mike Kaczmarski and this was ostensibly the only change required.

Testing:
- setup shared common services installed on a roks cluster, setup ldap users
- run the preload_data.sh script
- ensure script completes successfully, verify the  mongodbdir-icp-mongodb-0 pvc is bound in the target namespace
- run conversion using the target namespace of the preload script as the new cs instance, verify ldap can login to new cs namespace