### PR TITLE
add 4.0.0 tag back to related images

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -355,7 +355,7 @@ spec:
   provider:
     name: IBM
   relatedImages:
-  - image: icr.io/cpopen/common-service-operator
+  - image: icr.io/cpopen/common-service-operator:4.0.0
     name: COMMON_SERVICE_OPERATOR_IMAGE
   - image: icr.io/cpopen/cpfs/cpfs-utils:4.0.0
     name: CS_UTILS_IMAGE

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -180,7 +180,7 @@ spec:
   provider:
     name: IBM
   relatedImages:
-  - image: icr.io/cpopen/common-service-operator
+  - image: icr.io/cpopen/common-service-operator:4.0.0
     name: COMMON_SERVICE_OPERATOR_IMAGE
   - image: icr.io/cpopen/cpfs/cpfs-utils:4.0.0
     name: CS_UTILS_IMAGE


### PR DESCRIPTION
fix for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58865
`:4.0.0` tag is added back to the common service operator image