### PR TITLE
[Bedrock 4.1] Implement Concatenating OperandConfig YAMLs

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -731,6 +731,29 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 
 // InstallOrUpdateOpcon will install or update OperandConfig when Opcon CRD is existent
 func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
+	var err error
+
+	// Append CP3 Services with suffix into CP3 and SaaS OperandConfig
+	Configs := []string{
+		constant.MongoDBOpCon,
+		constant.IMOpCon,
+		constant.IdpConfigUIOpCon,
+		constant.PlatformUIOpCon,
+	}
+
+	constant.CSV3OperandConfig = constant.CSV3OpCon
+	constant.CSV3SaasOperandConfig = constant.CSV3SaasOpCon
+	for _, con := range Configs {
+		constant.CSV3OperandConfig, err = constant.ConcatenateConfigs(constant.CSV3OperandConfig, con, b.CSData)
+		if err != nil {
+			klog.Errorf("failed to append CP3 services into OperandConfig: %v", err)
+		}
+		constant.CSV3SaasOperandConfig, err = constant.ConcatenateConfigs(constant.CSV3SaasOperandConfig, con, b.CSData)
+		if err != nil {
+			klog.Errorf("failed to append CP3 services into SaaS OperandConfig: %v", err)
+		}
+	}
+
 	if b.SaasEnable {
 		// OperandConfig for SaaS deployment
 		if err := b.renderTemplate(constant.CSV3SaasOperandConfig, b.CSData, forceUpdateODLMCRs); err != nil {


### PR DESCRIPTION
Introduced a new function `ConcatenateConfigs` essentially combines the `Services` from two OperandConfig objects and returns the concatenated YAML representation of the modified OperandConfig.

for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57539

####  The function performs the following steps:

- It creates two OperandConfig objects: `baseConfig` and `insertedConfig` by unmarshaling the YAML templates using the applyTemplate function.
- It appends the `Services` from `insertedConfig` to the existing `Services` in `baseConfig`.
- It marshals the modified base object back to YAML format using json.Marshal.
- It returns the resulting YAML string and any error that occurred during the process.

#### Verify
test image: quay.io/yuchen_shen/cs_operator:split_opcon
delete origin OprandConfig and it will create a new one with the entries of CP3 services and followed by the services with suffix.
