### PR TITLE
[LTSR] allow multiple opbi

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -30,8 +30,25 @@ spec:
     spec:
       IBMLicensing:
         datasource: datacollector
-      operandBindInfo:
-        registryNamespace: "{{ .MasterNs }}"
+    resources:
+    - apiVersion: operator.ibm.com/v1alpha1
+      kind: OperandBindInfo
+      metadata:
+        name: ibm-licensing-bindinfo
+        namespace: "{{ .MasterNs }}"
+      spec:
+        operand: ibm-licensing-operator
+        registry: common-service
+        description: Binding information that should be accessible to licensing adopters
+        bindings:
+          public-api-data:
+            secret: ibm-licensing-token
+            configmap: ibm-licensing-info
+          public-api-token:
+            secret: ibm-licensing-token
+          public-api-upload:
+            secret: ibm-licensing-upload-token
+            configmap: ibm-licensing-upload-config
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}
@@ -470,7 +487,25 @@ spec:
         datasource: datacollector
         routeEnabled: false
         logLevel: VERBOSE
-      operandBindInfo: {}
+    resources:
+    - apiVersion: operator.ibm.com/v1alpha1
+      kind: OperandBindInfo
+      metadata:
+        name: ibm-licensing-bindinfo
+        namespace: "{{ .MasterNs }}"
+      spec:
+        operand: ibm-licensing-operator
+        registry: common-service
+        description: Binding information that should be accessible to licensing adopters
+        bindings:
+          public-api-data:
+            secret: ibm-licensing-token
+            configmap: ibm-licensing-info
+          public-api-token:
+            secret: ibm-licensing-token
+          public-api-upload:
+            secret: ibm-licensing-upload-token
+            configmap: ibm-licensing-upload-config
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -33,22 +33,22 @@ spec:
     resources:
     - apiVersion: operator.ibm.com/v1alpha1
       kind: OperandBindInfo
-      metadata:
-        name: ibm-licensing-bindinfo
-        namespace: "{{ .MasterNs }}"
-      spec:
-        operand: ibm-licensing-operator
-        registry: common-service
-        description: Binding information that should be accessible to licensing adopters
-        bindings:
-          public-api-data:
-            secret: ibm-licensing-token
-            configmap: ibm-licensing-info
-          public-api-token:
-            secret: ibm-licensing-token
-          public-api-upload:
-            secret: ibm-licensing-upload-token
-            configmap: ibm-licensing-upload-config
+      name: ibm-licensing-bindinfo
+      namespace: "{{ .MasterNs }}"
+      data:
+        spec:
+          operand: ibm-licensing-operator
+          registry: common-service
+          description: Binding information that should be accessible to licensing adopters
+          bindings:
+            public-api-data:
+              secret: ibm-licensing-token
+              configmap: ibm-licensing-info
+            public-api-token:
+              secret: ibm-licensing-token
+            public-api-upload:
+              secret: ibm-licensing-upload-token
+              configmap: ibm-licensing-upload-config
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}
@@ -490,22 +490,22 @@ spec:
     resources:
     - apiVersion: operator.ibm.com/v1alpha1
       kind: OperandBindInfo
-      metadata:
-        name: ibm-licensing-bindinfo
-        namespace: "{{ .MasterNs }}"
-      spec:
-        operand: ibm-licensing-operator
-        registry: common-service
-        description: Binding information that should be accessible to licensing adopters
-        bindings:
-          public-api-data:
-            secret: ibm-licensing-token
-            configmap: ibm-licensing-info
-          public-api-token:
-            secret: ibm-licensing-token
-          public-api-upload:
-            secret: ibm-licensing-upload-token
-            configmap: ibm-licensing-upload-config
+      name: ibm-licensing-bindinfo
+      namespace: "{{ .MasterNs }}"
+      data:
+        spec:
+          operand: ibm-licensing-operator
+          registry: common-service
+          description: Binding information that should be accessible to licensing adopters
+          bindings:
+            public-api-data:
+              secret: ibm-licensing-token
+              configmap: ibm-licensing-info
+            public-api-token:
+              secret: ibm-licensing-token
+            public-api-upload:
+              secret: ibm-licensing-upload-token
+              configmap: ibm-licensing-upload-config
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}


### PR DESCRIPTION
For ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58807
Use k8s resources to create licensing operandBindInfo instead of alm-example, which allows us to create multiple opbi in different namespace