### PR TITLE
only wait for iam if it's requested during rollback

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -255,7 +255,8 @@ function check_IAM(){
         do
             zenservice_exists=$(${OC} get zenservice -n $cp_namespace || echo fail)
             if [[ $zenservice_exists != "fail" ]] && [[ $zenservice_exists != "" ]]; then
-                iam_enabled=$(${OC} get zenservice -n $cp_namespace -o yaml | grep iamIntegration | awk '{print $2}')
+                zenservice=$(${OC} get zenservice -n $cp_namespace --no-headers | awk '{print $1}')
+                iam_enabled=$(${OC} get zenservice $zenservice -n $cp_namespace -o yaml | ${YQ} '.spec.iamIntegration')
                 if [[ $iam_enabled == "true" ]]; then
                     if [[ $namespaces == "" ]]; then
                         namespaces="$cs_namespace"

--- a/rollback-multi-instance.sh
+++ b/rollback-multi-instance.sh
@@ -302,16 +302,15 @@ function check_IAM(){
     do
         zenservice_exists=$(${OC} get zenservice -n $cp_namespace || echo fail)
         if [[ $zenservice_exists != "fail" ]] && [[ $zenservice_exists != "" ]]; then
-            iam_enabled=$(${OC} get zenservice -n $cp_namespace -o yaml | grep iamIntegration | awk '{print $2}')
+            zenservice=$(${OC} get zenservice -n $cp_namespace --no-headers | awk '{print $1}')
+            iam_enabled=$(${OC} get zenservice $zenservice -n $cp_namespace -o yaml | ${YQ} '.spec.iamIntegration')
             if [[ $iam_enabled == "true" ]]; then
                 break
-            else
-                info "IAM not requested by zenservice in namespace $cp_namespace, skipping wait."
             fi
         fi
     done
     
-    if [[ $iam_enabled ]]; then
+    if [[ $iam_enabled == "true" ]]; then
         retries=40
         sleep_time=30
         total_time_mins=$(( sleep_time * retries / 60))
@@ -337,6 +336,8 @@ function check_IAM(){
                 break
             fi
         done
+    else
+        info "IAM not requested by zen, skipping wait."
     fi
 }
 


### PR DESCRIPTION
Similar to the changes made for the conversion script here https://github.com/IBM/ibm-common-service-operator/pull/1171

Low priority given current use case for rollback and the scenario required for this to be a blocker but I ran into it in my testing of https://github.com/IBM/ibm-common-service-operator/pull/1227 so opened a pr before forgetting. 

Basically, we are looking if any of the cp namespaces have a zenservice that requested iam. If they do, we wait for iam to come ready in master ns and if they do not, we skip the wait.

Testing:
- setup a converted cluster with zen requested, create zenservice that sets `iamIntegration: false`
- ensure no other zenservices enable iam
- rollback the cluster
- verify the script completes and does not wait on iam to come ready

example cs maps for start of the test:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: common-service-maps
  namespace: kube-public
data:
  common-service-maps.yaml: |
    controlNamespace: cs-control
    namespaceMapping:
    - requested-from-namespace:
      - zen
      map-to-common-service-namespace: ibm-common-services
```
example csmaps pre-rollback (just make sure to remove the control namespace before running script):
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: common-service-maps
  namespace: kube-public
data:
  common-service-maps.yaml: |
    namespaceMapping:
    - requested-from-namespace:
      - zen
      map-to-common-service-namespace: ibm-common-services
```