### PR TITLE
creating namespaces in pre-req

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -208,7 +208,7 @@ function wait_for_no_pod() {
 function wait_for_project() {
     local name=$1
     local condition="${OC} get project ${name} --no-headers --ignore-not-found"
-    local retries=50
+    local retries=12
     local sleep_time=10
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for project ${name} to be created"
@@ -417,6 +417,7 @@ function create_namespace() {
         if [[ $? -ne 0 ]]; then
             error "Error creating namespace ${namespace}"
         fi
+        wait_for_project ${namespace}
     else
         info "Namespace ${namespace} already exists. Skip creating"
     fi

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -126,7 +126,7 @@ function wait_for_condition() {
     done
 
     if [[ ! -z "${success_message}" ]]; then
-        success "${success_message}"
+        success "${success_message}\n"
     fi
 }
 
@@ -387,7 +387,10 @@ function is_sub_exist() {
 }
 
 function check_cert_manager(){
-    csv_count=`$OC get csv -n "$2" | grep "$1" | wc -l`
+    local service_name=$1    
+    local namespace=$2
+    title " Checking whether Cert Manager exist...\n" 
+    csv_count=`$OC get csv -n "$namespace" | grep "$service_name" | wc -l`
     if [[ $csv_count == 0 ]]; then
         error "Missing a cert-manager"
     fi
@@ -397,6 +400,7 @@ function check_cert_manager(){
 }
 
 function check_licensing(){
+    title " Checking IBMLicensing...\n"
     [[ ! $($OC get IBMLicensing) ]] && error "User does not have proper permission to get IBMLicensing or IBMLicensing is not installed"
     instance_count=`$OC get IBMLicensing -o name | wc -l`
     if [[ $instance_count == 0 ]]; then
@@ -410,9 +414,8 @@ function check_licensing(){
 
 function create_namespace() {
     local namespace=$1
-    
     if [[ -z "$(${OC} get namespace ${namespace} --ignore-not-found)" ]]; then
-        title "Creating namespace ${namespace}\n"
+        title "Creating namespace ${namespace}"
         ${OC} create namespace ${namespace}
         if [[ $? -ne 0 ]]; then
             error "Error creating namespace ${namespace}"

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -46,6 +46,7 @@ function main() {
     trap cleanup_log EXIT
     pre_req
     setup_topology
+    check_singleton_service
     setup_nss
     install_cs_operator
 }
@@ -142,6 +143,7 @@ function print_usage() {
 }
 
 function pre_req() {
+    title "Start to validate necessary functional prerequisite... "
     # Check the value of DEBUG
     if [[ "$DEBUG" != "1" && "$DEBUG" != "0" ]]; then
         error "Invalid value for DEBUG. Expected 0 or 1."
@@ -156,22 +158,13 @@ function pre_req() {
     else
         success "oc command logged in as ${user}"
     fi
-
-    create_ns_list
-    check_cert_manager "cert-manager" "$OPERATOR_NS"
+    
     if [ $? -ne 0 ]; then
         error "Cert-manager is not found or having more than one\n"
     fi
 
     if [ $LICENSE_ACCEPT -ne 1 ]; then
         error "License not accepted. Rerun script with --license-accept flag set. See https://ibm.biz/integration-licenses for more details"
-    fi
-
-    if [ $ENABLE_LICENSING -eq 1 ]; then
-        check_licensing
-        if [ $? -ne 0 ]; then
-            error "ibm-licensing is not found or having more than one\n"
-        fi
     fi
 
     # Check INSTALL_MODE
@@ -238,6 +231,16 @@ EOF
     create_operator_group "common-service" "$OPERATOR_NS" "$target"
     if [ $? -ne 0 ]; then
         error "Operatorgroup cannot be created in namespace $OPERATOR_NS, please ensure user $user has proper permission to create Operatorgroup\n"
+    fi
+}
+
+function check_singleton_service() {
+    check_cert_manager "cert-manager" "$OPERATOR_NS"
+    if [ $ENABLE_LICENSING -eq 1 ]; then
+        check_licensing
+        if [ $? -ne 0 ]; then
+            error "ibm-licensing is not found or having more than one\n"
+        fi
     fi
 }
 

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -143,7 +143,7 @@ function print_usage() {
 }
 
 function pre_req() {
-    title "Start to validate necessary functional prerequisite... "
+    title "Start to validate the parameters passed into script... "
     # Check the value of DEBUG
     if [[ "$DEBUG" != "1" && "$DEBUG" != "0" ]]; then
         error "Invalid value for DEBUG. Expected 0 or 1."

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -157,6 +157,7 @@ function pre_req() {
         success "oc command logged in as ${user}"
     fi
 
+    create_ns_list
     check_cert_manager "cert-manager" "$OPERATOR_NS"
     if [ $? -ne 0 ]; then
         error "Cert-manager is not found or having more than one\n"


### PR DESCRIPTION
Since we do the cert manager check in `pre-req` function, we need to create all namespaces before `check_cert_manager` for those which are first time passed into the script, otherwise, there will be `No resources found in operator_namespace` and failed in `[✘] Missing a cert-manager`
fix for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59207

test result：
```
# Start to validate necessary functional prerequisite... 
[✔] oc command available
[✔] oc command logged in as kube:admin
[✔] Channel is valid
[✔] Profile size is valid.
# Creating namespace cloudpak-control-test
namespace/cloudpak-control-test created
[INFO] Waiting for project cloudpak-control-test to be created
[✔] Project cloudpak-control-test is created

# Creating namespace cloudpak-data-test
namespace/cloudpak-data-testcreated
[INFO] Waiting for project cloudpak-data-test to be created
[✔] Project cloudpak-data-test is created

#  Checking whether Cert Manager exist...

#  Checking IBMLicensing...

```