### PR TITLE
Revert OC cmd for setup_singleton.sh

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -427,7 +427,7 @@ function create_namespace() {
     title "Checking whether Namespace $namespace exist..."
     if [[ -z "$(${OC} get namespace ${namespace} --ignore-not-found)" ]]; then
         info "Creating namespace ${namespace}"
-        ${OC_CMD} create namespace ${namespace}
+        ${OC} create namespace ${namespace}
         if [[ $? -ne 0 ]]; then
             error "Error creating namespace ${namespace}"
         fi
@@ -461,7 +461,7 @@ EOF
     info "Creating following OperatorGroup:\n"
     cat ${PREVIEW_DIR}/operatorgroup.yaml
     echo ""
-    cat "${PREVIEW_DIR}/operatorgroup.yaml" | ${OC_CMD} apply -f -
+    cat "${PREVIEW_DIR}/operatorgroup.yaml" | ${OC} apply -f -
     if [[ $? -ne 0 ]]; then
         error "Failed to create OperatorGroup ${name} in ${ns}\n"
     fi
@@ -492,7 +492,7 @@ EOF
     info "Creating following Subscription:\n"
     cat ${PREVIEW_DIR}/${name}-subscription.yaml
     echo ""
-    cat ${PREVIEW_DIR}/${name}-subscription.yaml | ${OC_CMD} apply -f -
+    cat ${PREVIEW_DIR}/${name}-subscription.yaml | ${OC} apply -f -
     if [[ $? -ne 0 ]]; then
         error "Failed to create subscription ${name} in ${ns}\n"
     fi

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -388,7 +388,7 @@ function check_cert_manager(){
     local service_name=$1    
     local namespace=$2
     title " Checking whether Cert Manager exist..." 
-    if [ $PREVIEW_MODE -eq 1 ]; then
+    if [[ $PREVIEW_MODE -eq 1 ]]; then
         info "Preview mode is on, skip checking whether Cert Manager exist\n"
         return 0       
     fi
@@ -404,7 +404,7 @@ function check_cert_manager(){
 
 function check_licensing(){
     title " Checking IBMLicensing..."
-    if [ $PREVIEW_MODE -eq 1 ]; then
+    if [[ $PREVIEW_MODE -eq 1 ]]; then
         info "Preview mode is on, skip checking IBMLicensing\n"
         return 0
     fi
@@ -431,7 +431,7 @@ function create_namespace() {
         if [[ $? -ne 0 ]]; then
             error "Error creating namespace ${namespace}"
         fi
-        if [ $PREVIEW_MODE -eq 0 ]; then
+        if [[ $PREVIEW_MODE -eq 0 ]]; then
             wait_for_project ${namespace}
         fi
     else
@@ -991,7 +991,7 @@ function accept_license() {
     local namespace=$2
     local cr_name=$3
     title "Accepting license for $kind $cr_name in namespace $namespace..."
-    if [ $PREVIEW_MODE -eq 1 ]; then
+    if [[ $PREVIEW_MODE -eq 1 ]]; then
         info "Preview mode is on, skip patching license acceptance\n"
         return 0       
     fi


### PR DESCRIPTION
Fix issue for empty value `OC_CMD`
```
./cp3pt0-deployment/setup_singleton.sh --license-accept --enable-licensing
[✔] oc command available
[✔] oc command logged in as kube:admin
[✔] Channel is valid
# Installing cert-manager

# Checking whether Namespace ibm-cert-manager exist...
[INFO] Creating namespace ibm-cert-manager
/root/ibm-common-service-operator/cp3pt0-deployment/common/utils.sh: line 430: create: command not found
[✘] Error creating namespace ibm-cert-manager
```

Fix issue for empty value `PREVIEW_MODE`
```
# Checking whether Namespace ibm-licensing exist...
[INFO] Creating namespace ibm-licensing
namespace/ibm-licensing created
/root/ibm-common-service-operator/cp3pt0-deployment/common/utils.sh: line 434: [: -eq: unary operator expected
# Checking whether OperatorGroup in ibm-licensing exist...
```