### PR TITLE
match admin pass to original

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -1052,6 +1052,9 @@ data:
   storageclass.list: 'rook-ceph-block,rook-cephfs'
 EOF
     #icp-mongodb-admin-secret.yaml
+    pass=$(${OC} get secret icp-mongodb-admin -n $FROM_NAMESPACE -o=jsonpath='{.data.password}')
+    user=$(${OC} get secret icp-mongodb-admin -n $FROM_NAMESPACE -o=jsonpath='{.data.user}')
+    
     cat << EOF | oc apply -f -
 kind: Secret
 apiVersion: v1
@@ -1060,8 +1063,8 @@ metadata:
   labels:
     app: icp-mongodb
 data:
-  password: VlZWVlZWVlZWVlZWVg==
-  user: QkJCQkJCQkI=
+  password: $pass
+  user: $user
 type: Opaque
 EOF
     #icp-mongodb-client-cert-cert.yaml


### PR DESCRIPTION
Currently, the admin user/pass is hardcoded so any mongo that gets it's data after the preload process is using the exact same admin user/pass combo regardless of cluster or which mongo its data originated from. Change this to use the existing admin user/pass combo from the mongo the data originates from instead.

test:
- run preload
- verify script completes
- check icp-mongodb-admin secret and verify it matches in original and new cs ns 