### PR TITLE
check necessary br files in filesystem

### DIFF
--- a/backup_restore_mongo.sh
+++ b/backup_restore_mongo.sh
@@ -122,17 +122,17 @@ function prep_backup() {
     #TODO add clarifying messages and check response code to make more transparent
     #backup files
     info "Checking for necessary backup files..."
-    if [[ -f "mongodbbackup.yaml" ]]; then
+    if [[ -f "./velero/backup/mongoDB/mongodbbackup.yaml" ]]; then
         info "mongodbbackup.yaml already present"
     else
         info "mongodbbackup.yaml not found, downloading from https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/backup/mongoDB/mongodbbackup.yaml"
         wget -O mongodbbackup.yaml https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/backup/mongoDB/mongodbbackup.yaml || error "Failed to download mongodbbackup.yaml"
     fi
 
-    if [[ -f "mongo-backup.sh" ]]; then
+    if [[ -f "./velero/backup/mongoDB/mongo-backup.sh" ]]; then
         info "mongo-backup.sh already present"
     else
-        info "mongodbbackup.yaml not found, downloading from https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/backup/mongoDB/mongo-backup.sh"
+        info "./velero/backup/mongoDB/mongodbbackup.yaml not found, downloading from https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/backup/mongoDB/mongo-backup.sh"
         wget -O mongo-backup.sh https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/backup/mongoDB/mongo-backup.sh
     fi
 
@@ -208,21 +208,21 @@ function prep_restore() {
     
     #Restore files
     info "Checking for necessary restore files..."
-    if [[ -f "mongodbrestore.yaml" ]]; then
+    if [[ -f "./velero/restore/mongoDB/mongodbrestore.yaml" ]]; then
         info "mongodbrestore.yaml already present"
     else
         info "mongodbrestore.yaml not found, downloading from https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/restore/mongoDB/mongodbrestore.yaml"
         wget https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/restore/mongoDB/mongodbrestore.yaml || error "Failed to download mongodbrestore.yaml"
     fi
 
-    if [[ -f "set_access.js" ]]; then
+    if [[ -f "./velero/restore/mongoDB/set_access.js" ]]; then
         info "set_access.js already present"
     else
         info "set_access.js not found, downloading from https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/restore/mongoDB/set_access.js"
         wget https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/restore/mongoDB/set_access.js || error "Failed to download set_access.js"
     fi
 
-    if [[ -f "mongo-restore.sh" ]]; then
+    if [[ -f "./velero/restore/mongoDB/mongo-restore.sh" ]]; then
         info "mongo-restore.sh already present"
     else
         info "set_access.js not found, downloading from https://raw.githubusercontent.com/IBM/ibm-common-service-operator/scripts/velero/restore/mongoDB/mongo-restore.sh"


### PR DESCRIPTION
Adding the scripts repo to the case bundles means that we can expect the file system to be the same in the bundle (and in airgap scenarios) as what is in the scripts repo. As it is now, the checks for files to be present would fail since the necessary files are in separate directories. This would cause the script to fail ostensibly due to a lack of prereq files when they are already present. Changing the check to check the relative file path should resolve that. We'll just need to make sure to update it should the layout of the scripts branch change.