### PR TITLE
align name of cp3 mongodb operator with im operator

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -46,7 +46,7 @@ metadata:
     excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog
 spec:
   operators:
-  - name: ibm-mongodb-operator-v4.0
+  - name: ibm-im-mongodb-operator-v4.0
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
     packageName: ibm-mongodb-operator-app
@@ -269,6 +269,13 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-im-mongodb-operator
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3
     name: ibm-events-operator
     namespace: "{{ .CPFSNs }}"
@@ -281,6 +288,14 @@ spec:
     namespace: "{{ .CPFSNs }}"
     channel: {{ .Channel }}
     packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-idp-config-ui-operator
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
@@ -423,6 +438,13 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-im-mongodb-operator
+    namespace: "{{ .CPFSNs }}"
+    channel: {{ .Channel }}
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3
     name: ibm-events-operator
     namespace: "{{ .CPFSNs }}"
@@ -479,7 +501,11 @@ spec:
     spec:
       mongoDB: {}
       operandRequest: {}
-  - name: ibm-mongodb-operator-v4.0
+  - name: ibm-im-mongodb-operator
+    spec:
+      mongoDB: {}
+      operandRequest: {}
+  - name: ibm-im-mongodb-operator-v4.0
     spec:
       mongoDB: {}
       operandRequest: {}
@@ -494,8 +520,8 @@ spec:
       operandRequest: 
         requests:
           - operands:
-              - name: ibm-mongodb-operator-{{ .Channel }}
-              - name: ibm-idp-config-ui-operator-{{ .Channel }}
+              - name: ibm-im-mongodb-operator
+              - name: ibm-idp-config-ui-operator
             registry: common-service
   - name: ibm-im-operator-v4.0
     spec:
@@ -508,7 +534,7 @@ spec:
       operandRequest:
         requests:
           - operands:
-              - name: ibm-mongodb-operator-v4.0
+              - name: ibm-im-mongodb-operator-v4.0
               - name: ibm-idp-config-ui-operator-v4.0
             registry: common-service
   - name: ibm-iam-operator
@@ -910,7 +936,11 @@ spec:
     spec:
       mongoDB: {}
       operandRequest: {}
-  - name: ibm-mongodb-operator-v4.0
+  - name: ibm-im-mongodb-operator
+    spec:
+      mongoDB: {}
+      operandRequest: {}
+  - name: ibm-im-mongodb-operator-v4.0
     spec:
       mongoDB: {}
       operandRequest: {}
@@ -926,8 +956,8 @@ spec:
       operandRequest:
         requests:
           - operands:
-              - name: ibm-mongodb-operator-{{ .Channel }}
-              - name: ibm-idp-config-ui-operator-{{ .Channel }}
+              - name: ibm-im-mongodb-operator
+              - name: ibm-idp-config-ui-operator
             registry: common-service
   - name: ibm-im-operator-v4.0
     spec:
@@ -940,7 +970,7 @@ spec:
       operandRequest:
         requests:
           - operands:
-              - name: ibm-mongodb-operator-v4.0
+              - name: ibm-im-mongodb-operator-v4.0
               - name: ibm-idp-config-ui-operator-v4.0
             registry: common-service
   - name: ibm-iam-operator

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -64,7 +64,26 @@ const ConfigurationRules = `
           limits:
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: LARGEST_VALUE
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+      metrics:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: LARGEST_VALUE
@@ -370,6 +389,26 @@ const ConfigurationRules = `
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: LARGEST_VALUE
+      resources:
+        requests:
+          memory: LARGEST_VALUE
+          cpu: LARGEST_VALUE
+        limits:
+          memory: LARGEST_VALUE
+          cpu: LARGEST_VALUE
+      commonWebUIConfig:
+        dashboardData:
+          resources:
+            limits:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+            requests:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: LARGEST_VALUE

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -63,7 +63,26 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3Gi
+        requests:
+          cpu: 500m
+          memory: 3Gi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Large = `
             cpu: 300m
             memory: 384Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 3
+      resources:
+        requests:
+          memory: 490Mi
+          cpu: 450m
+        limits:
+          memory: 660Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -63,7 +63,26 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+ - name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3072Mi
+        requests:
+          cpu: 500m
+          memory: 3072Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Large = `
           cpu: 300m
           memory: 270Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 1225Mi
+        requests:
+          cpu: 300m
+          memory: 384Mi
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -63,7 +63,26 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3072Mi
+        requests:
+          cpu: 500m
+          memory: 3072Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Large = `
           cpu: 200m
           memory: 270Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 430Mi
+        requests:
+          cpu: 300m
+          memory: 384Mi
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -63,7 +63,26 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2Gi
+        requests:
+          cpu: 500m
+          memory: 2Gi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Medium = `
             cpu: 300m
             memory: 384Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 2
