### PR TITLE
Enable Licensing Service Migration

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -58,7 +58,7 @@ function main() {
 
     # Migrate singleton services
     local arguments="--enable-licensing"
-    arguments=" -licensingNs $CONTROL_NS"
+    arguments+=" -licensingNs $CONTROL_NS"
 
     if [[ $ENABLE_PRIVATE_CATALOG -eq 1 ]]; then
         arguments+=" --enable-private-catalog"


### PR DESCRIPTION
The issue is that `arguments` variable is assigned twice, and `arguments="--enable-licensing"` is overwritten.

### There is no licensing migration before change
```
[INFO] Waiting for pod cert-manager-cainjector in namespace cs-control to be deleting
[✔] Pod cert-manager-cainjector in namespace cs-control is deleted
[INFO] Waiting for pod cert-manager-controller in namespace cs-control to be deleting
[✔] Pod cert-manager-controller in namespace cs-control is deleted
[INFO] Waiting for pod cert-manager-webhook in namespace cs-control to be deleting
[✔] Pod cert-manager-webhook in namespace cs-control is deleted
[INFO] Waiting for pod ibm-cert-manager-operator in namespace cs-control to be running
[✔] Pod ibm-cert-manager-operator in namespace cs-control is running

[✔] Migration is completed for Cloud Pak 3.0 Foundational singleton services.
```

### There is licensing migration after change
```
[INFO] Waiting for pod cert-manager-cainjector in namespace cs-control to be deleting
[✔] Pod cert-manager-cainjector in namespace cs-control is deleted
[INFO] Waiting for pod cert-manager-controller in namespace cs-control to be deleting
[✔] Pod cert-manager-controller in namespace cs-control is deleted
[INFO] Waiting for pod cert-manager-webhook in namespace cs-control to be deleting
[✔] Pod cert-manager-webhook in namespace cs-control is deleted
[INFO] Waiting for pod ibm-cert-manager-operator in namespace cs-control to be running
[✔] Pod ibm-cert-manager-operator in namespace cs-control is running
# Deleting ibm-licensing-operator in namesapce cs-control...
[1] Removing the subscription of ibm-licensing-operator in namesapce cs-control ...
[2] Removing the csv of ibm-licensing-operator in namesapce cs-control ...

[✔] Remove ibm-licensing-operator successfully.

[✔] Migration is completed for Cloud Pak 3.0 Foundational singleton services.
```