### PR TITLE
Fix NSS Patch waiting condition

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -278,7 +278,7 @@ function wait_for_nss_patch() {
         result=$(eval "${condition}")
 
         # restart namespace scope operator pod to reconcilie
-        if [[ ( ${retries} -eq 0 ) && ( ! -z "${result}" ) ]]; then
+        if [[ ( ${retries} -eq 0 ) && ( -z "${result}" ) ]]; then
             info "Reconciling namespace scope operator"
             echo "deleting pod ${pod_name}"
             $OC delete pod ${pod_name} -n ${namespace}    


### PR DESCRIPTION
Fix the issue that the `retries` goes to negative number
```
[INFO] Waiting for cs-operator CSV to be patched with NSS configmap
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (10 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (9 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (8 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (7 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (6 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (5 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (4 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (3 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (2 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (1 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (0 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (-1 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (-2 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (-3 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (-4 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (-5 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (-6 left)
[INFO] RETRYING: Waiting for cs-operator CSV to be patched with NSS configmap (-7 left)
```