### PR TITLE
move ns existence check earlier in script

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -82,9 +82,9 @@ function main() {
     create_empty_csmaps
     insert_control_ns
     update_tenant "${MASTER_NS}" "${ns_list}"
+    check_cm_ns_exist "$ns_list $CONTROL_NS" # debating on turning this off by default since this technically falls outside the scope of isolate
     removeNSS
     uninstall_singletons
-    check_cm_ns_exist "$ns_list $CONTROL_NS" # debating on turning this off by default since this technically falls outside the scope of isolate
     isolate_odlm "ibm-odlm" $MASTER_NS
     restart
     if [[ $CERT_MANAGER_MIGRATED == "true" ]]; then


### PR DESCRIPTION
Licensing noticed if cs-control was not already created before running script, isolate would fail if it needed to move over licensing configmaps because the check for cs-control to exist was after the call to move licensing configmaps.

Test:
- setup environment for isolation with at least one licensing configmap (can be dummy, see list of possible cms in script)
- do not create control namespace before running script
- run isolate script
- ensure control namespace is created before licensing configmaps are moved over
- ensure script completes successfully