### PR TITLE
rename related images

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -358,5 +358,5 @@ spec:
   - image: icr.io/cpopen/common-service-operator:4.0.0
     name: COMMON_SERVICE_OPERATOR_IMAGE
   - image: icr.io/cpopen/cpfs/cpfs-utils:4.0.0
-    name: CS_UTILS_IMAGE
+    name: CPFS_UTILS_IMAGE
   version: 4.0.0

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -183,5 +183,5 @@ spec:
   - image: icr.io/cpopen/common-service-operator:4.0.0
     name: COMMON_SERVICE_OPERATOR_IMAGE
   - image: icr.io/cpopen/cpfs/cpfs-utils:4.0.0
-    name: CS_UTILS_IMAGE
+    name: CPFS_UTILS_IMAGE
   version: 0.0.0


### PR DESCRIPTION
modified related image name to `CPFS_UTILS_IMAGE` for Airgap mirroring
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58865#issuecomment-57825125