### PR TITLE
update channels for all operators with suffix v4.0 pointing to v4.1 in OperandRegistry

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -50,7 +50,7 @@ spec:
   operators:
   - name: ibm-im-mongodb-operator-v4.0
     namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
+    channel: v4.0
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
@@ -72,7 +72,7 @@ spec:
   operators:
   - name: ibm-im-operator-v4.0
     namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
+    channel: v4.0
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
@@ -95,7 +95,7 @@ spec:
   operators:
   - name: ibm-idp-config-ui-operator-v4.0
     namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
+    channel: v4.0
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
@@ -118,7 +118,7 @@ spec:
   operators:
   - name: ibm-platformui-operator-v4.0
     namespace: "{{ .CPFSNs }}"
-    channel: {{ .Channel }}
+    channel: v4.0
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}


### PR DESCRIPTION
fix for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58416#issuecomment-59591625

test image: quay.io/yuchen_shen/cs_operator:opreg_version

test result:
```
- channel: v4.0
      installPlanApproval: Automatic
      name: ibm-im-mongodb-operator-v4.0
      namespace: simple-cloudpak2
      packageName: ibm-mongodb-operator-app
      sourceName: opencloud-operators
      sourceNamespace: openshift-marketplace
    - channel: v4.0
      installPlanApproval: Automatic
      name: ibm-im-operator-v4.0
      namespace: simple-cloudpak2
      packageName: ibm-iam-operator
      scope: public
      sourceName: opencloud-operators
      sourceNamespace: openshift-marketplace
    - channel: v4.0
      installPlanApproval: Automatic
      name: ibm-idp-config-ui-operator-v4.0
      namespace: simple-cloudpak2
      packageName: ibm-commonui-operator-app
      scope: public
      sourceName: opencloud-operators
      sourceNamespace: openshift-marketplace
    - channel: v4.0
      installPlanApproval: Automatic
      name: ibm-platformui-operator-v4.0
      namespace: simple-cloudpak2
      packageName: ibm-zen-operator
      scope: public
      sourceName: opencloud-operators
      sourceNamespace: openshift-marketplace
 ```