+      resources:
+        requests:
+          memory: 480Mi
+          cpu: 450m
+        limits:
+          memory: 660Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -63,7 +63,26 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2048Mi
+        requests:
+          cpu: 500m
+          memory: 2048Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Medium = `
           cpu: 300m
           memory: 230Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 2
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 1225Mi
+        requests:
+          cpu: 300m
+          memory: 376Mi
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -63,7 +63,26 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2048Mi
+        requests:
+          cpu: 500m
+          memory: 2048Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Medium = `
           cpu: 200m
           memory: 230Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 2
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 430Mi
+        requests:
+          cpu: 300m
+          memory: 376Mi
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -63,7 +63,26 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 640Mi
+        requests:
+          cpu: 500m
+          memory: 640Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Small = `
             cpu: 300m
             memory: 384Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 130m
+        limits:
+          memory: 440Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -63,7 +63,26 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Small = `
             cpu: 300m
             memory: 384Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 150m
+        limits:
+          memory: 800Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -63,7 +63,26 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 3
@@ -361,6 +380,17 @@ const Small = `
             cpu: 300m
             memory: 384Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 150m
+        limits:
+          memory: 440Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -63,7 +63,26 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 640Mi
+        requests:
+          cpu: 500m
+          memory: 640Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 1
@@ -361,6 +380,17 @@ const StarterSet = `
             cpu: 300m
             memory: 384Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 130m
+        limits:
+          memory: 440Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -63,7 +63,26 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 1
@@ -361,6 +380,17 @@ const StarterSet = `
             cpu: 300m
             memory: 384Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 150m
+        limits:
+          memory: 800Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -63,7 +63,26 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
-- name: ibm-mongodb-operator-v4.0
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:
       replicas: 1
@@ -361,6 +380,17 @@ const StarterSet = `
             cpu: 300m
             memory: 384Mi
 - name: ibm-commonui-operator
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 150m
+        limits:
+          memory: 440Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator
   spec:
     commonWebUI:
       replicas: 1

--- a/docs/cloudpak-integration.md
+++ b/docs/cloudpak-integration.md
@@ -119,6 +119,12 @@ spec:
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}
+  - name: ibm-im-mongodb-operator
+    spec:
+      mongoDB: {}
+  - name: ibm-im-mongodb-operator-v4.0
+    spec:
+      mongoDB: {}
   - name: ibm-cert-manager-operator
     spec:
       certManager: {}

--- a/testdata/actual.yaml
+++ b/testdata/actual.yaml
@@ -609,6 +609,42 @@
     }
   },
   {
+    "name": "ibm-im-mongodb-operator",
+    "spec": {
+      "mongoDB": {
+        "replicas": 3,
+        "resources": {
+          "limits": {
+            "cpu": "3000m",
+            "memory": "3Gi"
+          },
+          "requests": {
+            "cpu": "500m",
+            "memory": "3Gi"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "ibm-im-mongodb-operator-v4.0",
+    "spec": {
+      "mongoDB": {
+        "replicas": 3,
+        "resources": {
+          "limits": {
+            "cpu": "3000m",
+            "memory": "3Gi"
+          },
+          "requests": {
+            "cpu": "500m",
+            "memory": "3Gi"
+          }
+        }
+      }
+    }
+  },
+  {
     "name": "ibm-monitoring-grafana-operator",
     "spec": {
       "grafana": {

--- a/testdata/expected.yaml
+++ b/testdata/expected.yaml
@@ -609,6 +609,42 @@
     }
   },
   {
+    "name": "ibm-im-mongodb-operator",
+    "spec": {
+      "mongoDB": {
+        "replicas": 3,
+        "resources": {
+          "limits": {
+            "cpu": "3000m",
+            "memory": "3Gi"
+          },
+          "requests": {
+            "cpu": "500m",
+            "memory": "3Gi"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "ibm-im-mongodb-operator-v4.0",
+    "spec": {
+      "mongoDB": {
+        "replicas": 3,
+        "resources": {
+          "limits": {
+            "cpu": "3000m",
+            "memory": "3Gi"
+          },
+          "requests": {
+            "cpu": "500m",
+            "memory": "3Gi"
+          }
+        }
+      }
+    }
+  },
+  {
     "name": "ibm-monitoring-grafana-operator",
     "spec": {
       "grafana": {


### PR DESCRIPTION
for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58223#issuecomment-57732331
testing image: quay.io/yuchen_shen/cs_operator:split_opreg

- The `ibm-mongodb-operator` will be renamed to `ibm-im-mongodb-operator` for CP3 mongo.
- The `ibm-im-operator` without version suffix would request the internal component `ibm-im-mongodb-operator`
- The `ibm-im-operator-v4.0` with version suffix would request the internal component with version suffix `ibm-im-mongodb-operator-v4.0`
