### PR TITLE
update the placement for -A and remove regular exp

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -709,7 +709,7 @@ function wait_for_certmanager() {
 
     #check cert manager operator pod
     local name="cert-manager-operator"
-    local condition="${OC} -A get deploy --no-headers --ignore-not-found | egrep '1/1' | grep ^${name} || true"
+    local condition="${OC} get deploy -A --no-headers --ignore-not-found | egrep '1/1' | grep ${name} || true"
     local retries=20
     local sleep_time=15
     local total_time_mins=$(( sleep_time * retries / 60))


### PR DESCRIPTION
1. Update the placement for `-A` with following error
```
[INFO] Cert manager not requested in scope, deploying...
operandrequest.operator.ibm.com/ibm-cert-manager-operator created
[INFO] Waiting for deployment cert-manager-operator to be running ...
flags cannot be placed before plugin name: -A
flags cannot be placed before plugin name: -A
[INFO] RETRYING: Waiting for deployment cert-manager-operator to be running ... (20 left)
```

2. Remove regular expression on `grep ^"cert-manager-operator"`
If we are using `grep ^${name}`, it will explicitly look for deployment named `cert-manager-operator`.
```
➜  ✗ name=cert-manager-operator                                                    
➜  ✗ oc get deploy -A --no-headers --ignore-not-found | egrep '1/1' | grep ${name}
cs-control                                         ibm-cert-manager-operator                                   1/1   1     1     28m
ibm-cert-manager                                   ibm-cert-manager-operator                                   1/1   1     1     38d
➜  ✗ oc get deploy -A --no-headers --ignore-not-found | egrep '1/1' | grep ^${name}
```