### PR TITLE
Networkpolicies cp3 zen

### DIFF
--- a/cp3-networkpolicy/ingress/services/zen-access-to-audit-svc.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-audit-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-audit-svc
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-audit"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} 

--- a/cp3-networkpolicy/ingress/services/zen-access-to-nginx.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-nginx.yaml
@@ -1,16 +1,15 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: access-to-ibm-nginx
+  namespace: "csNamespace"
   labels:
     component: cpfs3
-  name: access-to-zen-stopgap
-  namespace: "csNamespace"
 spec:
-  ingress:
-  - {}
   podSelector:
-    matchExpressions:
-    - key: app
-      operator: Exists
+    matchLabels:
+      component: "ibm-nginx"
   policyTypes:
   - Ingress
+  ingress:
+  - {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-usermgmt.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-usermgmt.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-usermgmt
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "usermgmt"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector: 
+        matchLabels:
+          kubernetes.io/metadata.name: "opNamespace"
+    - podSelector: {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-core-api.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-core-api.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-core-api
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-core-api"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector: 
+        matchLabels:
+          kubernetes.io/metadata.name: "opNamespace"
+    - podSelector: {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-core.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-core.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-core
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-core"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-minio.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-minio.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-minio
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-minio"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: "opNamespace"
+    - podSelector: {}

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-volumes.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-volumes.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-volumes
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      icpdsupport/app: volumes
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} 

--- a/cp3-networkpolicy/ingress/services/zen-access-to-zen-watchdog.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-access-to-zen-watchdog.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: access-to-zen-watchdog
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "zen-watchdog"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {} 

--- a/cp3-networkpolicy/ingress/services/zen-allow-iam-config-job.yaml
+++ b/cp3-networkpolicy/ingress/services/zen-allow-iam-config-job.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-iam-config-job
+  namespace: "csNamespace"
+  labels:
+    component: cpfs3
+spec:
+  podSelector:
+    matchLabels:
+      component: "iam-config-job"
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector: {}

--- a/cp3-networkpolicy/install_networkpolicy.sh
+++ b/cp3-networkpolicy/install_networkpolicy.sh
@@ -197,7 +197,7 @@ function install_networkpolicy() {
     
     for policyfile in `ls -1 ${BASE_DIR}/services/*.yaml`; do
         info "Installing `basename ${policyfile}` ..."
-        cat ${policyfile} | sed -e "s/csNamespace/${CS_NAMESPACE}/g" | oc apply -f -
+        cat ${policyfile} | sed -e "s/csNamespace/${CS_NAMESPACE}/g" | sed -e "s/opNamespace/${OPERATORS_NAMESPACE}/g" | oc apply -f -
     done
 
     for policyfile in `ls -1 ${BASE_DIR}/operators/*.yaml`; do


### PR DESCRIPTION
Adding zen network policy for cp3. 
Note that `opNamespace` is added in services policies as another placeholder for string replacement(`sed`).

Installation testing:
```
$ ./install_networkpolicy.sh -n cpd-instance -o cpd-operator
# [0] Checking prerequisites ...
-----------------------------------------------------------------------
[✔] oc command available
[✔] oc command logged in as kube:admin
[✔] IBM Common Services found in namespace cpd-operator
# [0] Installing IBM Common Services Network Policies ...
-----------------------------------------------------------------------
[INFO] Using IBM Common Services namespace: cpd-instance
[INFO] Using operators namespace: cpd-operator
...
...
-----------------------------------------------------------------------
[✔] IBM Common Services NetworkPolicies installation or removal completed at Thu May 18 07:24:47 PDT 2023 .
```

```
$ oc get netpol -A
NAMESPACE      NAME                                     POD-SELECTOR                                     AGE
cpd-instance   access-to-audit-svc                      component=zen-audit                              6s
cpd-instance   access-to-common-web-ui                  k8s-app=common-web-ui                            8s
cpd-instance   access-to-edb-postgres                   k8s.enterprisedb.io/cluster                      8s
cpd-instance   access-to-ibm-nginx                      component=ibm-nginx                              6s
cpd-instance   access-to-icp-mongodb                    app=icp-mongodb                                  8s
cpd-instance   access-to-platform-auth-service          k8s-app=platform-auth-service                    7s
cpd-instance   access-to-platform-identity-management   k8s-app=platform-identity-management             7s
cpd-instance   access-to-platform-identity-provider     k8s-app=platform-identity-provider               7s
cpd-instance   access-to-usermgmt                       component=usermgmt                               6s
cpd-instance   access-to-volumes                        icpdsupport/app=volumes                          5s
cpd-instance   access-to-zen-core                       component=zen-core                               5s
cpd-instance   access-to-zen-core-api                   component=zen-core-api                           6s
cpd-instance   access-to-zen-minio                      component=zen-minio                              5s
cpd-instance   access-to-zen-watchdog                   component=zen-watchdog                           4s
cpd-instance   allow-iam-config-job                     component=iam-config-job                         4s
cpd-operator   access-to-edb-postgres-webhooks          app.kubernetes.io/name=cloud-native-postgresql   4s
cpd-operator   access-to-ibm-common-service-operator    name=ibm-common-service-operator                 4s
cpd-operator   access-to-zen-meta-api                   app.kubernetes.io/instance=ibm-zen-meta-api      3s
cpd-operator   allow-webhook-access-from-apiserver      <none>                                           3s
```