### PR TITLE
Scripts and Script-dev branch sync up for review

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -709,7 +709,7 @@ function wait_for_certmanager() {
 
     #check cert manager operator pod
     local name="cert-manager-operator"
-    local condition="${OC} -A get deploy --no-headers --ignore-not-found | egrep '1/1' | grep ^${name} || true"
+    local condition="${OC} get deploy -A --no-headers --ignore-not-found | egrep '1/1' | grep ${name} || true"
     local retries=20
     local sleep_time=15
     local total_time_mins=$(( sleep_time * retries / 60))

--- a/isolate.sh
+++ b/isolate.sh
@@ -277,12 +277,16 @@ function update_tenant() {
         updated_yaml=$(echo "$current_yaml" | "${YQ}" eval 'with(.namespaceMapping; . += [{"map-to-common-service-namespace": "'$map_to_cs_ns'"}])')
     fi
 
-    local tmp="\"$map_to_cs_ns\","
+    local tmp="\"$map_to_cs_ns\""
     debug1 "map $map_to_cs_ns namespace $namespaces tmp $tmp"
     for ns in $namespaces; do
-        tmp="$tmp\"$ns\","
+        debug1 "ns $ns mapto: $map_to_cs_ns"
+        if [[ $ns != $map_to_cs_ns ]]; then
+            tmp="$tmp,\"$ns\""
+        fi
     done
-    local ns_delimited="${tmp:0:-1}" # substring from 0 to length - 1
+    local ns_delimited="${tmp}"
+    debug1 "ns_delimited: $ns_delimited"
 
     updated_yaml=$(echo "$updated_yaml" | "${YQ}" eval 'with(.namespaceMapping[]; select(.map-to-common-service-namespace == "'$map_to_cs_ns'").requested-from-namespace = ['$ns_delimited'])')
     updated_yaml=$(echo "$updated_yaml" | "${YQ}" eval 'with(.namespaceMapping[]; select(.map-to-common-service-namespace == "'$map_to_cs_ns'").requested-from-namespace |= unique)')

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -55,6 +55,7 @@ function main() {
     copy_resource "secret" "platform-oidc-credentials"
     copy_resource "configmap" "ibm-cpp-config"
     copy_resource "configmap" "common-web-ui-config"
+    copy_resource "configmap" "platform-auth-idp"
     copy_resource "commonservice" "common-service"
     # any extra config
 }

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -52,6 +52,7 @@ function main() {
     # copy im credentials
     copy_resource "secret" "platform-auth-idp-credentials"
     copy_resource "secret" "platform-auth-ldaps-ca-cert"
+    copy_resource "secret" "platform-oidc-credentials"
     copy_resource "configmap" "ibm-cpp-config"
     copy_resource "configmap" "common-web-ui-config"
     copy_resource "commonservice" "common-service"


### PR DESCRIPTION
## Summary of changes
- check cs operator version in all namespaces in `isolate.sh`
  - cs operator in all cloudpak namespaces should be no less than 3.19.9
  - cs operator in original common service namespace should be either 3.20+ or 3.19.9+
- Copy `secret/platform-oidc-credentials` and `configmap/platform-auth-idp` from original namespace to new services namespace
- Support Mac OS system for `isolated.sh`
- Also have cert manager operator pod existing in CS control namespace at the end of `isolated.sh` script