### PR TITLE
Cleanup scritp enhancement

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -644,7 +644,7 @@ function cleanup_OperandBindInfo() {
 
 function cleanup_NamespaceScope() {
     local namespace=$1
-    ${OC} delete namespacescope odlm-scope-managedby-odlm nss-odlm-scope nss-managedby-odlm -n ${namespace} --ignore-not-found
+    ${OC} delete namespacescope odlm-scope-managedby-odlm nss-odlm-scope nss-managedby-odlm common-service -n ${namespace} --ignore-not-found
 }
 
 function cleanup_OperandRequest() {

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1031,7 +1031,7 @@ function delete_operand_finalizer() {
     local ns=$2
     for crd in ${crds}; do
         if [ "${crd}" != "packagemanifests.packages.operators.coreos.com" ] && [ "${crd}" != "events" ] && [ "${crd}" != "events.events.k8s.io" ]; then
-            crs=$(${OC} get ${crd} --no-headers --ignore-not-found -n ${ns} 2>/dev/null | awk '{print $1}')
+            crs=$(${OC} get "${crd}" --no-headers --ignore-not-found -n "${ns}" 2>/dev/null | awk '{print $1}')
             for cr in ${crs}; do
                 msg "Removing the finalizers for resource: ${crd}/${cr}"
                 ${OC} patch ${crd} ${cr} -n ${ns} --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]' 2>/dev/null

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -366,7 +366,9 @@ function cleanup_cs_control() {
         cleanup_secretshare $CONTROL_NS ""
         # cleanup crossplane    
         cleanup_crossplane
-
+        # delete common-service-maps 
+        ${OC} delete configmap common-service-maps -n kube-public
+        # delete namespace
         ${OC} delete --ignore-not-found ns "$CONTROL_NS" --timeout=30s
         if [ $? -ne 0 ] || [ $FORCE_DELETE -eq 1 ]; then
             warning "Failed to delete namespace $CONTROL_NS, force deleting remaining resources..."

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -303,7 +303,7 @@ function delete_tenant_ns() {
         update_namespaceMapping $ns
     done
 
-    cleanup_cs_contorl
+    cleanup_cs_control
 
     success "Common Services uninstall finished and successfull." 
 }
@@ -349,10 +349,10 @@ EOF
 }
 
 # check if we need to cleanup contorl namespace and clean it
-function cleanup_cs_contorl() {
+function cleanup_cs_control() {
     local current_yaml=$("${OC}" get -n kube-public cm common-service-maps -o yaml | yq '.data.["common-service-maps.yaml"]')
     local isExist=$(echo "$current_yaml" | yq '.namespaceMapping[] | has("map-to-common-service-namespace")' )
-    if [ "$isExists" ]; then
+    if [ $isExists=="true" ]; then
         info "map-to-common-service-namespace exist in common-service-maps, don't clean up control namespace"
     else
         title "Clean up control namespace"

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -140,9 +140,7 @@ function set_tenant_namespaces() {
 
         # if this namespace is servicesNamespace
         operator_ns=$(${OC} get -n "$ns" commonservice common-service -o jsonpath='{.spec.operatorNamespace}' --ignore-not-found)
-        echo "$operator_ns"
         services_ns=$(${OC} get -n "$ns" commonservice common-service -o jsonpath='{.spec.servicesNamespace}' --ignore-not-found)
-        echo "$services_ns"
         if [ "$services_ns" == "$ns" ]; then
             temp_namespace=$(${OC} get -n "$operator_ns" configmap namespace-scope -o jsonpath='{.data.namespaces}' --ignore-not-found)
             if [ "$TENANT_NAMESPACES" == "" ]; then
@@ -164,8 +162,8 @@ function set_tenant_namespaces() {
     done
 
     # delete duplicate namespace in TENANT_NAMESPACES and OPERATOR_NS_LIST
-    TENANT_NAMESPACES=$(echo "$TENANT_NAMESPACES" | sed -e 's/,/\n/g' | sort -u | tr "\r\n" ","  | sed 's/\r\n/,/g' | sed '$ s/,$//')
-    OPERATOR_NS_LIST=$(echo "$OPERATOR_NS_LIST" | sed -e 's/,/\n/g' | sort -u | tr "\r\n" ","  | sed 's/\r\n/,/g' | sed '$ s/,$//')
+    TENANT_NAMESPACES=$(echo "$TENANT_NAMESPACES" | sed -e 's/,/\n/g' | sort -u | tr "\r\n" "," | sed '$ s/,$//')
+    OPERATOR_NS_LIST=$(echo "$OPERATOR_NS_LIST" | sed -e 's/,/\n/g' | sort -u | tr "\r\n" "," | sed '$ s/,$//')
     info "Tenant namespaces are: $TENANT_NAMESPACES"
 }
 

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -313,9 +313,9 @@ function update_namespaceMapping() {
     title "Updating common-service-maps $namespace"
     msg "-----------------------------------------------------------------------"
     local current_yaml=$("${OC}" get -n kube-public cm common-service-maps -o yaml | yq '.data.["common-service-maps.yaml"]')
-    local isExists=$(echo "$current_yaml" | yq '.namespaceMapping[] | select(.map-to-common-service-namespace == "'$namespace'")')
+    local isExist=$(echo "$current_yaml" | yq '.namespaceMapping[] | select(.map-to-common-service-namespace == "'$namespace'")')
 
-    if [ "$isExists" ]; then
+    if [ "$isExist" ]; then
         info "The map-to-common-service-namespace: $namespace, exist in common-service-maps"
         info "Deleting this tenant in common-service-maps"
         updated_yaml=$(echo "$current_yaml" | yq 'del(.namespaceMapping[] | select(.map-to-common-service-namespace == "'$namespace'"))')
@@ -352,12 +352,11 @@ EOF
 function cleanup_cs_control() {
     local current_yaml=$("${OC}" get -n kube-public cm common-service-maps -o yaml | yq '.data.["common-service-maps.yaml"]')
     local isExist=$(echo "$current_yaml" | yq '.namespaceMapping[] | has("map-to-common-service-namespace")' )
-    if [ $isExists=="true" ]; then
+    if [ "$isExist" ]; then
         info "map-to-common-service-namespace exist in common-service-maps, don't clean up control namespace"
     else
         title "Clean up control namespace"
         msg "-----------------------------------------------------------------------"
-        info "Cleanning up control namespace"
         get_control_namespace
         # cleanup namespaceScope in Control namespace
         cleanup_NamespaceScope $CONTROL_NS

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -339,6 +339,12 @@ function cleanup_cs_contorl() {
         # cleanup crossplane    
         cleanup_crossplane
 
+        ${OC} delete --ignore-not-found ns "$CONTROL_NS" --timeout=30s
+        if [ $? -ne 0 ] || [ $FORCE_DELETE -eq 1 ]; then
+            warning "Failed to delete namespace $CONTROL_NS, force deleting remaining resources..."
+            remove_all_finalizers $ns && success "Namespace $CONTROL_NS is deleted successfully."
+        fi
+
         success "Control namespace: ${CONTROL_NS} is cleanup"
     fi
 


### PR DESCRIPTION
1. Allow user to input multiple namespaces
2. update common-service-maps after a tenant is uninstalled
3. when there is no `map-to-common-service-namespace` in the common-service-maps , cleanup control ns