### PR TITLE
Support in-place upgrade for Licensing Migration

### DIFF
--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -275,9 +275,9 @@ function pre_req() {
         MIGRATE_SINGLETON=1
         get_and_validate_arguments
         if [[ "$ENABLE_LICENSING" == 1 ]];then
-            if [[ "$CUSTOMIZED_LICENSING_NAMESPACE" -eq 1 ]] && [[ "$CONTROL_NS" != "$LICENSING_NAMESPACE" ]]; then
+            if [[ "$CUSTOMIZED_LICENSING_NAMESPACE" -eq 1 ]] && [[ "$CONTROL_NS" != "$LICENSING_NAMESPACE" ]] && [[ "$CONTROL_NS" != "" ]]; then
                 error "Licensing Migration could only be done in $CONTROL_NS, please do not set parameter '-licensingNs $LICENSING_NAMESPACE'"
-            else 
+            elif [[ "$CONTROL_NS" != "" ]]; then
                 LICENSING_NAMESPACE="${CONTROL_NS}"
             fi
         fi


### PR DESCRIPTION
It is used to support upgrade All Namespaces Install Mode scenario.

There is no `common-service-maps` ConfigMap, and there is no controlNamespace defined like `cs-control`.

We should migrate Licensing Service from `ibm-common-services` to `ibm-licensing` namespace.

### Test
```
[INFO] Found parameter '--operator-namespace', migrating singleton services
Error from server (NotFound): configmaps "common-service-maps" not found
[✗] Not found common-serivce-maps ConfigMap in kube-public namespace. It is a single shared Common Service instance upgrade
certmanager.operator.ibm.com "default" deleted
...
[✔] Remove ibm-cert-manager-operator successfully.

configmap/ibmlicensing-instance-bak created
ibmlicensing.operator.ibm.com "instance" deleted
# Deleting ibm-licensing-operator in namesapce ibm-common-services...
[1] Removing the subscription of ibm-licensing-operator in namesapce ibm-common-services ...
subscription.operators.coreos.com "ibm-licensing-operator" deleted
[2] Removing the csv of ibm-licensing-operator in namesapce ibm-common-services ...
clusterserviceversion.operators.coreos.com "ibm-licensing-operator.v1.20.3" deleted

[✔] Remove ibm-licensing-operator successfully.

ibmlicensing.operator.ibm.com/instance created
# Creating namespace ibm-licensing

namespace/ibm-licensing created
# Migrating IBM License Service data from ibm-common-services into ibm-licensing namespace
[✔] Licensing Service ConfigMaps are migrated from ibm-common-services to ibm-licensing
[✔] Migration is completed for Cloud Pak 3.0 Foundational singleton services.
```