### PR TITLE
z specific changes to preload process

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -479,7 +479,7 @@ EOF
     while [ $retries > 0 ]
     do
       info "waiting for completion"
-      status=$(${OC} get po | grep mongodb-backup | awk '{print $3}')
+      status=$(${OC} get po | grep mongodb-backup | grep Completed | awk '{print $3}' || echo "Unknown")
       ${OC} get po | grep mongodb-backup
       if [[ "$status" == "Completed" ]]; then
         break
@@ -728,7 +728,7 @@ EOF
     while [ $retries > 0 ]
     do
       info "waiting for completion"
-      status=$(${OC} get po | grep mongodb-restore | awk '{print $3}')
+      status=$(${OC} get po | grep mongodb-restore | grep Completed | awk '{print $3}' || echo "Unknown")
       ${OC} get po | grep mongodb-restore
       if [[ "$status" == "Completed" ]] || [[ "$status" == "" ]]; then
         break

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -142,7 +142,7 @@ function prereq() {
       mongo_op_scaled=$(${OC} get deploy -n $FROM_NAMESPACE | grep ibm-mongodb-operator | egrep '1/1' || echo false)
       if [[ $mongo_op_scaled == "false" ]]; then
         debug1 "Mongo operator still scaled down, scaling up."
-        ${OC} scale deploy -n $FROM_NAMESPACE ibm-mongodb-operator --repilcas=1
+        ${OC} scale deploy -n $FROM_NAMESPACE ibm-mongodb-operator --replicas=1
         delete_mongo_pods "$FROM_NAMESPACE"
       fi
     fi

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -1516,7 +1516,7 @@ metadata:
     app.kubernetes.io/name: mongodbs.operator.ibm.com
     release: mongodb
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: icp-mongodb

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -501,6 +501,7 @@ EOF
     delete_mongo_pods "$FROM_NAMESPACE"
     info "Scale mongo operator back up to 1"
     ${OC} scale deploy -n $FROM_NAMESPACE ibm-mongodb-operator --replicas=1
+  fi
   success "Backup Complete"
 } # dumpmongo
 

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -143,6 +143,7 @@ function prereq() {
       if [[ $mongo_op_scaled == "false" ]]; then
         debug1 "Mongo operator still scaled down, scaling up."
         ${OC} scale deploy -n $FROM_NAMESPACE ibm-mongodb-operator --repilcas=1
+        delete_mongo_pods "$FROM_NAMESPACE"
       fi
     fi
 }

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -139,6 +139,7 @@ function prereq() {
     architecture=$(${OC} describe node $mongo_node | grep "Architecture:" | awk '{print $2}')
     if [[ $architecture == "s390x" ]]; then
       s390x_ENV="true"
+      info "Z cluster detected, be prepared for multiple restarts of mongo pods. This is expected behavior."
       mongo_op_scaled=$(${OC} get deploy -n $FROM_NAMESPACE | grep ibm-mongodb-operator | egrep '1/1' || echo false)
       if [[ $mongo_op_scaled == "false" ]]; then
         info "Mongo operator still scaled down, scaling up."
@@ -1515,7 +1516,7 @@ metadata:
     app.kubernetes.io/name: mongodbs.operator.ibm.com
     release: mongodb
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: icp-mongodb

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -468,41 +468,11 @@ spec:
 EOF
   fi
 
-  status="Unknown"
   info "Running Backup" 
   ${OC} apply -f $TEMPFILE -n $FROM_NAMESPACE
   ${OC} get pods -n $FROM_NAMESPACE | grep mongodb-backup || echo ""
   wait_for_job_complete "mongodb-backup" "$FROM_NAMESPACE"
 
-  # while [[ "$status" != "Completed" ]]
-  # do
-  #   ${OC} apply -f $TEMPFILE
-  #   sleep 10
-  #   retries=10
-  #   while [ $retries > 0 ]
-  #   do
-  #     info "waiting for completion"
-  #     status=$(${OC} get po | grep mongodb-backup | grep Completed | awk '{print $3}' || echo "Unknown")
-  #     ${OC} get po | grep mongodb-backup
-  #     if [[ "$status" == "Completed" ]]; then
-  #       break
-  #     elif [[ "$status" == "Running" ]]; then
-  #       retries=10
-  #       sleep 10
-  #     elif [[ "$status" == "" ]]; then
-  #       break
-  #     else
-  #       retries=$(( $retries - 1 ))
-  #       sleep 10
-  #     fi  
-  #   done
-  #   if [[ "$status" != "Completed" ]]; then
-  #     info "Retrying mongodb-backup"
-  #     ${OC} delete job mongodb-backup
-  #   fi
-  # done
-
-  dumplogs mongodb-backup
   if [[ $s390x_ENV == "true" ]]; then
     #reset changes for z environment
     info "Reverting change to icp-mongodb configmap" 
@@ -719,38 +689,9 @@ spec:
 EOF
   fi
 
-  status="Unknown"
   info "Running Restore"
   ${OC} apply -f $TEMPFILE -n $TO_NAMESPACE
   wait_for_job_complete "mongodb-restore" "$TO_NAMESPACE"
-  
-  # while [[ "$status" != "Completed" ]]
-  # do
-  #   info "Starting MongoDB Restore Job "
-  #   ${OC} apply -f $TEMPFILE
-  #   sleep 10
-  #   retries=10
-  #   while [ $retries > 0 ]
-  #   do
-  #     info "waiting for completion"
-  #     status=$(${OC} get po | grep mongodb-restore | grep Completed | awk '{print $3}' || echo "Unknown")
-  #     ${OC} get po | grep mongodb-restore
-  #     if [[ "$status" == "Completed" ]] || [[ "$status" == "" ]]; then
-  #       break
-  #     elif [[ "$status" == "Running" ]]; then
-  #       retries=10
-  #       sleep 10
-  #     else
-  #       retries=$(( $retries - 1 ))
-  #       sleep 10
-  #     fi  
-  #   done
-  #   if [[ "$status" != "Completed" ]]; then
-  #     info "Retrying MongoDB Restore"
-  #     ${OC} delete job mongodb-restore
-  #   fi
-  # done
-  # dumplogs mongodb-restore
   success "Restore Complete"
 } # loadmongo
 

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -397,7 +397,7 @@ data:
       bindIpAll: true
       port: 27017
       ssl:
