### PR TITLE
always call wait for certmanager function

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -387,17 +387,12 @@ function is_sub_exist() {
 }
 
 function check_cert_manager(){
-    csv_count=$(${OC} get csv -A | grep "cert-manager"| wc -l | tr -d " ")
+    csv_count=`$OC get csv |grep "cert-manager"|wc -l`
     if [[ $csv_count == 0 ]]; then
         error "Missing a cert-manager"
     fi
-    # if installed in all namespace mode or alongside cp2 cert manager, 
-    # csv_count will be >1, need to check for multiple deployments
     if [[ $csv_count > 1 ]]; then
-        webhook_deployments=$(${OC} get deploy -A --no-headers --ignore-not-found | grep "cert-manager-webhook" -c)
-        if [[ $webhook_deployments != "1" ]]; then
-            error "Multiple cert-managers found. Only one should be installed per cluster"
-        fi
+        error "Multiple cert-manager csv found. Only one should be installed per cluster"
     fi
 }
 

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -391,8 +391,13 @@ function check_cert_manager(){
     if [[ $csv_count == 0 ]]; then
         error "Missing a cert-manager"
     fi
+    # if installed in all namespace mode or alongside cp2 cert manager, 
+    # csv_count will be >1, need to check for multiple deployments
     if [[ $csv_count > 1 ]]; then
-        error "Multiple cert-manager csv found. Only one should be installed per cluster"
+        webhook_deployments=$(${OC} get deploy -A --no-headers --ignore-not-found | grep "cert-manager-webhook" -c)
+        if [[ $webhook_deployments != "1" ]]; then
+            error "Multiple cert-managers found. Only one should be installed per cluster"
+        fi
     fi
 }
 

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -387,7 +387,7 @@ function is_sub_exist() {
 }
 
 function check_cert_manager(){
-    csv_count=`$OC get csv |grep "cert-manager"|wc -l`
+    csv_count=$(${OC} get csv -A | grep "cert-manager"| wc -l | tr -d " ")
     if [[ $csv_count == 0 ]]; then
         error "Missing a cert-manager"
     fi

--- a/isolate.sh
+++ b/isolate.sh
@@ -153,7 +153,7 @@ function prereq() {
     fi
     
     #verify one and only one cert manager is installed
-    check_cert_manager
+    check_certmanager_count
 
     # LicenseServiceReporter should not be installed because it does not support multi-instance mode
     return_value=$(("${OC}" get crd ibmlicenseservicereporters.operator.ibm.com > /dev/null && echo exists) || echo fail)
@@ -721,6 +721,21 @@ function wait_for_certmanager() {
     fi
     webhook_ns=$(${OC} get deploy -A | grep cert-manager-webhook | awk '{print $1}')
     success "Cert Manager ready. Cert Manager operands deployed in $webhook_ns"
+}
+
+function check_certmanager_count(){
+    csv_count=$(${OC} get csv -A | grep "cert-manager"| wc -l | tr -d " ")
+    if [[ $csv_count == 0 ]]; then
+        error "Missing a cert-manager"
+    fi
+    # if installed in all namespace mode or alongside cp2 cert manager, 
+    # csv_count will be >1, need to check for multiple deployments
+    if [[ $csv_count > 1 ]]; then
+        webhook_deployments=$(${OC} get deploy -A --no-headers --ignore-not-found | grep "cert-manager-webhook" -c)
+        if [[ $webhook_deployments != "1" ]]; then
+            error "Multiple cert-managers found. Only one should be installed per cluster"
+        fi
+    fi
 }
 
 function wait_for_nss_update() {

--- a/isolate.sh
+++ b/isolate.sh
@@ -112,7 +112,7 @@ function main() {
         info "Licensing not marked for backup, skipping."
     fi
     restart
-    wait_for_certmanager "$CONTROL_NS" "${ns_list}"
+    wait_for_certmanager "${ns_list}"
     wait_for_nss_update "${ns_list}"
     success "Isolation complete"
 }
@@ -689,10 +689,8 @@ EOF
 }
 
 function wait_for_certmanager() {
-    local namespace=$1
-    shift
     local namespaces=$@
-    title " Wait for Cert Manager pods to come ready in namespace $namespace "
+    title " Wait for Cert Manager pods to come ready "
     msg "-----------------------------------------------------------------------"
     
     check_if_certmanager_deployed "${namespaces}"
@@ -703,9 +701,9 @@ function wait_for_certmanager() {
     local retries=20
     local sleep_time=15
     local total_time_mins=$(( sleep_time * retries / 60))
-    local wait_message="Waiting for deployment ${name} in namespace ${namespace} to be running ..."
-    local success_message="Deployment ${name} in namespace ${namespace} is running."
-    local error_message="Timeout after ${total_time_mins} minutes waiting for deployment ${name} in namespace ${namespace} to be running."
+    local wait_message="Waiting for deployment ${name} to be running ..."
+    local success_message="Deployment ${name} is running."
+    local error_message="Timeout after ${total_time_mins} minutes waiting for deployment ${name} to be running."
     wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
 
     #check webhook pod runnning
@@ -722,7 +720,7 @@ function wait_for_certmanager() {
         error "More than one cert-manager-webhook deployment exists on the cluster."
     fi
     webhook_ns=$(${OC} get deploy -A | grep cert-manager-webhook | awk '{print $1}')
-    success "Cert Manager ready in namespace $namespace. Cert Manager operands deployed in $webhook_ns"
+    success "Cert Manager ready. Cert Manager operands deployed in $webhook_ns"
 }
 
 function wait_for_nss_update() {

--- a/isolate.sh
+++ b/isolate.sh
@@ -151,6 +151,9 @@ function prereq() {
     if [[ "$DEBUG" != "1" && "$DEBUG" != "0" ]]; then
         error "Invalid value for DEBUG. Expected 0 or 1."
     fi
+    
+    #verify one and only one cert manager is installed
+    check_cert_manager
 
     # LicenseServiceReporter should not be installed because it does not support multi-instance mode
     return_value=$(("${OC}" get crd ibmlicenseservicereporters.operator.ibm.com > /dev/null && echo exists) || echo fail)

--- a/isolate.sh
+++ b/isolate.sh
@@ -112,11 +112,7 @@ function main() {
         info "Licensing not marked for backup, skipping."
     fi
     restart
-    if [[ $CERT_MANAGER_MIGRATED == "true" ]]; then
-        wait_for_certmanager "$CONTROL_NS" "${ns_list}"
-    else
-        info "Cert Manager not migrated, skipping wait."
-    fi
+    wait_for_certmanager "$CONTROL_NS" "${ns_list}"
     wait_for_nss_update "${ns_list}"
     success "Isolation complete"
 }

--- a/isolate.sh
+++ b/isolate.sh
@@ -343,8 +343,10 @@ function uninstall_singletons() {
 
     migrate_lic_cms $MASTER_NS
 
-    licensing_exists=$(${OC} get IBMLicensing || echo "fail")
-    if [[ $licensing_exists != "fail" ]]; then
+    licensing_exists=""
+    licensing_exists=$(${OC} get IBMLicensing)
+    if [[ $licensing_exists != "" ]]; then
+        info "Licensing marked for backup"
         backup_ibmlicensing
         BACKUP_LICENSING="true"
     else
@@ -696,8 +698,8 @@ function wait_for_certmanager() {
     check_if_certmanager_deployed "${namespaces}"
 
     #check cert manager operator pod
-    local name="ibm-cert-manager-operator"
-    local condition="${OC} -n ${namespace} get deploy --no-headers --ignore-not-found | egrep '1/1' | grep ^${name} || true"
+    local name="cert-manager-operator"
+    local condition="${OC} -A get deploy --no-headers --ignore-not-found | egrep '1/1' | grep ^${name} || true"
     local retries=20
     local sleep_time=15
     local total_time_mins=$(( sleep_time * retries / 60))


### PR DESCRIPTION
In the scenario where the isolate script fails and is then run again, it is possible given current implementation that the cert manager is deleted and marked for migration on the first failed run. Then, if the script failed before cert manager was redeployed, it would not be marked for migration on the second run. Combine this situation with the possibility that operand requests requesting cert manager are now all out of scope (due to the excluded parameter) and it creates a scenario where cert manager is not installed at all.

The code change in this pr would always call the `wait_for_certmanager` function. This function calls `check_if_certmanager_deployed` which checks the scope for operand requests calling for cert manager. If none exist in scope, it will create one in the original cs ns and which then deploys cert manager to the control namespace. This way, we always have cert manager deployed. If community is already installed, then only the operator pod will start up for the ibm cert manager and the rest of the wait checks will still pass as they are looking for the webhook pod to be ready somewhere on the cluster.

Testing:
- setup cp2 cluster with only opreq for cert manager in `test-ns` and no operand requests for im
- run isolate.sh excluding `test-ns`
- verify script completes
- verify cert manager operator pod exists in control namespace