### PR TITLE
Initial upload of CP3 network policies

### DIFF
--- a/cp3-networkpolicy/README.md
+++ b/cp3-networkpolicy/README.md
@@ -1,0 +1,69 @@
+# Overview
+
+This folder contains the list of network policies those required for Bedrock Common Services to work in a cluster where the deny_all policy has been implemented. The script **install_networkpolicy.sh** provided to install all the YAML definition of NetworkPolicies for Bedrock Common Services to the specified namespace. If you have the deny-all policy in place, the ingress traffic to all pods in not allowed. In this scenario, for foundational services to work, you need to import and install network policies. If you do not use deny-all policy, you may not need to import or install network policies.
+
+For more details on the usage of the script and to check various supported inputs , refer to the [document section](https://www.ibm.com/docs/en/cpfs?topic=operator-installing-network-policies)
+
+## Sample usage - installing Network Policies
+
+```
+networkpolicy % ./install_networkpolicy.sh -n services-namespace -o operators-namespace
+# [0] Checking prerequisites ...
+-----------------------------------------------------------------------
+[✔] oc command available
+[✔] oc command logged in as user
+[✔] IBM Common Services found in namespace operators-namespace
+# [0] Installing IBM Common Services Network Policies ...
+-----------------------------------------------------------------------
+[INFO] Using IBM Common Services namespace: services-namespace
+[INFO] Using operators namespace: operators-namespace
+[INFO] Installing access-to-common-web-ui.yaml ...
+networkpolicy.networking.k8s.io/access-to-common-web-ui created
+[INFO] Installing access-to-edb-postgres.yaml ...
+networkpolicy.networking.k8s.io/access-to-edb-postgres created
+[INFO] Installing access-to-icp-mongodb.yaml ...
+networkpolicy.networking.k8s.io/access-to-icp-mongodb created
+[INFO] Installing access-to-platform-auth-service.yaml ...
+networkpolicy.networking.k8s.io/access-to-platform-auth-service created
+[INFO] Installing access-to-platform-identity-management.yaml ...
+networkpolicy.networking.k8s.io/access-to-platform-identity-management created
+[INFO] Installing access-to-platform-identity-provider.yaml ...
+networkpolicy.networking.k8s.io/access-to-platform-identity-provider created
+[INFO] Installing access-to-zen-stopgap.yaml ...
+networkpolicy.networking.k8s.io/access-to-zen-stopgap created
+[INFO] Installing access-to-edb-postgres-webhooks.yaml ...
+networkpolicy.networking.k8s.io/access-to-edb-postgres-webhooks created
+[INFO] Installing access-to-ibm-common-service-operator.yaml ...
+networkpolicy.networking.k8s.io/access-to-ibm-common-service-operator created
+[INFO] Installing access-to-zen-meta-api.yaml ...
+networkpolicy.networking.k8s.io/access-to-zen-meta-api created
+[INFO] Installing allow-webhook-access-from-apiserver.yaml ...
+networkpolicy.networking.k8s.io/allow-webhook-access-from-apiserver created
+```
+
+## Sample usage - removing Network Policies
+
+```
+networkpolicy % ./install_networkpolicy.sh -u
+# [0] Checking prerequesites ...
+-----------------------------------------------------------------------
+[✔] oc command available
+[✔] oc command logged in as [redacted]
+[✔] IBM Common Services found in namespace ibm-common-services
+# [0] Removing Bedrock Network Policies ...
+-----------------------------------------------------------------------
+networkpolicy.networking.k8s.io "access-to-common-web-ui" deleted
+networkpolicy.networking.k8s.io "access-to-edb-postgres" deleted
+networkpolicy.networking.k8s.io "access-to-icp-mongodb" deleted
+networkpolicy.networking.k8s.io "access-to-platform-auth-service" deleted
+networkpolicy.networking.k8s.io "access-to-platform-identity-management" deleted
+networkpolicy.networking.k8s.io "access-to-platform-identity-provider" deleted
+networkpolicy.networking.k8s.io "access-to-zen-stopgap" deleted
+networkpolicy.networking.k8s.io "access-to-edb-postgres-webhooks" deleted
+networkpolicy.networking.k8s.io "access-to-ibm-common-service-operator" deleted
+networkpolicy.networking.k8s.io "access-to-zen-meta-api" deleted
+networkpolicy.networking.k8s.io "allow-webhook-access-from-apiserver" deleted
+No resources found
+-----------------------------------------------------------------------
+[✔] Bedrock NetworkPolicies installation completed.
+```

--- a/cp3-networkpolicy/ingress/cert-manager/allow-webhook-access-from-apiserver.yaml
+++ b/cp3-networkpolicy/ingress/cert-manager/allow-webhook-access-from-apiserver.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: allow-webhook-access-from-apiserver
+  namespace: "certNamespace"
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          apiserver: "true"
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/cert-manager/bedrock-access-to-cert-manager-webhook.yaml
+++ b/cp3-networkpolicy/ingress/cert-manager/bedrock-access-to-cert-manager-webhook.yaml
@@ -1,0 +1,13 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-cert-manager-webhook
+  namespace: "certNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      app: ibm-cert-manager-webhook
+  ingress:
+  - {}

--- a/cp3-networkpolicy/ingress/license-service/bedrock-access-to-license-service-reporter.yaml
+++ b/cp3-networkpolicy/ingress/license-service/bedrock-access-to-license-service-reporter.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-ibm-licensing-service-reporter
+  namespace: "licNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      app: ibm-license-service-reporter-instance
+  ingress:
+    - {}
+  policyTypes:
+    - Ingress

--- a/cp3-networkpolicy/ingress/license-service/bedrock-access-to-license-service.yaml
+++ b/cp3-networkpolicy/ingress/license-service/bedrock-access-to-license-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-ibm-licensing-service-instance
+  namespace: "licNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      app: ibm-licensing-service-instance
+  ingress:
+    - {}
+  policyTypes:
+    - Ingress

--- a/cp3-networkpolicy/ingress/operators/access-to-edb-postgres-webhooks.yaml
+++ b/cp3-networkpolicy/ingress/operators/access-to-edb-postgres-webhooks.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-edb-postgres-webhooks
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: cloud-native-postgresql
+  policyTypes:
+  - Ingress
+

--- a/cp3-networkpolicy/ingress/operators/access-to-edb-postgres-webhooks.yaml
+++ b/cp3-networkpolicy/ingress/operators/access-to-edb-postgres-webhooks.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     component: cpfs3
   name: access-to-edb-postgres-webhooks
-  namespace: "csNamespace"
+  namespace: "opNamespace"
 spec:
   ingress:
   - {}
@@ -13,4 +13,3 @@ spec:
       app.kubernetes.io/name: cloud-native-postgresql
   policyTypes:
   - Ingress
-

--- a/cp3-networkpolicy/ingress/operators/access-to-ibm-common-service-operator.yaml
+++ b/cp3-networkpolicy/ingress/operators/access-to-ibm-common-service-operator.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-ibm-common-service-operator
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      name: ibm-common-service-operator
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/operators/access-to-ibm-common-service-operator.yaml
+++ b/cp3-networkpolicy/ingress/operators/access-to-ibm-common-service-operator.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     component: cpfs3
   name: access-to-ibm-common-service-operator
-  namespace: "csNamespace"
+  namespace: "opNamespace"
 spec:
   ingress:
   - {}

--- a/cp3-networkpolicy/ingress/operators/access-to-zen-meta-api.yaml
+++ b/cp3-networkpolicy/ingress/operators/access-to-zen-meta-api.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     component: cpfs3
   name: access-to-zen-meta-api
-  namespace: "csNamespace"
+  namespace: "opNamespace"
 spec:
   ingress:
   - {}

--- a/cp3-networkpolicy/ingress/operators/access-to-zen-meta-api.yaml
+++ b/cp3-networkpolicy/ingress/operators/access-to-zen-meta-api.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-zen-meta-api
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: ibm-zen-meta-api
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/operators/allow-webhook-access-from-apiserver.yaml
+++ b/cp3-networkpolicy/ingress/operators/allow-webhook-access-from-apiserver.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: allow-webhook-access-from-apiserver
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - from:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          apiserver: "true"
+  podSelector: {}
+  policyTypes:
+  - Ingress
+

--- a/cp3-networkpolicy/ingress/operators/allow-webhook-access-from-apiserver.yaml
+++ b/cp3-networkpolicy/ingress/operators/allow-webhook-access-from-apiserver.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     component: cpfs3
   name: allow-webhook-access-from-apiserver
-  namespace: "csNamespace"
+  namespace: "opNamespace"
 spec:
   ingress:
   - from:

--- a/cp3-networkpolicy/ingress/services/access-to-common-web-ui.yaml
+++ b/cp3-networkpolicy/ingress/services/access-to-common-web-ui.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-common-web-ui
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      k8s-app: common-web-ui
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/services/access-to-edb-postgres.yaml
+++ b/cp3-networkpolicy/ingress/services/access-to-edb-postgres.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-edb-postgres
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchExpressions:
+    - key: k8s.enterprisedb.io/cluster
+      operator: Exists
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/services/access-to-icp-mongodb.yaml
+++ b/cp3-networkpolicy/ingress/services/access-to-icp-mongodb.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-icp-mongodb
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      app: icp-mongodb
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/services/access-to-platform-auth-service.yaml
+++ b/cp3-networkpolicy/ingress/services/access-to-platform-auth-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-platform-auth-service
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      k8s-app: platform-auth-service
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/services/access-to-platform-identity-management.yaml
+++ b/cp3-networkpolicy/ingress/services/access-to-platform-identity-management.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-platform-identity-management
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      k8s-app: platform-identity-management
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/services/access-to-platform-identity-provider.yaml
+++ b/cp3-networkpolicy/ingress/services/access-to-platform-identity-provider.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-platform-identity-provider
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      k8s-app: platform-identity-provider
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/services/access-to-zen-stopgap.yaml
+++ b/cp3-networkpolicy/ingress/services/access-to-zen-stopgap.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs3
+  name: access-to-zen-stopgap
+  namespace: "csNamespace"
+spec:
+  ingress:
+  - {}
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: Exists
+  policyTypes:
+  - Ingress

--- a/cp3-networkpolicy/ingress/services/zen-access-to-audit-svc.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-audit-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-audit-svc
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-audit"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} 

--- a/cp3-networkpolicy/ingress/services/zen-access-to-nginx.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-nginx.yaml
@@ -1,16 +1,15 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: access-to-ibm-nginx
+  namespace: "csNamespace"
   labels:
     component: cpfs3
-  name: access-to-zen-stopgap
-  namespace: "csNamespace"
 spec:
-  ingress:
-  - {}
   podSelector:
-    matchExpressions:
-    - key: app
-      operator: Exists
+    matchLabels:
+      component: "ibm-nginx"
   policyTypes:
   - Ingress
+  ingress:
+  - {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-usermgmt.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-usermgmt.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-usermgmt
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "usermgmt"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector: 
+        matchLabels:
+          kubernetes.io/metadata.name: "opNamespace"
+    - podSelector: {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-core-api.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-core-api.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-core-api
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-core-api"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector: 
+        matchLabels:
+          kubernetes.io/metadata.name: "opNamespace"
+    - podSelector: {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-core.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-core.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-core
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-core"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-minio.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-minio.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-minio
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-minio"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: "opNamespace"
+    - podSelector: {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-volumes.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-volumes.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-volumes
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      icpdsupport/app: volumes
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} 

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-watchdog.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-watchdog.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-watchdog
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-watchdog"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} 

--- a/cp3-networkpolicy/ingress/services/zen-allow-iam-config-job.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-allow-iam-config-job.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-iam-config-job
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "iam-config-job"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}

--- a/cp3-networkpolicy/install_networkpolicy.sh
+++ b/cp3-networkpolicy/install_networkpolicy.sh
@@ -197,12 +197,12 @@ function install_networkpolicy() {
     
     for policyfile in `ls -1 ${BASE_DIR}/services/*.yaml`; do
         info "Installing `basename ${policyfile}` ..."
-        cat ${policyfile} | sed -e "s/csNamespace/${CS_NAMESPACE}/g" | oc apply -f -
+        cat ${policyfile} | sed -e "s/csNamespace/${CS_NAMESPACE}/g" | sed -e "s/opNamespace/${OPERATORS_NAMESPACE}/g" | oc apply -f -
     done
 
     for policyfile in `ls -1 ${BASE_DIR}/operators/*.yaml`; do
         info "Installing `basename ${policyfile}` ..."
-        cat ${policyfile} | sed -e "s/csNamespace/${OPERATORS_NAMESPACE}/g" | oc apply -f -
+        cat ${policyfile} | sed -e "s/csNamespace/${CS_NAMESPACE}/g" | sed -e "s/opNamespace/${OPERATORS_NAMESPACE}/g" | oc apply -f -
     done
 
 }

--- a/cp3-networkpolicy/install_networkpolicy.sh
+++ b/cp3-networkpolicy/install_networkpolicy.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+# Licensed Materials - Property of IBM
+# Copyright IBM Corporation 2023. All Rights Reserved
+# US Government Users Restricted Rights -
+# Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# This is an internal component, bundled with an official IBM product. 
+# Please refer to that particular license for additional information. 
+
+
+# ---------- Command variables ----------
+
+# script base directory
+BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
+
+# common-services namespace
+CS_NAMESPACE=
+
+# operators namespace
+OPERATORS_NAMESPACE=
+
+# is uninstall flag?
+UNINSTALL=
+
+IFS='
+'
+
+
+# counter to keep track of installation steps
+STEP=0
+
+# ---------- Main functions ----------
+
+function msg() {
+    printf '%b\n' "$1"
+}
+
+function info() {
+    msg "[INFO] ${1}"
+}
+
+function success() {
+    msg "\33[32m[✔] ${1}\33[0m"
+}
+
+function warning() {
+    msg "\33[33m[✗] ${1}\33[0m"
+}
+
+function error() {
+    msg "\33[31m[✘] ${1}\33[0m"
+    exit 1
+}
+
+function title() {
+    msg "\33[34m# ${1}\33[0m"
+}
+
+function translate_step() {
+    local step=$1
+    echo "${step}" | tr '[1-9]' '[a-i]'
+}
+
+function main() {
+    parse_arguments "$@"
+    install_policies
+}
+
+function install_policies() {
+    check_prereqs # TODO: uncomment me
+
+    if [[ -z ${UNINSTALL} ]]; then
+        install_networkpolicy
+    fi
+    if [[ ${UNINSTALL} == "true" ]]; then
+        delete_networkpolicy
+    fi
+
+    msg "-----------------------------------------------------------------------"
+    success "IBM Common Services NetworkPolicies installation or removal completed at $(date) ."
+    exit 0
+}
+
+function print_usage() {
+    script_name=`basename ${0}`
+    echo "Usage: ${script_name} [OPTIONS]..."
+    echo ""
+    echo "Install IBM Common Services NetworkPolicies"
+    echo ""
+    echo "Options:"
+    echo "   -n, --namespace string       IBM Common Services operand namespace. Default is same namespace for both operators and services"
+    echo "   -o, --operators-namespace string   Operators namespace. Default is same namespace as IBM Common Services"
+    echo "   -u, --uninstall              Uninstall IBM Common Services Network Policies"
+    echo "   -e, --egress                 Deploy egress NetworkPolicies"
+    echo "   -h, --help                   Print usage information"
+    echo ""
+}
+
+function parse_arguments() {
+    # process options
+    while [[ "$1" != "" ]]; do
+        case "$1" in
+        -n | --namespace)
+            shift
+            CS_NAMESPACE=$1
+            ;;
+        -o | --operators-namespace)
+            shift
+            OPERATORS_NAMESPACE=$1
+            ;;
+        -u | --uninstall)
+            shift
+            UNINSTALL=true
+            ;;
+        -e | --egress)
+            shift
+            EGRESS=true
+            ;;
+        -h | --help)
+            print_usage
+            exit 1
+            ;;
+        *) 
+            ;;
+        esac
+        shift
+    done
+}
+
+# ---------- Supporting functions ----------
+
+function check_prereqs() {
+    title "[$(translate_step ${STEP})] Checking prerequisites ..."
+    msg "-----------------------------------------------------------------------"
+
+    # checking oc command
+    if [[ -z "$(command -v oc 2> /dev/null)" ]]; then
+        error "oc command not available"
+    else
+        success "oc command available"
+    fi
+
+    # checking oc command logged in
+    user=$(oc whoami 2> /dev/null)
+    if [ $? -ne 0 ]; then
+        error "You must be logged into the OpenShift Cluster from the oc command line"
+    else
+        success "oc command logged in as ${user}"
+    fi
+
+    # checking for CS_NAMESPACE
+    if [[ -z "${CS_NAMESPACE}" ]]; then
+        CS_NAMESPACE=$(oc project -q)
+    fi
+
+    # check existence of CS_NAMESPACE
+    cs_namespace_exists=$(oc get project "${CS_NAMESPACE}" 2> /dev/null)
+    if [ $? -ne 0 ]; then
+        info "Creating IBM Common Services namespace: ${CS_NAMESPACE}"
+        oc create namespace "${CS_NAMESPACE}"
+    fi
+
+    # checking for ibm-common-service-operator in CS_NAMESPACE
+    if [[ -z "$(oc -n ${OPERATORS_NAMESPACE} get csv --ignore-not-found | grep 'ibm-common-service-operator')" ]]; then
+        info "IBM Common Services are not installed in namespace ${OPERATORS_NAMESPACE}"
+    else
+        success "IBM Common Services found in namespace ${OPERATORS_NAMESPACE}"
+    fi
+
+    # if OPERATORS_NAMESPACE is not specified, use CS_NAMESPACE
+    if [[ -z "${OPERATORS_NAMESPACE}" ]]; then
+        OPERATORS_NAMESPACE=${CS_NAMESPACE}
+    fi
+
+    # check existence of OPERATORS_NAMESPACE
+    operators_namespace_exists=$(oc get project "${OPERATORS_NAMESPACE}" 2> /dev/null)
+    if [ $? -ne 0 ]; then
+        info "Creating operators namespace: ${OPERATORS_NAMESPACE}"
+        oc create namespace "${OPERATORS_NAMESPACE}"
+    fi
+
+}
+
+function install_networkpolicy() {
+    title "[$(translate_step ${STEP})] Installing IBM Common Services Network Policies ..."
+    msg "-----------------------------------------------------------------------"
+
+    info "Using IBM Common Services namespace: ${CS_NAMESPACE}"
+    info "Using operators namespace: ${OPERATORS_NAMESPACE}"
+
+    if [[ ${EGRESS} == "true" ]]; then
+        BASE_DIR="${BASE_DIR}/egress"
+    else
+        BASE_DIR="${BASE_DIR}/ingress"
+    fi
+    
+    for policyfile in `ls -1 ${BASE_DIR}/services/*.yaml`; do
+        info "Installing `basename ${policyfile}` ..."
+        cat ${policyfile} | sed -e "s/csNamespace/${CS_NAMESPACE}/g" | oc apply -f -
+    done
+
+    for policyfile in `ls -1 ${BASE_DIR}/operators/*.yaml`; do
+        info "Installing `basename ${policyfile}` ..."
+        cat ${policyfile} | sed -e "s/csNamespace/${OPERATORS_NAMESPACE}/g" | oc apply -f -
+    done
+
+}
+
+function delete_networkpolicy() {
+    title "[$(translate_step ${STEP})] Removing IBM Common Services Network Policies ..."
+    msg "-----------------------------------------------------------------------"
+
+    oc delete networkpolicies -n ${CS_NAMESPACE} --selector=component=cpfs3
+    oc delete networkpolicies -n ${OPERATORS_NAMESPACE} --selector=component=cpfs3
+
+}
+
+# --- Run ---
+
+main $*


### PR DESCRIPTION
Contributes to https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58737 .
Added network policies for IM, Mongo, CS-operator and EDB. Added a stop-gap network policy for Zen, before the fine-grained one is provided.

cc @bitscuit @ujjwalchk-it 