### PR TITLE
Check if IBMLicensing CRD exists or not

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -356,13 +356,13 @@ function uninstall_singletons() {
     migrate_lic_cms $MASTER_NS
 
     licensing_exists=""
-    licensing_exists=$(${OC} get IBMLicensing)
-    if [[ $licensing_exists != "" ]]; then
+    licensing_exists=$(${OC} get IBMLicensing || echo "not found")
+    if [[ $licensing_exists == "" || $licensing_exists == "not found" ]]; then
+        info "No ibmlicensing resources on cluster, skipping backup."
+    else
         info "Licensing marked for backup"
         backup_ibmlicensing
         BACKUP_LICENSING="true"
-    else
-        info "No ibmlicensing resources on cluster, skipping backup."
     fi
     isExists=$("${OC}" get deployments -n "${MASTER_NS}" --ignore-not-found ibm-licensing-operator)
     if [ ! -z "$isExists" ]; then


### PR DESCRIPTION
If IBMLicensing CRD does not exist or IBMLicensing CR does not exists, skip the backup.

### Test
#### IBMLicensing CRD does not exist
The value of `$licensing_exists` is `not found`

```
➜  ✗ ./isolate.sh --original-cs-ns cloudpak2-cs3-only --control-ns cs-control

...
[INFO] No licensing configmaps to migrate
error: the server doesn't have a resource type "IBMLicensing"
[INFO] licensing_exists: not found
[INFO] No ibmlicensing resources on cluster, skipping backup.
...
```

#### IBMLicensing CR does not exist
The value of `$licensing_exists` is `''`
```
➜  ✗ ./isolate.sh --original-cs-ns cloudpak2-cs3-only --control-ns cs-control

...
[INFO] No licensing configmaps to migrate
No resources found
[INFO] licensing_exists: 
[INFO] No ibmlicensing resources on cluster, skipping backup.
...
```

#### IBMLicensing CR exists
The value of `$licensing_exists` is not `""` or `not found`

```
➜  ✗ ./isolate.sh --original-cs-ns cloudpak2-cs3-only --control-ns cs-control

...
[INFO] No licensing configmaps to migrate
[INFO] Licensing marked for backup
configmap/ibmlicensing-instance-bak configured
...
```