### PR TITLE
Cover corner case for fresh install without CRD

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -394,6 +394,7 @@ function install_cs_operator() {
     wait_for_nss_patch "$OPERATOR_NS" 
     wait_for_cs_webhook "$OPERATOR_NS" "ibm-common-service-webhook"
     if [ "$is_CS_CRD_exist" == "fail" ] || [ $RETRY_CONFIG_CSCR -eq 1 ]; then
+        RETRY_CONFIG_CSCR=1
         configure_cs_kind
     fi
 }


### PR DESCRIPTION
Cover the concern case for fresh installation when CommonService CRD does not exist.

When it is a fresh installation, `RETRY_CONFIG_CSCR` will never set to 1. And `configure_cs_kind` function will not raise error if `RETRY_CONFIG_CSCR` is not `1`.

We need to set `RETRY_CONFIG_CSCR` to 1 when `configure_cs_kind` is called AFTER installing cs-operator, it will abort the scripts when number of remaining retires is 0.