### PR TITLE
enhance singleton script to handle all cases

### DIFF
--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -195,4 +195,4 @@ function pre_req() {
     fi    
 }
 
-main $*
+main "$@"

--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -35,13 +35,6 @@ STEP=0
 . ${BASE_DIR}/utils.sh
 
 function main() {
-
-    # delegate certmanager cr if control namespace exists
-    # delete certmanager operator if control namespace does not exist
-    # if enable licensing and licensing operator is in operator ns
-    #   migrate licensing to LICENSING_NS
-    #   delete operator
-
     parse_arguments "$@"
     pre_req
 
@@ -186,10 +179,6 @@ function print_usage() {
 }
 
 function pre_req() {
-    if [ "$OPERATOR_NS" == "" ]; then
-        error "Must provide operator namespace"
-    fi
-
     if [ "$CONTROL_NS" == "" ]; then
         CONTROL_NS=$OPERATOR_NS
     fi    

--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -97,7 +97,7 @@ function main() {
 function restore_ibmlicensing() {
 
     # extracts the previously saved IBMLicensing CR from ConfigMap and creates the IBMLicensing CR
-    "${OC}" get cm ibmlicensing-instance-bak -n ${CONTROL_NS} -o yaml --ignore-not-found | "${YQ}" .data | sed -e 's/.*ibmlicensing.yaml.*//' | 
+    "${OC}" get cm ibmlicensing-instance-bak -n ${LICENSING_NS} -o yaml --ignore-not-found | "${YQ}" .data | sed -e 's/.*ibmlicensing.yaml.*//' | 
     sed -e 's/^  //g' | oc apply -f -
 
 }
@@ -117,7 +117,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ibmlicensing-instance-bak
-  namespace: ${CONTROL_NS}
+  namespace: ${LICENSING_NS}
 data:
   ibmlicensing.yaml: |
 ${instance}

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1066,8 +1066,13 @@ function is_supports_delegation() {
     minor=$(echo "$version" | cut -d '.' -f2)
     patch=$(echo "$version" | cut -d '.' -f3)
 
+    if [ -z "$version" ]; then
+        info "No ibm-common-service-operator found on the cluster, skipping delegation check"
+        return 0
+    fi
+
     if [ "$major" -gt 3 ]; then
-        echo "Major version is greater than 3, skipping delegation check"
+        info "Major version is greater than 3, skipping delegation check"
         return 0
     fi
 

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1056,18 +1056,15 @@ function debug1() {
        debug "${1}"
     fi
 }
-<<<<<<< HEAD
-=======
 
 # check if version of CS supports delegation for ibm-cert-manager-operator
 # >= v3.19.9 if in v3 channel
 # or >= v3.21.0 in any other channel
 function is_supports_delegation() {
     local version=$1
-    major=$(echo "$version" | cut -d '.' -f1)
+    major=$(echo "$version" | cut -d '.' -f1 | cut -d 'v' -f2)
     minor=$(echo "$version" | cut -d '.' -f2)
     patch=$(echo "$version" | cut -d '.' -f3)
-    # echo $major $minor $patch
 
     if [ "$major" -gt 3 ]; then
         echo "Major version is greater than 3, skipping delegation check"
@@ -1091,4 +1088,4 @@ function is_supports_delegation() {
 
     echo "Version: $version supports cert-manager delegation"
 }
->>>>>>> added cert-manager delegation check
+

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1056,3 +1056,39 @@ function debug1() {
        debug "${1}"
     fi
 }
+<<<<<<< HEAD
+=======
+
+# check if version of CS supports delegation for ibm-cert-manager-operator
+# >= v3.19.9 if in v3 channel
+# or >= v3.21.0 in any other channel
+function is_supports_delegation() {
+    local version=$1
+    major=$(echo "$version" | cut -d '.' -f1)
+    minor=$(echo "$version" | cut -d '.' -f2)
+    patch=$(echo "$version" | cut -d '.' -f3)
+    # echo $major $minor $patch
+
+    if [ "$major" -gt 3 ]; then
+        echo "Major version is greater than 3, skipping delegation check"
+        return 0
+    fi
+
+    if [ "$major" -lt 3 ]; then
+        return 1
+    fi
+
+    if [ "$minor" -lt 19 ]; then
+        return 1
+    fi
+
+    # only LTSR starting from 3.19.9 supported delegation
+    if [ "$minor" -eq 19 ]; then
+        if [ "$patch" -lt 9 ]; then
+            return 1
+        fi
+    fi
+
+    echo "Version: $version supports cert-manager delegation"
+}
+>>>>>>> added cert-manager delegation check

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -239,14 +239,17 @@ function install_cert_manager() {
     fi
 
     local api_version=$("$OC" get deployments -n "$webhook_ns" cert-manager-webhook -o jsonpath='{.metadata.ownerReferences[*].apiVersion}')
-    if [ "$api_version" == "$CERT_MANAGER_V1ALPHA1_OWNER" ]; then
+    if [ ! -z "$api_version" ]; then
+        if [ "$api_version" == "$CERT_MANAGER_V1ALPHA1_OWNER" ]; then
         error "Cluster has not deactivated LTSR ibm-cert-manager-operator yet, please re-run this script"
-    fi
-    if [ "$api_version" != "$CERT_MANAGER_V1_OWNER" ]; then
-        warning "Cluster has a non ibm-cert-manager-operator already installed, skipping"
-        return 0
-    fi
+        fi
 
+        if [ "$api_version" != "$CERT_MANAGER_V1_OWNER" ]; then
+            warning "Cluster has a non ibm-cert-manager-operator already installed, skipping"
+            return 0
+        fi
+    fi
+    
     create_namespace "${CERT_MANAGER_NAMESPACE}"
     create_operator_group "ibm-cert-manager-operator" "${CERT_MANAGER_NAMESPACE}" "{}"
     create_subscription "ibm-cert-manager-operator" "${CERT_MANAGER_NAMESPACE}" "$CHANNEL" "ibm-cert-manager-operator" "${CERT_MANAGER_SOURCE}" "${SOURCE_NS}" "${INSTALL_MODE}"

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -264,8 +264,7 @@ function install_licensing() {
     title "Installing licensing\n"
     is_sub_exist "ibm-licensing-operator-app" # this will catch the packagenames of all ibm-licensing-operator-app
     if [ $? -eq 0 ]; then
-        warning "There is an ibm-licensing-operator-app Subscription already\n"
-        return 0
+        warning "There is an ibm-licensing-operator-app Subscription already, so will upgrade it\n"
     elif [ $SKIP_INSTALL -eq 1 ]; then
         error "There is no ibm-licensing-operator-app Subscription installed\n"
     fi

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -282,6 +282,10 @@ function pre_req() {
             fi
         fi
     fi
+    
+    local csv=$("$OC" get sub -n "$OPERATOR_NS" -o jsonpath='{.status.currentCSV}' ibm-cert-manager-operator)
+    local version=$("$OC" get csv "$csv" -o jsonpath='{.spec.version}')
+    is_supports_delegation "$version"
 }
 
 # TODO validate argument

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -50,14 +50,17 @@ function main() {
     save_log "logs" "setup_singleton_log" "$DEBUG"
     trap cleanup_log EXIT
     pre_req
-    if [ $MIGRATE_SINGLETON -eq 1 ]; then
-        info "Found parameter '--operator-namespace', migrating singleton services"
-        if [ $ENABLE_LICENSING -eq 1 ]; then
-            ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" "--enable-licensing"
-        else
-            ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" 
-        fi
-    fi
+
+    # Debating on whether to keep this or not as a manual override to force migration path
+    # if [ $MIGRATE_SINGLETON -eq 1 ]; then
+    #     info "Found parameter '--operator-namespace', migrating singleton services"
+    #     if [ $ENABLE_LICENSING -eq 1 ]; then
+    #         ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" "--enable-licensing"
+    #     else
+    #         ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" 
+    #     fi
+    # fi
+
 
     install_cert_manager
     install_licensing

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -58,7 +58,7 @@ function main() {
 
     if [ $MIGRATE_SINGLETON -eq 1 ]; then
         if [ $ENABLE_LICENSING -eq 1 ]; then
-            ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" --control-namespace "$CONTROL_NS" "--enable-licensing" --licensing-namespace "$LICENSING_NS"
+            ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" --control-namespace "$CONTROL_NS" "--enable-licensing" --licensing-namespace "$LICENSING_NAMESPACE"
         else
             ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS" --control-namespace "$CONTROL_NS"
         fi
@@ -176,7 +176,6 @@ function is_migrate_cert_manager() {
         return 0
     fi
     MIGRATE_SINGLETON=1
-    ${BASE_DIR}/common/migrate_singleton.sh "--operator-namespace" "$OPERATOR_NS"
 }
 
 function is_migrate_licensing() {
@@ -356,4 +355,4 @@ function get_and_validate_arguments() {
     get_control_namespace
 }
 
-main $*
+main "$@"

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -282,9 +282,10 @@ function pre_req() {
             fi
         fi
     fi
-    
-    local csv=$("$OC" get sub -n "$OPERATOR_NS" -o jsonpath='{.status.currentCSV}' ibm-cert-manager-operator)
-    local version=$("$OC" get csv "$csv" -o jsonpath='{.spec.version}')
+
+    # Check if all CS installations are above 3.19.9
+    local csvs=$("$OC" get csv -A | grep ibm-common-service-operator | awk '{print $2}' | sort -V)
+    local version=$(echo "$csvs" | head -n 1 | cut -d '.' -f2-)
     is_supports_delegation "$version"
 }
 

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -188,7 +188,7 @@ function is_migrate_licensing() {
     
     local version=$("$OC" get ibmlicensing instance -o jsonpath='{.spec.version}')
     if [ -z "$version" ]; then
-        warn "No version field in ibmlicensing CR, skipping"
+        warning "No version field in ibmlicensing CR, skipping"
         return 0
     fi
     local major=$(echo "$version" | cut -d '.' -f1)


### PR DESCRIPTION
cases include: migrate, install, and upgrade

How to test migrate (isolated migration):

1. Set up cluster with installer operators and singletons at LTSR level
2. run `isolate.sh --original-cs-ns ibm-common-services --control-ns cs-control`
3. run `setup_singleton.sh --operator-namespace ibm-common-services --enable-licensing --license-accept`
4. Verify results:
   - cert-manager v4 running in ibm-cert-manager, including operands
   - cert-manager LTSR running in cs-control (only operator)
   - licensing v4 running in cs-control

How to test migrate (in place migration):

1. Set up cluster with installer operators and singletons at LTSR level
2. run `setup_singleton.sh  --operator-namespace ibm-common-services --enable-licensing --license-accept`
3. Verify results:
   - no control namespace exists
   - cert-manager v4 running in ibm-cert-manager, including operands
   - licensing v4 running in ibm-licensing

How to test install (no CS exists on cluster):

1. run `setup_singleton.sh --enable-licensing --license-accept`
2. Verify results:
   - no control namespace exists
   - cert-manager v4 running in ibm-cert-manager, including operands
   - licensing v4 running in ibm-licensing