### PR TITLE
Update Github Actions for scripts

### DIFF
--- a/.github/workflows/approve_for_sync_up.yml
+++ b/.github/workflows/approve_for_sync_up.yml
@@ -1,0 +1,36 @@
+name: Sync up branches for scripts
+
+on:
+  pull_request:
+    branches:
+      - scripts-adopter
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  push-for-sync-up:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Push to scripts-adopter branch
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'ok-to-sync') &&
+          !contains(toJson(github.event.pull_request.labels.*.name), 'do-not-merge') &&
+          github.event.pull_request.head.ref == 'scripts-dev' &&
+          github.event.pull_request.base.ref == 'scripts-adopter'
+        run: |
+          git fetch origin
+          git checkout scripts-dev
+          git push origin scripts-dev:scripts-adopter

--- a/.github/workflows/open_pr_for_review.yml
+++ b/.github/workflows/open_pr_for_review.yml
@@ -1,0 +1,37 @@
+name: Open PR for scripts review
+
+on:
+  push:
+    branches:
+      - scripts-dev
+
+jobs:
+  open-pr-for-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Create PR
+        run: |
+          git checkout scripts-dev
+          timestamp=$(date +%Y-%m-%d-%H-%M-%S)
+          message="common service installer automation on $timestamp"
+          base_branch="scripts-adopter"
+          branch_to_merge="scripts-dev"
+          result=$(gh pr list --search "base:scripts-adopter head:scripts-dev is:open")
+          if [ -z "$result" ]; then
+            echo "No PR found, creating a new one"
+            gh pr create -B $base_branch -H $branch_to_merge --title "Review changes from $branch_to_merge to $base_branch" --body "$message"
+          else
+            echo "PR already exists, skipping gh pr create"
+            exit 0
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/shell_linter.yml
+++ b/.github/workflows/shell_linter.yml
@@ -1,0 +1,33 @@
+name: Shell Script Linter
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+jobs:
+  lint:
+    name: Lint Shell Scripts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Install ShellCheck
+        run: sudo apt-get install shellcheck -y
+
+      - name: Check Label
+        id: label
+        run: echo "::set-output name=label::${{ github.event.label.name }}"
+
+      - name: Run ShellCheck
+        if: ${{ steps.label.outputs.label == 'ok-to-test' }}
+        run: shellcheck -e SC1090,SC1091 -f checkstyle **/*.sh | tee shellcheck.xml
+
+      - name: Upload ShellCheck Results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: shellcheck-results
+          path: shellcheck.xml


### PR DESCRIPTION
Create several Github Actions
- Action will open a PR from `scripts-dev` branch to `scripts-adopter` branch when there is no PR already opened and there is a change in `scripts-dev` branch
- Action will make a push from `scripts-dev` branch to `scripts-adopter` branch when the PR from `scripts-dev` branch to `scripts-adopter` branch contains label `ok-to-sync` and does not contain any labels with `do-not-merge`.
  - When the push is made by Action, the PR opened will show merged status, and two branches are totally synced.
- Action will run Lint check for scripts when PR is marked as `ok-to-test`
  - This is the draft, and not functional right now. Will need more investigation on how to use it.