### PR TITLE
[4.1] check operatorNS and servicesNS in cs cr

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -492,7 +492,7 @@ EOF
 }
 
 function configure_cs_kind() {
-    local retries=5
+    local retries=10
     local delay=30
 
     title "Configuring CommonService CR in $OPERATOR_NS..."
@@ -531,8 +531,9 @@ EOF
             else
                 operatorNSinCR=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.operatorNamespace')
                 servicesNSinCR=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.servicesNamespace')
-                info "OperatorNamespace in CommonService cr should be ${OPERATOR_NS}, but it is ${operatorNSinCR}"
-                info "ServicesNamespace in CommonService cr should be ${SERVICES_NS}, but it is ${servicesNSinCR}"
+                warning "OperatorNamespace in CommonService cr should be ${OPERATOR_NS}, but it is ${operatorNSinCR}"
+                warning "ServicesNamespace in CommonService cr should be ${SERVICES_NS}, but it is ${servicesNSinCR}"
+                retries=$((retries-1))
             fi
         else
             warning "Failed to patch CommonService CR in ${OPERATOR_NS}, retry it in ${delay} seconds..."

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -464,8 +464,12 @@ EOF
     
         # Check if the patch was successful
         if [[ $? -eq 0 ]]; then
-            success "Successfully patched CommonService CR in ${OPERATOR_NS}"
-            break
+            checkOperatorNS=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.operatorNamespace=="'${OPERATOR_NS}'"')
+            checkServicesNS=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.servicesNamespace=="'${SERVICES_NS}'"')
+            if [ $checkOperatorNS ] && [ $checkServicesNS ]; then
+                success "Successfully patched CommonService CR in ${OPERATOR_NS}"
+                break
+            fi
         else
             warning "Failed to patch CommonService CR in ${OPERATOR_NS}, retry it in ${delay} seconds"
             sleep ${delay}

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -469,6 +469,11 @@ EOF
             if [ $checkOperatorNS ] && [ $checkServicesNS ]; then
                 success "Successfully patched CommonService CR in ${OPERATOR_NS}"
                 break
+            else
+                operatorNSinCR=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.operatorNamespace')
+                servicesNSinCR=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.servicesNamespace')
+                info "OperatorNamespace in CommonService cr should be ${OPERATOR_NS}, but it is ${operatorNSinCR}"
+                info "ServicesNamespace in CommonService cr should be ${SERVICES_NS}, but it is ${servicesNSinCR}"
             fi
         else
             warning "Failed to patch CommonService CR in ${OPERATOR_NS}, retry it in ${delay} seconds"

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -465,7 +465,7 @@ EOF
         # Check if the patch was successful
         if [[ $? -eq 0 ]]; then
             checkOperatorNS=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.operatorNamespace=="'${OPERATOR_NS}'"')
-            checkServicesNS=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.servicesNamespace=="'${SERVICES_NS}'"')
+            checkServicesNS=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.servicesNamespace=="'${SERVICES_NS}'"')
             if [ $checkOperatorNS ] && [ $checkServicesNS ]; then
                 success "Successfully patched CommonService CR in ${OPERATOR_NS}"
                 break


### PR DESCRIPTION
for ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59007
In the upgrade, if CommonService CRD does not contain  `x-kubernetes-preserve-unknown-fields: true`, operatorNS and serviceNS will be removed by k8s, so we need to double check it.
