### PR TITLE
Not remove licensing instance for in-place upgrade

### DIFF
--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -61,8 +61,6 @@ function main() {
             # Migrate Licensing Services Data
             ${BASE_DIR}/migrate_cp2_licensing.sh --control-namespace $CONTROL_NS "--skip-user-vertify"
         fi
-        # Delete IBM Licensing Service instance
-        ${OC} delete --ignore-not-found ibmlicensing instance
         # Delete licensing csv/subscriptions
         delete_operator "ibm-licensing-operator" "$CONTROL_NS"
     fi


### PR DESCRIPTION
Same change for isolated upgrade has been delivered https://github.com/IBM/ibm-common-service-operator/pull/1250