### PR TITLE
CS operator handles scoping changes

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -39,7 +39,6 @@ type CSData struct {
 	ApprovalMode       string
 	OnPremMultiEnable  string
 	ZenOperatorImage   string
-	IsOCP              bool
 	WatchNamespaces    string
 }
 

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -108,10 +108,6 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 	if err != nil {
 		return
 	}
-	isOCP, err := isOCP(mgr, servicesNs)
-	if err != nil {
-		return
-	}
 
 	catalogSourceName, catalogSourceNs := util.GetCatalogSource(constant.IBMCSPackage, operatorNs, mgr.GetAPIReader())
 	if catalogSourceName == "" || catalogSourceNs == "" {
@@ -130,7 +126,6 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		CatalogSourceNs:   catalogSourceNs,
 		ApprovalMode:      approvalMode,
 		ZenOperatorImage:  util.GetImage("IBM_ZEN_OPERATOR_IMAGE"),
-		IsOCP:             isOCP,
 		WatchNamespaces:   util.GetWatchNamespace(),
 		OnPremMultiEnable: strconv.FormatBool(util.CheckMultiInstances(mgr.GetAPIReader())),
 	}
@@ -161,20 +156,6 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 	}
 	klog.Infof("Single Deployment Status: %v, MultiInstance Deployment status: %v, SaaS Depolyment Status: %v", !bs.MultiInstancesEnable, bs.MultiInstancesEnable, bs.SaasEnable)
 	return
-}
-
-func isOCP(mgr manager.Manager, ns string) (bool, error) {
-	config := &corev1.ConfigMap{}
-	if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: constant.IBMCPPCONFIG, Namespace: ns}, config); err != nil && !errors.IsNotFound(err) {
-		return false, err
-	} else if errors.IsNotFound(err) {
-		return true, nil
-	} else {
-		if config.Data["kubernetes_cluster_type"] == "" || config.Data["kubernetes_cluster_type"] == "ocp" {
-			return true, nil
-		}
-		return false, nil
-	}
 }
 
 // InitResources initialize resources at the bootstrap of operator
@@ -1035,7 +1016,7 @@ func (b *Bootstrap) CheckClusterType(ns string) (bool, error) {
 						Version: "v1",
 						Kind:    "Infrastructure",
 					})
-					if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraObj); err == nil {
+					if err := b.Client.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infraObj); err == nil {
 						isOCP = true
 					} else {
 						klog.Errorf("Fail to get Infrastructure resource named cluster: %v", err)

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1010,9 +1010,9 @@ func (b *Bootstrap) DeployResource(cr, placeholder string) bool {
 	return true
 }
 
-func CheckClusterType(mgr manager.Manager, ns string) (bool, error) {
+func (b *Bootstrap) CheckClusterType(ns string) (bool, error) {
 	var isOCP bool
-	dc := discovery.NewDiscoveryClientForConfigOrDie(mgr.GetConfig())
+	dc := discovery.NewDiscoveryClientForConfigOrDie(b.Config)
 	_, apiLists, err := dc.ServerGroupsAndResources()
 	if err != nil {
 		return false, err
@@ -1047,7 +1047,7 @@ func CheckClusterType(mgr manager.Manager, ns string) (bool, error) {
 	klog.Infof("Cluster type is OCP: %v", isOCP)
 
 	config := &corev1.ConfigMap{}
-	if err := mgr.GetClient().Get(context.TODO(), types.NamespacedName{Name: constant.IBMCPPCONFIG, Namespace: ns}, config); err != nil && !errors.IsNotFound(err) {
+	if err := b.Client.Get(context.TODO(), types.NamespacedName{Name: constant.IBMCPPCONFIG, Namespace: ns}, config); err != nil && !errors.IsNotFound(err) {
 		return false, err
 	} else if errors.IsNotFound(err) {
 		if isOCP {

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -173,6 +173,25 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		}
 	}
 
+	typeCorrect, err := r.Bootstrap.CheckClusterType(util.GetServicesNamespace(r.Reader))
+	if err != nil {
+		klog.Errorf("Failed to verify cluster type  %v", err)
+		if err := r.updatePhase(ctx, instance, CRFailed); err != nil {
+			klog.Error(err)
+		}
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		return ctrl.Result{}, err
+	}
+
+	if !typeCorrect {
+		klog.Error("Cluster type specificed in the ibm-cpp-config isn't correct")
+		if err := r.updatePhase(ctx, instance, CRFailed); err != nil {
+			klog.Error(err)
+		}
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		return ctrl.Result{}, err
+	}
+
 	// Init common service bootstrap resource
 	// Including namespace-scope configmap
 	// Deploy OperandConfig and OperandRegistry

--- a/main.go
+++ b/main.go
@@ -194,7 +194,7 @@ func main() {
 		klog.Infof("Common Service Operator in the namespace %s takes charge of resource management", cpfsNs)
 	}
 
-	// Start up the webhook server if it is ocp
+	// Start up the webhook server
 	if err = (&commonservicewebhook.Defaulter{
 		Client:    mgr.GetClient(),
 		Reader:    mgr.GetAPIReader(),

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"os"
 	"strings"
-	"time"
 
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -142,20 +141,6 @@ func main() {
 	// If Common Service Operator Namespace is not in the same as .spec.operatorNamespace(cpfsNs) in default CS CR,
 	// this Common Service Operator is not in the operatorNamespace(cpfsNs) under this tenant, and goes dormant.
 	if operatorNs == cpfsNs {
-		for {
-			typeCorrect, err := bootstrap.CheckClusterType(mgr, util.GetServicesNamespace(mgr.GetAPIReader()))
-			if err != nil {
-				klog.Errorf("Failed to verify cluster type  %v", err)
-				continue
-			}
-
-			if !typeCorrect {
-				klog.Error("Cluster type specificed in the ibm-cpp-config isn't correct")
-				time.Sleep(2 * time.Minute)
-			} else {
-				break
-			}
-		}
 
 		// New bootstrap Object
 		bs, err := bootstrap.NewBootstrap(mgr)


### PR DESCRIPTION
For issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/58293

Moving cluster type check into reconcile master CS CR
This PR partially fix for the scenario that NSS CR accidentally remove namespace from scope which will cause the cs-operator stuck in this initialization stage (0/1 pod not ready), and error msg ` Failed to verify cluster type unable to get: xxx/ibm-cpp-config because of unknown namespace for the cache`. This is because cs operator does not have permissions copy the ibm-cpp-config configmap to the namespace as it has been removed from NSS CR.

