### PR TITLE
remove internal URL for lint error

### DIFF
--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -8,8 +8,6 @@
 # This is an internal component, bundled with an official IBM product. 
 # Please refer to that particular license for additional information. 
 
-# Base on https://github.ibm.com/IBMPrivateCloud/cs-dev-tools/blob/master/install/cp3pt0-install/uninstall_tenant.sh
-
 # ---------- Command arguments ----------
 
 OC=oc


### PR DESCRIPTION
Aim to fix the lint error
```
==> Linting results for ibmcase-bundle ibm-cp-common-services-bundle
[ERROR] case/ibm-cp-common-services/inventory/ibmCommonServiceOperatorSetup/installer_scripts/cp3pt0-deployment/uninstall_tenant.sh: internal URL "github.ibm.com" not allowed (NoInternalURLs)
```
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59196