### PR TITLE
skip restarting cert-manager if it not installed

### DIFF
--- a/cp3pt0-deployment/common/delegate_cp2_cert_manager.sh
+++ b/cp3pt0-deployment/common/delegate_cp2_cert_manager.sh
@@ -140,15 +140,18 @@ EOF
     fi
     msg ""
 
-    info "Restarting IBM Cloud Pak 2.0 Cert Manager to provide cert-rotation only..."
-    oc delete pod -l name=ibm-cert-manager-operator -n ${CONTROL_NS} --ignore-not-found
-    msg ""
-
+    is_exist=$(${OC} get pod -l name=ibm-cert-manager-operator -n ${CONTROL_NS} --ignore-not-found | grep "ibm-cert-manager-operator" || echo "failed")
+    if  [[ $is_exist != "failed" ]]; then
+        info "Restarting IBM Cloud Pak 2.0 Cert Manager to provide cert-rotation only..."
+            ${OC} delete pod -l name=ibm-cert-manager-operator -n ${CONTROL_NS} --ignore-not-found
+        msg ""
+        wait_for_pod ${CONTROL_NS} "ibm-cert-manager-operator"
+    else
+        warning "IBM Cloud Pak 2.0 Cert Manager does not exist in namespace ${CONTROL_NS}, skip restarting cert manager pod..."
+    fi
     wait_for_no_pod ${CONTROL_NS} "cert-manager-cainjector"
     wait_for_no_pod ${CONTROL_NS} "cert-manager-controller"
     wait_for_no_pod ${CONTROL_NS} "cert-manager-webhook"
-
-    wait_for_pod ${CONTROL_NS} "ibm-cert-manager-operator"
 
 }
 


### PR DESCRIPTION
There is a case that cert-manager is not installed in control namespace. So we will skip waiting for cert-manager-operator running the control namespace.

### How to test
- Scale down CP2 ODLM if there is CP2 OperandRequest asking for cert-manager
- Delete IBM cert-manager operator v3 from control namespace
- execute script `./common/delegate_cp2_cert_manager.sh --control-namespace cs-control`
```
./common/delegate_cp2_cert_manager.sh --control-namespace cs-control
[✔] oc command available
[✔] oc command logged in as kube:admin
# De-activating IBM Cloud Pak 2.0 Cert Manager in cs-control...

[INFO] Configuring Common Services Cert Manager..
configmap/ibm-cpp-config configured

[INFO] Deleting existing Cert Manager CR...

[✗] IBM Cloud Pak 2.0 Cert Manager does not exist in namespace cs-control, skip restarting cert manager pod...
[INFO] Waiting for pod cert-manager-cainjector in namespace cs-control to be deleting
[✔] Pod cert-manager-cainjector in namespace cs-control is deleted
[INFO] Waiting for pod cert-manager-controller in namespace cs-control to be deleting
[✔] Pod cert-manager-controller in namespace cs-control is deleted
[INFO] Waiting for pod cert-manager-webhook in namespace cs-control to be deleting
[✔] Pod cert-manager-webhook in namespace cs-control is deleted
```