### PR TITLE
support both bash and Bourne shell

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Licensed Materials - Property of IBM
 # Copyright IBM Corporation 2023. All Rights Reserved
@@ -1027,8 +1027,19 @@ function save_log(){
         if [[ ! -d $LOG_DIR ]]; then
             mkdir -p "$LOG_DIR"
         fi
-        # Redirect stdout and stderr to the log file, overwriting it each time
-        exec > >(tee "$LOG_FILE") 2>&1      
+
+        # Create a named pipe
+        PIPE=$(mktemp -u)
+        mkfifo "$PIPE"
+
+        # Tee the output to both the log file and the terminal
+        tee "$LOG_FILE" < "$PIPE" &
+
+        # Redirect stdout and stderr to the named pipe
+        exec > "$PIPE" 2>&1
+
+        # Remove the named pipe
+        rm "$PIPE"
     fi
 }
 


### PR DESCRIPTION
CP4BA is using Bourne shell to execute the script, and it does not support process substitution for command `>(tee "$LOG_FILE")` to record the logs.

Update the scripts to use a named pipe  to tee the output to both the log file and the terminal

### Original issue
#### Working with bash shell
```
> cp3pt0-deployment git:(scripts-dev) ./setup_singleton.sh --enable-licensing --license-accept -v 1
[✔] oc command available
[✔] oc command logged in as kube:admin
[✔] Channel is valid
# Installing cert-manager
```

#### Failed with Bourne shell
```
> cp3pt0-deployment git:(scripts-dev) ✗ sh setup_singleton.sh --enable-licensing --license-accept -v 1
/Users/daniel/Downloads/IBM/ibm-common-service-operator/cp3pt0-deployment/common/utils.sh: line 1031: syntax error near unexpected token `>'
/Users/daniel/Downloads/IBM/ibm-common-service-operator/cp3pt0-deployment/common/utils.sh: line 1031: `        exec > >(tee "$LOG_FILE") 2>&1      '
setup_singleton.sh: line 50: save_log: command not found
[✔] oc command available
[✔] oc command logged in as kube:admin
```

### Test
#### Bash Shell
```
> ./cp3pt0-deployment/setup_tenant.sh -v 1 --operator-namespace cloudpak-control --services-namespace cloudpak-data --license-accept
[✔] oc command available
[✔] oc command logged in as kube:admin
[✔] Channel is valid
[✔] Profile size is valid.
[INFO] Namespace cloudpak-control already exists. Skip creating
[INFO] Namespace cloudpak-data already exists. Skip creating
[INFO] Checking existing OperatorGroup in cloudpak-control
```

#### Bourne shell
```
> sh cp3pt0-deployment/setup_tenant.sh -v 1 --operator-namespace cloudpak-control-2 --services-namespace cloudpak-data-2 --license-accept
[✔] oc command available
[✔] oc command logged in as kube:admin
[✔] Channel is valid
[✔] Profile size is valid.
[INFO] Namespace cloudpak-control-2 already exists. Skip creating
[INFO] Namespace cloudpak-data-2 already exists. Skip creating
[INFO] Checking existing OperatorGroup in cloudpak-control-2
```

Both of them will generate the log file
```
[✔] oc command available
[✔] oc command logged in as kube:admin
[✔] Channel is valid
[✔] Profile size is valid.
[INFO] Namespace cloudpak-control-2 already exists. Skip creating
[INFO] Namespace cloudpak-data-2 already exists. Skip creating
[INFO] Checking existing OperatorGroup in cloudpak-control-2:

[INFO] OperatorGroup already exists in cloudpak-control-2. Skip creating
# Installing Namespace Scope operator
```