### PR TITLE
setup_tenant.sh: change --tenant-namespaces to not require entire tenant list, add --excluded-namespaces parameter

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -197,7 +197,7 @@ function pre_req() {
     fi
 
     if [[ "$SERVICES_NS" == "$OPERATOR_NS" && "$TETHERED_NS" == "" && "$EXCLUDED_NS" == "" ]]; then
-        error "Must provide additional namespaces for --tethered-namespaces or --excluded-ns when services-namespace is the same as operator-namespace"
+        error "Must provide additional namespaces for --tethered-namespaces or --excluded-namespaces when services-namespace is the same as operator-namespace"
     fi
 
     if [[ "$TETHERED_NS" == "$OPERATOR_NS" || "$TETHERED_NS" == "$SERVICES_NS" ]]; then


### PR DESCRIPTION
Zen has asked to make it so users of the setup_tenant.sh script did not need to enter the entire list of tenant namespaces every time the script is run. This pr makes it so you only need to add the new namespaces with the --tenant-namespaces parameter. This parameter still works with entering the entire list of namespaces though. Explanation:
- script checks for existing common-service NSS (what is being updated or created)
- if it does not exist, create based on namespaces used in --tenant-namespaces
- if it does exist, remove any duplicate entries between the existing list and the new list entered with --tenant-namespaces. The net change is additive only unless namespaces were specified with optional --excluded-namespaces parameter.

The new --excluded-namespaces parameter removes a comma delimited list of namespaces from the existing common-service NSS. This parameter is not required and does nothing if the NSS does not already exist.

This script should be backward compatible with existing automation while adding flexibility in adding and removing namespaces from a tenant.

Testing:
- install 4.0 cs operator in operator namespace
- run setup_tenant.sh to initiate the nss
- run it again with different values for --tenant-namespaces
- run it again with values for --excluded-namespaces
- if you want to get really fancy, run it with both --tenant-namespaces and --excluded-namespaces
- ensure script always completes
- ensure common-service NSS looks as expected based on --tenant-namespaces and --excluded-namespaces parameters