### PR TITLE
check for ibmlicensing resource to exist before backup

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -338,7 +338,12 @@ function uninstall_singletons() {
 
     migrate_lic_cms $MASTER_NS
 
-    backup_ibmlicensing
+    licensing_exists=$(${OC} get IBMLicensing || echo "fail")
+    if [[ $licensing_exists != "fail" ]]; then
+        backup_ibmlicensing
+    else
+        info "No ibmlicensing resources on cluster, skipping backup."
+    fi
     isExists=$("${OC}" get deployments -n "${MASTER_NS}" --ignore-not-found ibm-licensing-operator)
     if [ ! -z "$isExists" ]; then
         "${OC}" delete -n "${MASTER_NS}" --ignore-not-found ibmlicensing instance


### PR DESCRIPTION
If there is no ibmlicensing resource on a cluster, the isolate script will fail with `error: the server doesn't have a resource type "IBMLicensing"`. This pr adds a check for  the resource to exist before continuing to prevent an unnecessary script exit.

Testing
- setup cluster with common services but without licensing deployed
- run the isolate script
- verify script completes and this info line is output: "No ibmlicensing resources on cluster, skipping backup."