### PR TITLE
Bug/58774: re-fix of license service migration with customisation preserved

### DIFF
--- a/cp3pt0-deployment/common/migrate_cp2_licensing.sh
+++ b/cp3pt0-deployment/common/migrate_cp2_licensing.sh
@@ -33,6 +33,7 @@ function main() {
     parse_arguments "$@"
     pre_req
     create_namespace $TARGET_NS
+    restore_ibmlicensing
     migrate_lic_cms
     # TODO: restore ibm-license-service Secrets
 }
@@ -152,6 +153,15 @@ function migrate_lic_cms() {
         fi
     done
     success "Licensing Service ConfigMaps are migrated from $CONTROL_NS to $TARGET_NS"
+}
+
+
+function restore_ibmlicensing() {
+
+    # extracts the previously saved IBMLicensing CR from ConfigMap and creates the IBMLicensing CR
+    "${OC}" get cm ibmlicensing-instance-bak -n ${CONTROL_NS} -o yaml --ignore-not-found | "${YQ}" .data | sed -e 's/.*ibmlicensing.yaml.*//' | 
+    sed -e 's/^  //g' | oc apply -f -
+
 }
 
 function debug1() {

--- a/cp3pt0-deployment/common/migrate_cp2_licensing.sh
+++ b/cp3pt0-deployment/common/migrate_cp2_licensing.sh
@@ -33,7 +33,6 @@ function main() {
     parse_arguments "$@"
     pre_req
     create_namespace $TARGET_NS
-    restore_ibmlicensing
     migrate_lic_cms
     # TODO: restore ibm-license-service Secrets
 }
@@ -155,14 +154,6 @@ function migrate_lic_cms() {
     success "Licensing Service ConfigMaps are migrated from $CONTROL_NS to $TARGET_NS"
 }
 
-
-function restore_ibmlicensing() {
-
-    # extracts the previously saved IBMLicensing CR from ConfigMap and creates the IBMLicensing CR
-    "${OC}" get cm ibmlicensing-instance-bak -n ${CONTROL_NS} -o yaml --ignore-not-found | "${YQ}" .data | sed -e 's/.*ibmlicensing.yaml.*//' | 
-    sed -e 's/^  //g' | oc apply -f -
-
-}
 
 function debug1() {
     if [ $DEBUG -eq 1 ]; then

--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -67,6 +67,10 @@ function main() {
         # Delete licensing csv/subscriptions
         delete_operator "ibm-licensing-operator" "$CONTROL_NS"
 
+        # restore licensing configuration so that subsequent License Service install will pick them up
+        restore_ibmlicensing
+        
+
         if [[ "$CONTROL_NS" == "$OPERATOR_NS" ]]; then
             # Migrate Licensing Services Data
             ${BASE_DIR}/migrate_cp2_licensing.sh --control-namespace $CONTROL_NS "--skip-user-vertify"
@@ -81,6 +85,14 @@ function main() {
     success "Migration is completed for Cloud Pak 3.0 Foundational singleton services."
 }
 
+
+function restore_ibmlicensing() {
+
+    # extracts the previously saved IBMLicensing CR from ConfigMap and creates the IBMLicensing CR
+    "${OC}" get cm ibmlicensing-instance-bak -n ${CONTROL_NS} -o yaml --ignore-not-found | "${YQ}" .data | sed -e 's/.*ibmlicensing.yaml.*//' | 
+    sed -e 's/^  //g' | oc apply -f -
+
+}
 
 function backup_ibmlicensing() {
 

--- a/isolate.sh
+++ b/isolate.sh
@@ -321,6 +321,7 @@ function uninstall_singletons() {
         "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-licensing-operator
         "${OC}" delete -n "${MASTER_NS}" --ignore-not-found csv "${csv}"
         "${OC}" delete -n "${MASTER_NS}" --ignore-not-found OperandBindInfo ibm-licensing-bindinfo
+        "${OC}" patch  -n "${MASTER_NS}" OperandBindInfo ibm-licensing-bindinfo --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
     fi
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-crossplane-operator-app
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-crossplane-provider-kubernetes-operator-app

--- a/isolate.sh
+++ b/isolate.sh
@@ -312,10 +312,7 @@ function uninstall_singletons() {
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found csv "${csv}"
 
     migrate_lic_cms $MASTER_NS
-    isExists=$("${OC}" get deployments -n "${MASTER_NS}" --ignore-not-found ibm-licensing-operator)
-    if [ ! -z "$isExists" ]; then
-        "${OC}" delete -n "${MASTER_NS}" --ignore-not-found ibmlicensing instance
-    fi
+
 
     #might need a more robust check for if licensing is installed
     #"${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-licensing-operator
@@ -323,6 +320,7 @@ function uninstall_singletons() {
     if [[ $csv != "fail" ]]; then
         "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-licensing-operator
         "${OC}" delete -n "${MASTER_NS}" --ignore-not-found csv "${csv}"
+        "${OC}" delete -n "${MASTER_NS}" --ignore-not-found OperandBindInfo ibm-licensing-bindinfo
     fi
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-crossplane-operator-app
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-crossplane-provider-kubernetes-operator-app

--- a/isolate.sh
+++ b/isolate.sh
@@ -444,8 +444,7 @@ function restore_ibmlicensing() {
 
     # extracts the previously saved IBMLicensing CR from ConfigMap and creates the IBMLicensing CR
     "${OC}" get cm ibmlicensing-instance-bak -n ${CONTROL_NS} -o yaml --ignore-not-found | "${YQ}" .data | sed -e 's/.*ibmlicensing.yaml.*//' | 
-    sed -e 's/^  //g' |
-    sed -e 's/name: instance/name: instance2/g' | oc apply -f -
+    sed -e 's/^  //g' | oc apply -f -
 
 }
 

--- a/isolate.sh
+++ b/isolate.sh
@@ -86,6 +86,7 @@ function main() {
     removeNSS
     uninstall_singletons
     isolate_odlm "ibm-odlm" $MASTER_NS
+    restore_ibmlicensing
     restart
     if [[ $CERT_MANAGER_MIGRATED == "true" ]]; then
         wait_for_certmanager "$CONTROL_NS" "${ns_list}"
@@ -313,6 +314,11 @@ function uninstall_singletons() {
 
     migrate_lic_cms $MASTER_NS
 
+    backup_ibmlicensing
+    isExists=$("${OC}" get deployments -n "${MASTER_NS}" --ignore-not-found ibm-licensing-operator)
+    if [ ! -z "$isExists" ]; then
+        "${OC}" delete -n "${MASTER_NS}" --ignore-not-found ibmlicensing instance
+    fi
 
     #might need a more robust check for if licensing is installed
     #"${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-licensing-operator
@@ -409,6 +415,38 @@ function migrate_lic_cms() {
     echo "$cleaned_cm_list" | "${OC}" apply -n "$CONTROL_NS" -f -
     success "Licensing configmaps copied from $namespace to $CONTROL_NS"
     "${OC}" delete cm --ignore-not-found -n "${namespace}" "${possible_cms[@]}"
+}
+
+function backup_ibmlicensing() {
+
+    instance=`"${OC}" get IBMLicensing instance -o yaml --ignore-not-found | "${YQ}" '
+        with(.; del(.metadata.creationTimestamp) |
+        del(.metadata.managedFields) |
+        del(.metadata.resourceVersion) |
+        del(.metadata.uid) |
+        del(.status)
+        )
+    ' | sed -e 's/^/    /g'`
+cat << _EOF | oc apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ibmlicensing-instance-bak
+  namespace: ${CONTROL_NS}
+data:
+  ibmlicensing.yaml: |
+${instance}
+_EOF
+
+}
+
+function restore_ibmlicensing() {
+
+    # extracts the previously saved IBMLicensing CR from ConfigMap and creates the IBMLicensing CR
+    "${OC}" get cm ibmlicensing-instance-bak -n ${CONTROL_NS} -o yaml --ignore-not-found | "${YQ}" .data | sed -e 's/.*ibmlicensing.yaml.*//' | 
+    sed -e 's/^  //g' |
+    sed -e 's/name: instance/name: instance2/g' | oc apply -f -
+
 }
 
 # export_k8s_list_yaml Takes a k8s list in YAML form,


### PR DESCRIPTION
fixes: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58774

moved restore of IBMLicensing CR just after the LicSvc operator is removed, to avoid the situation where such operator is redeployed later, while the CR restore was conditional based on the namespaces/topology configuration