### PR TITLE
Update golang image to bullseye base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.5 as builder
+FROM golang:1.20.5-bullseye as builder
 ARG GOARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
golang:1.20.5 switched to a new base os debian `bookworm`, use `1.20.5-bullseye` to keep compatibility