### PR TITLE
redirect output to a log file

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1009,3 +1009,25 @@ function delete_operand_finalizer() {
         fi
     done
 }
+
+function save_log(){
+    local LOG_DIR="$BASE_DIR/$1"
+    LOG_FILE="$LOG_DIR/$2_$(date +'%Y%m%d%H%M%S').txt"
+    local debug=$3
+
+    if [ $debug -eq 1 ]; then
+        if [[ ! -d $LOG_DIR ]]; then
+            mkdir -p "$LOG_DIR"
+        fi
+        # Redirect stdout and stderr to the log file, overwriting it each time
+        exec > >(tee "$LOG_FILE") 2>&1      
+    fi
+}
+
+function cleanup_log() {
+    # Check if the log file already exists
+    if [[ -e $LOG_FILE ]]; then
+        # Remove ANSI escape sequences from log file
+        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
+    fi
+}

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -36,7 +36,7 @@ LICENSE_ACCEPT=0
 BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 
 # log file
-LOG_FILE="${BASE_DIR}/logs/migrate_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
+LOG_FILE="migrate_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
 
 # counter to keep track of installation steps
 STEP=0
@@ -47,8 +47,9 @@ STEP=0
 
 function main() {
     parse_arguments "$@"
-    pre_req
     save_log
+    trap cleanup_log EXIT
+    pre_req
     
     # TODO check Cloud Pak compatibility
 
@@ -120,13 +121,26 @@ function main() {
 
     success "Preparation is completed for upgrading Cloud Pak 3.0"
     info "Please update OperandRequest to upgrade foundational core services"
-    remove_ansi
 }
 
 function save_log(){
+    local LOG_DIR="$BASE_DIR/logs"
+    LOG_FILE="$LOG_DIR/migrate_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
+
     if [ $DEBUG -eq 1 ]; then
+        if [[ ! -d $LOG_DIR ]]; then
+            mkdir -p "$LOG_DIR"
+        fi
         # Redirect stdout and stderr to the log file, overwriting it each time
         exec > >(tee "$LOG_FILE") 2>&1      
+    fi
+}
+
+function cleanup_log() {
+    # Check if the log file already exists
+    if [[ -e $LOG_FILE ]]; then
+        # Remove ANSI escape sequences from log file
+        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
     fi
 }
 
@@ -221,6 +235,11 @@ function print_usage() {
 }
 
 function pre_req() {
+    # Check the value of DEBUG
+    if [[ "$DEBUG" != "1" && "$DEBUG" != "0" ]]; then
+        error "Invalid value for DEBUG. Expected 0 or 1."
+    fi
+
     check_command "${OC}"
     check_command "${YQ}"
 
@@ -228,7 +247,7 @@ function pre_req() {
     # # checking yq version is v4.30+
     # check_version "${YQ}" "--version" "mikefarah" "4\.([3-9][0-9])\.[0-9]+"
 
-    # checking oc command logged in
+    # Checking oc command logged in
     user=$(${OC} whoami 2> /dev/null)
     if [ $? -ne 0 ]; then
         error "You must be logged into the OpenShift Cluster from the oc command line"
@@ -279,16 +298,6 @@ function pre_req() {
     fi
     
     get_and_validate_arguments
-}
-
-function remove_ansi() {
-    echo "222"
-    # Check if the log file already exists
-    if [[ -e $LOG_FILE ]]; then
-        echo "111"
-        # Remove ANSI escape sequences from log file
-        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
-    fi
 }
 
 # TODO validate argument

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -35,6 +35,9 @@ LICENSE_ACCEPT=0
 # script base directory
 BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 
+# log file
+LOG_FILE="${BASE_DIR}/logs/migrate_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
+
 # counter to keep track of installation steps
 STEP=0
 
@@ -45,6 +48,7 @@ STEP=0
 function main() {
     parse_arguments "$@"
     pre_req
+    save_log
     
     # TODO check Cloud Pak compatibility
 
@@ -116,6 +120,14 @@ function main() {
 
     success "Preparation is completed for upgrading Cloud Pak 3.0"
     info "Please update OperandRequest to upgrade foundational core services"
+    remove_ansi
+}
+
+function save_log(){
+    if [ $DEBUG -eq 1 ]; then
+        # Redirect stdout and stderr to the log file, overwriting it each time
+        exec > >(tee "$LOG_FILE") 2>&1      
+    fi
 }
 
 function parse_arguments() {
@@ -269,15 +281,19 @@ function pre_req() {
     get_and_validate_arguments
 }
 
+function remove_ansi() {
+    echo "222"
+    # Check if the log file already exists
+    if [[ -e $LOG_FILE ]]; then
+        echo "111"
+        # Remove ANSI escape sequences from log file
+        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
+    fi
+}
+
 # TODO validate argument
 function get_and_validate_arguments() {
     get_control_namespace
-}
-
-function debug1() {
-    if [ $DEBUG -eq 1 ]; then
-       debug "${1}"
-    fi
 }
 
 main $*

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -47,7 +47,7 @@ STEP=0
 
 function main() {
     parse_arguments "$@"
-    save_log
+    save_log "logs" "migrate_tenant_log" "$DEBUG"
     trap cleanup_log EXIT
     pre_req
     
@@ -121,27 +121,6 @@ function main() {
 
     success "Preparation is completed for upgrading Cloud Pak 3.0"
     info "Please update OperandRequest to upgrade foundational core services"
-}
-
-function save_log(){
-    local LOG_DIR="$BASE_DIR/logs"
-    LOG_FILE="$LOG_DIR/migrate_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
-
-    if [ $DEBUG -eq 1 ]; then
-        if [[ ! -d $LOG_DIR ]]; then
-            mkdir -p "$LOG_DIR"
-        fi
-        # Redirect stdout and stderr to the log file, overwriting it each time
-        exec > >(tee "$LOG_FILE") 2>&1      
-    fi
-}
-
-function cleanup_log() {
-    # Check if the log file already exists
-    if [[ -e $LOG_FILE ]]; then
-        # Remove ANSI escape sequences from log file
-        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
-    fi
 }
 
 function parse_arguments() {

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -47,7 +47,7 @@ STEP=0
 
 function main() {
     parse_arguments "$@"
-    save_log
+    save_log "logs" "setup_singleton_log" "$DEBUG"
     trap cleanup_log EXIT
     pre_req
     if [ $MIGRATE_SINGLETON -eq 1 ]; then
@@ -61,27 +61,6 @@ function main() {
 
     install_cert_manager
     install_licensing
-}
-
-function save_log(){
-    local LOG_DIR="$BASE_DIR/logs"
-    LOG_FILE="$LOG_DIR/setup_singleton_log_$(date +'%Y%m%d%H%M%S').txt"
-
-    if [ $DEBUG -eq 1 ]; then
-        if [[ ! -d $LOG_DIR ]]; then
-            mkdir -p "$LOG_DIR"
-        fi
-        # Redirect stdout and stderr to the log file, overwriting it each time
-        exec > >(tee "$LOG_FILE") 2>&1      
-    fi
-}
-
-function cleanup_log() {
-    # Check if the log file already exists
-    if [[ -e $LOG_FILE ]]; then
-        # Remove ANSI escape sequences from log file
-        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
-    fi
 }
 
 function parse_arguments() {

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -39,10 +39,19 @@ STEP=0
 
 function main() {
     parse_arguments "$@"
+    save_log
     pre_req
     setup_topology
     setup_nss
     install_cs_operator
+    remove_ansi
+}
+
+function save_log(){
+    if [ $DEBUG -eq 1 ]; then
+        # Redirect stdout and stderr to the log file, overwriting it each time
+        exec > >(tee "setup_tenant.log") 2>&1      
+    fi
 }
 
 function parse_arguments() {
@@ -472,10 +481,8 @@ EOF
     fi
 }
 
-function debug1() {
-    if [ $DEBUG -eq 1 ]; then
-        debug "${1}"
-    fi
+function remove_ansi() {
+    sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "setup_tenant.log"
 }
 
 main $*

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -42,33 +42,12 @@ STEP=0
 
 function main() {
     parse_arguments "$@"
-    save_log
+    save_log "logs" "setup_tenant_log" "$DEBUG"
     trap cleanup_log EXIT
     pre_req
     setup_topology
     setup_nss
     install_cs_operator
-}
-
-function save_log(){
-    local LOG_DIR="$BASE_DIR/logs"
-    LOG_FILE="$LOG_DIR/setup_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
-
-    if [ $DEBUG -eq 1 ]; then
-        if [[ ! -d $LOG_DIR ]]; then
-            mkdir -p "$LOG_DIR"
-        fi
-        # Redirect stdout and stderr to the log file, overwriting it each time
-        exec > >(tee "$LOG_FILE") 2>&1      
-    fi
-}
-
-function cleanup_log() {
-    # Check if the log file already exists
-    if [[ -e $LOG_FILE ]]; then
-        # Remove ANSI escape sequences from log file
-        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
-    fi
 }
 
 function parse_arguments() {

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -29,6 +29,7 @@ RETRY_CONFIG_CSCR=0
 
 # script base directory
 BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
+LOG_FILE="${BASE_DIR}/logs/setup_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
 
 # counter to keep track of installation steps
 STEP=0
@@ -50,7 +51,7 @@ function main() {
 function save_log(){
     if [ $DEBUG -eq 1 ]; then
         # Redirect stdout and stderr to the log file, overwriting it each time
-        exec > >(tee "setup_tenant.log") 2>&1      
+        exec > >(tee "$LOG_FILE") 2>&1      
     fi
 }
 
@@ -482,7 +483,11 @@ EOF
 }
 
 function remove_ansi() {
-    sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "setup_tenant.log"
+    # Check if the log file already exists
+    if [[ -e $LOG_FILE ]]; then
+        # Remove ANSI escape sequences from log file
+        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
+    fi
 }
 
 main $*

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -29,6 +29,8 @@ RETRY_CONFIG_CSCR=0
 
 # script base directory
 BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
+
+#log file
 LOG_FILE="${BASE_DIR}/logs/setup_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
 
 # counter to keep track of installation steps

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -31,7 +31,7 @@ LOG_FILE="uninstall_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
 
 function main() {
     parse_arguments "$@"
-    save_log
+    save_log "logs" "uninstall_tenant_log" "$DEBUG"
     trap cleanup_log EXIT
     pre_req
     set_tenant_namespaces
@@ -42,27 +42,6 @@ function main() {
     delete_webhook
     delete_unavailable_apiservice
     delete_tenant_ns
-}
-
-function save_log(){
-    local LOG_DIR="$BASE_DIR/logs"
-    LOG_FILE="$LOG_DIR/uninstall_tenant_log_$(date +'%Y%m%d%H%M%S').txt"
-
-    if [ $DEBUG -eq 1 ]; then
-        if [[ ! -d $LOG_DIR ]]; then
-            mkdir -p "$LOG_DIR"
-        fi
-        # Redirect stdout and stderr to the log file, overwriting it each time
-        exec > >(tee "$LOG_FILE") 2>&1      
-    fi
-}
-
-function cleanup_log() {
-    # Check if the log file already exists
-    if [[ -e $LOG_FILE ]]; then
-        # Remove ANSI escape sequences from log file
-        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
-    fi
 }
 
 function parse_arguments() {

--- a/isolate.sh
+++ b/isolate.sh
@@ -41,6 +41,10 @@ BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 #log file
 LOG_FILE="isolate_log_$(date +'%Y%m%d%H%M%S').txt"
 
+# ---------- Main functions ----------
+
+. ${BASE_DIR}/cp3pt0-deployment/common/utils.sh
+
 function main() {
     while [ "$#" -gt "0" ]
     do
@@ -76,7 +80,7 @@ function main() {
         shift
     done
 
-    save_log
+    save_log "cp3pt0-deployment/logs" "isolate_log" "$DEBUG"
     trap cleanup_log EXIT
 
     which "${OC}" || error "Missing oc CLI"
@@ -108,28 +112,6 @@ function main() {
         info "Cert Manager not migrated, skipping wait."
     fi
     success "Isolation complete"
-}
-
-function save_log(){
-    echo "$BASE_DIR"
-    local LOG_DIR="$BASE_DIR/cp3pt0-deployment/logs"
-    LOG_FILE="$LOG_DIR/isolate_log_$(date +'%Y%m%d%H%M%S').txt"
-
-    if [ $DEBUG -eq 1 ]; then
-        if [[ ! -d $LOG_DIR ]]; then
-            mkdir -p "$LOG_DIR"
-        fi
-        # Redirect stdout and stderr to the log file, overwriting it each time
-        exec > >(tee "$LOG_FILE") 2>&1      
-    fi
-}
-
-function cleanup_log() {
-    # Check if the log file already exists
-    if [[ -e $LOG_FILE ]]; then
-        # Remove ANSI escape sequences from log file
-        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
-    fi
 }
 
 function usage() {

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -38,9 +38,13 @@ BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 #log file
 LOG_FILE="preload_data_log_$(date +'%Y%m%d%H%M%S').txt"
 
+# ---------- Main functions ----------
+
+. ${BASE_DIR}/cp3pt0-deployment/common/utils.sh
+
 function main() {
     parse_arguments "$@"
-    save_log
+    save_log "cp3pt0-deployment/logs" "preload_data_log" "$DEBUG"
     trap cleanup_log EXIT
     prereq
     # run backup preload
@@ -49,27 +53,6 @@ function main() {
     copy_secret "platform-auth-idp-credentials"
     copy_secret "platform-auth-ldaps-ca-cert"
     # any extra config
-}
-
-function save_log(){
-    local LOG_DIR="$BASE_DIR/cp3pt0-deployment/logs"
-    LOG_FILE="$LOG_DIR/preload_data_log_$(date +'%Y%m%d%H%M%S').txt"
-
-    if [ $DEBUG -eq 1 ]; then
-        if [[ ! -d $LOG_DIR ]]; then
-            mkdir -p "$LOG_DIR"
-        fi
-        # Redirect stdout and stderr to the log file, overwriting it each time
-        exec > >(tee "$LOG_FILE") 2>&1      
-    fi
-}
-
-function cleanup_log() {
-    # Check if the log file already exists
-    if [[ -e $LOG_FILE ]]; then
-        # Remove ANSI escape sequences from log file
-        sed -i 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' "$LOG_FILE"
-    fi
 }
 
 function parse_arguments() {


### PR DESCRIPTION
for issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/57620#issuecomment-57362560
- Check if the passed in value of DEBUG is 1 or 0, otherwise return error
- Redirect stdout and stderr to the log file, overwriting it each time
- Remove ANSI escape sequences from log file

#### log file example
```
[✔] oc command available
[✔] oc command logged in as kube:admin
[✔] Channel is valid
[✔] Profile size is valid.
[INFO] Namespace test-ns already exists. Skip creating
[INFO] Namespace test-ns already exists. Skip creating
[INFO] Namespace tenant1-a already exists. Skip creating
[INFO] Namespace tenant1-b already exists. Skip creating
[INFO] Checking existing OperatorGroup in test-ns:

[INFO] OperatorGroup already exists in test-ns. Skip creating
```