### PR TITLE
clean up the resources when services ns is changed

### DIFF
--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -60,8 +60,6 @@ const (
 	CRFailed       string = "Failed"
 )
 
-// var ctx = context.Background()
-
 func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
 	klog.Infof("Reconciling CommonService: %s", req.NamespacedName)

--- a/controllers/constant/certmanager.go
+++ b/controllers/constant/certmanager.go
@@ -33,6 +33,7 @@ metadata:
     app.kubernetes.io/instance: cs-ca-issuer
     app.kubernetes.io/managed-by: cert-manager-controller
     app.kubernetes.io/name: Issuer
+    operator.ibm.com/managedByCsOperator: "true"
   name: cs-ca-issuer
   namespace: "placeholder"
 spec:
@@ -49,6 +50,7 @@ metadata:
     app.kubernetes.io/instance: cs-ss-issuer
     app.kubernetes.io/managed-by: cert-manager-controller
     app.kubernetes.io/name: Issuer
+    operator.ibm.com/managedByCsOperator: "true"
   name: cs-ss-issuer
   namespace: "placeholder"
 spec:
@@ -64,6 +66,7 @@ metadata:
     app.kubernetes.io/instance: cs-ca-certificate
     app.kubernetes.io/managed-by: cert-manager-controller
     app.kubernetes.io/name: Certificate
+    operator.ibm.com/managedByCsOperator: "true"
     ibm-cert-manager-operator/refresh-ca-chain: 'true'
   name: cs-ca-certificate
   namespace: "placeholder"


### PR DESCRIPTION
For issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57401
Testing image: quay.io/yuchen_shen/cs_operator:clean_resources

When the first time to deploy CP3 in the cluster, by default `servicesNamespace` is the same as `operatorNamespace`, the following resources will be generated in that tmp `serivcesNamespace`.
After servicesNamespace is changed, the resources should be cleaned up properly and create under the new `serivcesNamespace`
#### Resources
- CertManager CRs including certificates and issuers
- default OperandRegistry and OperandConfig `common-service`
#### Verify 
1. Using setup_tenant script to deploy a CP3 (could choose Topology B with 2 different tethered ns, and same ns for services ns and operator ns)
2. apply the testing image
3. add label `operator.ibm.com/managedByCsOperator: 'true'` into `cs-ca-issuer`, `cs-ss-issuer` and `cs-ca-certificate`
4. run `setuo_tenant.sh` again with a new ns for `ServicesNamespace`
5. Observation results: all the resources default OperandRegistry, OperandConfig `common-service`, CertManager CRs in original services ns are deleted and create under new services ns.