-        mode: preferSSL
+        mode: diasbled
         CAFile: /data/configdb/tls.crt
         PEMKeyFile: /work-dir/mongo.pem
     replication:

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -397,7 +397,7 @@ data:
       bindIpAll: true
       port: 27017
       ssl:
-        mode: diasbled
+        mode: preferSSL
         CAFile: /data/configdb/tls.crt
         PEMKeyFile: /work-dir/mongo.pem
     replication:


### PR DESCRIPTION
Implementing the workaround for cpd quality repo issue 9990. 

Workaround is as follows:

- Scale down mongo operator in ibm-common-services to 0
-  edit icp-mongodb cm in ibm-common-services . Change the net.ssl.mode value to preferSSL from requireSSL
-  restart mongo pods in ibm-common-services one by one starting with icp-mongo-0. Delete the pod, let it come all the way ready, then move on to the next pod
-  clone the github repo for scripts branch, edit the preload_data.sh to remove the ssl parameters from the backup job definition [here](https://github.com/IBM/ibm-common-service-operator/blob/scripts/preload_data.sh#L317) and the restore job definition [here](https://github.com/IBM/ibm-common-service-operator/blob/scripts/preload_data.sh#L490)
-  remove the metrics container from the statefulset yaml (remove from https://github.com/IBM/ibm-common-service-operator/blob/scripts/preload_data.sh#L1554 through https://github.com/IBM/ibm-common-service-operator/blob/scripts/preload_data.sh#L1674)
-  save edited file
-  delete the dummy mongo statefulset in the services namespace (zen in the cluster from this issue)
-  rerun the edited preload_data.sh script with the same parameters
-  after completion, revert change to icp-mongodb configmap in ibm-common-services (aka the original cs namespace) to set net.ssl.mode to requireSSL
-  delete mongo pods one by one again same as before
-  scale mongo operator back to 1

Testing:
- setup cs on z cluster
- run preload_data.sh
- verify script completes and data is transferred into new namespace