### PR TITLE
check for cs op and odlm to be scaled after failure

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -739,9 +739,9 @@ function wait_for_certmanager() {
 
 function check_certmanager_count(){
     info "Verifying cert manager is deployed"
-    csv_count=$(${OC} get csv -A | grep "cert-manager"| wc -l | tr -d " " || echo "none")
+    csv_count=$(${OC} get csv -A | grep "cert-manager"| wc -l | tr -d " " || echo "")
     debug1 "cert manager csv count output: $csv_count"
-    if [[ "$csv_count" == "0" ]] || [[ "$csv_count" == "none" ]]; then
+    if [[ "$csv_count" == "0" ]] || [[ "$csv_count" == "" ]]; then
         error "Missing a cert-manager"
     fi
     # if installed in all namespace mode or alongside cp2 cert manager, 

--- a/isolate.sh
+++ b/isolate.sh
@@ -787,6 +787,7 @@ function wait_for_nss_exist() {
 function prev_fail_check() {
     info "Checking for common service operator and odlm pods"
     local cs_operator_scaled=$(${OC} get deploy -n $MASTER_NS | egrep '1/1'| grep ibm-common-service-operator || echo "false")
+    debug1 "cs op scaled output: $cs_operator_scaled"
     local cs_op_scale_needed="false"
     if [[ "$cs_operator_scaled" != "false" ]]; then 
         ${OC} scale deploy ibm-common-service-operator -n $MASTER_NS --replicas=1
@@ -796,6 +797,7 @@ function prev_fail_check() {
         info "Common Service Operator already scaled, skipping."
     fi
     local odlm_scaled=$(${OC} get deploy -n $MASTER_NS | egrep '1/1'| grep operand-deployment-lifecycle-manager || echo "false")
+    debug1 "odlm scaled output: $odlm_scaled"
     if [[ "$odlm_scaled" != "false" ]]; then 
         ${OC} scale deploy operand-deployment-lifecycle-manager -n $MASTER_NS --replicas=1
         info "ODLM scaled back to 1"

--- a/isolate.sh
+++ b/isolate.sh
@@ -740,6 +740,7 @@ function wait_for_certmanager() {
 function check_certmanager_count(){
     info "Verifying cert manager is deployed"
     csv_count=$(${OC} get csv -A | grep "cert-manager"| wc -l | tr -d " " || echo "none")
+    debug1 "cert manager csv count output: $csv_count"
     if [[ "$csv_count" == "0" ]] || [[ "$csv_count" == "none" ]]; then
         error "Missing a cert-manager"
     fi
@@ -789,7 +790,7 @@ function prev_fail_check() {
     local cs_operator_scaled=$(${OC} get deploy -n $MASTER_NS | egrep '1/1'| grep ibm-common-service-operator || echo "false")
     debug1 "cs op scaled output: $cs_operator_scaled"
     local cs_op_scale_needed="false"
-    if [[ "$cs_operator_scaled" != "false" ]]; then 
+    if [[ "$cs_operator_scaled" == "false" ]]; then 
         ${OC} scale deploy ibm-common-service-operator -n $MASTER_NS --replicas=1
         info "Common Service Operator scaled back to 1"
         cs_op_scale_needed="true"
@@ -798,7 +799,7 @@ function prev_fail_check() {
     fi
     local odlm_scaled=$(${OC} get deploy -n $MASTER_NS | egrep '1/1'| grep operand-deployment-lifecycle-manager || echo "false")
     debug1 "odlm scaled output: $odlm_scaled"
-    if [[ "$odlm_scaled" != "false" ]]; then 
+    if [[ "$odlm_scaled" == "false" ]]; then 
         ${OC} scale deploy operand-deployment-lifecycle-manager -n $MASTER_NS --replicas=1
         info "ODLM scaled back to 1"
     else

--- a/isolate.sh
+++ b/isolate.sh
@@ -808,6 +808,9 @@ function prev_fail_check() {
 
     if [[ $cs_op_scale_needed == "true" ]]; then
         check_CSCR "$MASTER_NS"
+        #wait for cert manager to come back ready after scaling up
+        local ns_list=$(gather_csmaps_ns)
+        wait_for_certmanager "${ns_list}"
     fi
 
 }


### PR DESCRIPTION
Always check to see if the common service operator and odlm pods have been scaled back up after a failed isolate attempt. 
Scenario:
On first attempt, the isolate script successfully scales down the cs operator and odlm deployments to 0 and uninstalls cert manager. However, the script fails before it can rescale cs operator and odlm deployments so cert manager is not deployed again either. The subsequent attempt at running the isolate script will then fail immediately because no cert manager is deployed. This failure is also very obtuse as the error handling of this function is not strong enough.

What this pr does:
1. makes the early failure due to a lack of cert manager more clear
2. ensures cs operator and odlm are scaled to 1 before proceeding with the script. Wait for CS CR after scaling

Testing: 
- deploy common services
- run isolate script, make sure to exit sometime after uninstall singletons
- verify cert manager is not installed, cs op and odlm are scaled to 0
- run this version of the isolate script
- verify script completes