### PR TITLE
copy oidc secret

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -52,6 +52,7 @@ function main() {
     # copy im credentials
     copy_resource "secret" "platform-auth-idp-credentials"
     copy_resource "secret" "platform-auth-ldaps-ca-cert"
+    copy_resource "secret" "platform-oidc-credentials"
     copy_resource "configmap" "ibm-cpp-config"
     copy_resource "configmap" "common-web-ui-config"
     copy_resource "commonservice" "common-service"


### PR DESCRIPTION
Copy over the oidc secret with the other custom resources copied over. This should be the last resource we need to copy over using preload_data.sh.