### PR TITLE
migrate tenant adoption on singleton enhancement

### DIFF
--- a/cp3pt0-deployment/common/delegate_cp2_cert_manager.sh
+++ b/cp3pt0-deployment/common/delegate_cp2_cert_manager.sh
@@ -14,7 +14,7 @@ OC=oc
 YQ=yq
 CONTROL_NS=""
 DEBUG=0
-PREVIEW_MODE=1
+PREVIEW_MODE=0
 SKIP_USER_VERIFY=0
 
 # ---------- Command variables ----------
@@ -79,6 +79,7 @@ function print_usage() {
     echo ""
     echo "Options:"
     echo "   --oc string                    File path to oc CLI. Default uses oc in your PATH"
+    echo "   --yq string                    File path to yq CLI. Default uses yq in your PATH"
     echo "   --control-namespace string     Required. Namespace to de-activate Cloud Pak 2.0 Cert Manager services."
     echo "   -v, --debug integer            Verbosity of logs. Default is 0. Set to 1 for debug logs."
     echo "   --skip-user-vertify string     Skip checking user logged into oc command"

--- a/cp3pt0-deployment/common/migrate_cp2_licensing.sh
+++ b/cp3pt0-deployment/common/migrate_cp2_licensing.sh
@@ -11,10 +11,11 @@
 # ---------- Command arguments ----------
 
 OC=oc
+YQ=yq
 CONTROL_NS=""
 TARGET_NS=ibm-licensing
 DEBUG=0
-PREVIEW_MODE=1
+PREVIEW_MODE=0
 SKIP_USER_VERIFY=0
 
 # ---------- Command variables ----------
@@ -85,6 +86,7 @@ function print_usage() {
     echo ""
     echo "Options:"
     echo "   --oc string                    File path to oc CLI. Default uses oc in your PATH"
+    echo "   --yq string                    File path to yq CLI. Default uses yq in your PATH"
     echo "   --control-namespace string     Required. Source Namespace where Cloud Pak 2.0 Licensing Data is located."
     echo "   --target-namespace string      Target Namespace where Cloud Pak 3.0 Licensing Operator is located. Default is ibm-licensing"
     echo "   -v, --debug integer            Verbosity of logs. Default is 0. Set to 1 for debug logs."
@@ -136,8 +138,8 @@ function migrate_lic_cms() {
         if [ $? -eq 0 ]
         then
             info "Copying Licensing Services ConfigMap $cm from $CONTROL_NS to $TARGET_NS"
-            ${OC} get configmap "${configmap}" -n "${CONTROL_NS}" -o yaml | yq -e '.metadata.namespace = "'${TARGET_NS}'"' > ${configmap}.yaml
-            yq eval 'select(.kind == "ConfigMap") | del(.metadata.resourceVersion) | del(.metadata.uid)' ${configmap}.yaml | ${OC} apply -f -
+            ${OC} get configmap "${configmap}" -n "${CONTROL_NS}" -o yaml | ${YQ} -e '.metadata.namespace = "'${TARGET_NS}'"' > ${configmap}.yaml
+            ${YQ} eval 'select(.kind == "ConfigMap") | del(.metadata.resourceVersion) | del(.metadata.uid)' ${configmap}.yaml | ${OC} apply -f -
 
             if [[ $? -eq 0 ]]; then
                 info "Licensing Services ConfigMap $configmap is copied from $CONTROL_NS to $TARGET_NS"

--- a/cp3pt0-deployment/common/migrate_singleton.sh
+++ b/cp3pt0-deployment/common/migrate_singleton.sh
@@ -20,7 +20,7 @@ LICENSING_NS=""
 NEW_MAPPING=""
 NEW_TENANT=0
 DEBUG=0
-PREVIEW_MODE=1
+PREVIEW_MODE=0
 
 # ---------- Command variables ----------
 

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1116,3 +1116,9 @@ function is_supports_delegation() {
     echo "Version: $version supports cert-manager delegation"
 }
 
+function prepare_preview_mode() {
+    mkdir -p ${PREVIEW_DIR}
+    if [ $PREVIEW_MODE -eq 1 ]; then
+        OC_CMD="oc --dry-run=client" # a redirect to the file is needed too
+    fi
+}

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -517,7 +517,7 @@ function update_cscr() {
             ${OC} get commonservice common-service -n "${namespace}" -o yaml | ${YQ} eval '.spec += {"operatorNamespace": "'${operator_ns}'", "servicesNamespace": "'${service_ns}'"}' > common-service.yaml
             
         fi  
-        yq eval 'select(.kind == "CommonService") | del(.metadata.resourceVersion) | del(.metadata.uid) | .metadata.namespace = "'${namespace}'"' common-service.yaml | ${OC} apply --overwrite=true -f -
+        ${YQ} eval 'select(.kind == "CommonService") | del(.metadata.resourceVersion) | del(.metadata.uid) | .metadata.namespace = "'${namespace}'"' common-service.yaml | ${OC} apply --overwrite=true -f -
         if [[ $? -ne 0 ]]; then
             error "Failed to apply CommonService CR in ${namespace}"
         fi
@@ -682,14 +682,14 @@ function get_control_namespace() {
     local config_map_name="common-service-maps"
 
     # Get the ConfigMap data
-    config_map_data=$(${OC} get configmap "${config_map_name}" -n kube-public -o yaml | yq '.data[]')
+    config_map_data=$(${OC} get configmap "${config_map_name}" -n kube-public -o yaml | ${YQ} '.data[]')
 
     # Check if the ConfigMap exists
     if [[ -z "${config_map_data}" ]]; then
         warning "Not found common-serivce-maps ConfigMap in kube-public namespace. It is a single shared Common Service instance upgrade"
     else
         # Get the controlNamespace value
-        control_namespace=$(echo "${config_map_data}" | yq -r '.controlNamespace')
+        control_namespace=$(echo "${config_map_data}" | ${YQ} -r '.controlNamespace')
 
         # Check if the controlNamespace key exists
         if [[ "${control_namespace}" == "null" ]] || [[ "${control_namespace}" == "" ]]; then
@@ -790,8 +790,8 @@ function update_operator() {
         # Retrieve the latest version of the subscription
         ${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml > sub.yaml
     
-        existing_channel=$(yq eval '.spec.channel' sub.yaml)
-        existing_catalogsource=$(yq eval '.spec.source' sub.yaml)
+        existing_channel=$(${YQ} eval '.spec.channel' sub.yaml)
+        existing_catalogsource=$(${YQ} eval '.spec.source' sub.yaml)
 
         compare_semantic_version $existing_channel $channel
         return_channel_value=$?
@@ -808,10 +808,10 @@ function update_operator() {
         fi
 
         # Update the subscription with the desired changes
-        yq -i eval 'select(.kind == "Subscription") | .spec += {"channel": "'${channel}'"}' sub.yaml
-        yq -i eval 'select(.kind == "Subscription") | .spec += {"source": "'${source}'"}' sub.yaml
-        yq -i eval 'select(.kind == "Subscription") | .spec += {"sourceNamespace": "'${source_ns}'"}' sub.yaml
-        yq -i eval 'select(.kind == "Subscription") | .spec += {"installPlanApproval": "'${install_mode}'"}' sub.yaml
+        ${YQ} -i eval 'select(.kind == "Subscription") | .spec += {"channel": "'${channel}'"}' sub.yaml
+        ${YQ} -i eval 'select(.kind == "Subscription") | .spec += {"source": "'${source}'"}' sub.yaml
+        ${YQ} -i eval 'select(.kind == "Subscription") | .spec += {"sourceNamespace": "'${source_ns}'"}' sub.yaml
+        ${YQ} -i eval 'select(.kind == "Subscription") | .spec += {"installPlanApproval": "'${install_mode}'"}' sub.yaml
 
         # Apply the patch
         ${OC} apply -f sub.yaml
@@ -905,8 +905,8 @@ function scale_down() {
     
     ${OC} get subscription.operators.coreos.com ${cs_sub} -n ${operator_ns} -o yaml > sub.yaml
 
-    existing_channel=$(yq eval '.spec.channel' sub.yaml)
-    existing_catalogsource=$(yq eval '.spec.source' sub.yaml)
+    existing_channel=$(${YQ} eval '.spec.channel' sub.yaml)
+    existing_catalogsource=$(${YQ} eval '.spec.source' sub.yaml)
     compare_semantic_version $existing_channel $channel
     return_channel_value=$?
 

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -38,6 +38,9 @@ BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 # log file
 LOG_FILE="migrate_tenant_log_$(date +'%Y%m%d%H%M%S').log"
 
+# preview mode directory
+PREVIEW_DIR="/tmp/preview"
+
 # counter to keep track of installation steps
 STEP=0
 
@@ -50,7 +53,8 @@ function main() {
     save_log "logs" "migrate_tenant_log" "$DEBUG"
     trap cleanup_log EXIT
     pre_req
-    
+    prepare_preview_mode
+
     # TODO check Cloud Pak compatibility
 
 

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -41,6 +41,9 @@ BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 # log file
 LOG_FILE="setup_singleton_log_$(date +'%Y%m%d%H%M%S').log"
 
+# preview mode directory
+PREVIEW_DIR="/tmp/preview"
+
 # counter to keep track of installation steps
 STEP=0
 
@@ -53,6 +56,7 @@ function main() {
     save_log "logs" "setup_singleton_log" "$DEBUG"
     trap cleanup_log EXIT
     pre_req
+    prepare_preview_mode
 
     is_migrate_licensing
     is_migrate_cert_manager

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -11,6 +11,7 @@
 # ---------- Command arguments ----------
 
 OC=oc
+YQ=yq
 ENABLE_LICENSING=0
 ENABLE_PRIVATE_CATALOG=0
 MIGRATE_SINGLETON=0
@@ -148,6 +149,7 @@ function print_usage() {
     echo ""
     echo "Options:"
     echo "   --oc string                                    File path to oc CLI. Default uses oc in your PATH"
+    echo "   --yq string                                    File path to yq CLI. Default uses yq in your PATH"
     echo "   --operator-namespace string                    Namespace to migrate Cloud Pak 2 Foundational services"
     echo "   --enable-licensing                             Set this flag to install ibm-licensing-operator"
     echo "   --enable-private-catalog                       Set this flag to use namespace scoped CatalogSource. Default is in openshift-marketplace namespace"
@@ -313,6 +315,7 @@ function wait_for_license_instance() {
     local retries=20
     local sleep_time=15
     local total_time_mins=$(( sleep_time * retries / 60))
+    local wait_message="Waiting for ibmlicensing ${name} to be present."
     local success_message="ibmlicensing ${name} present"
     local error_message="Timeout after ${total_time_mins} minutes waiting for ibmlicensing ${name} to be present."
     wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
@@ -325,6 +328,7 @@ function pre_req() {
     fi
 
     check_command "${OC}"
+    check_command "${YQ}"
 
     # Checking oc command logged in
     user=$(oc whoami 2> /dev/null)

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -234,13 +234,6 @@ function pre_req() {
     echo ""
 }
 
-function prepare_preview_mode() {
-    mkdir -p ${PREVIEW_DIR}
-    if [ $PREVIEW_MODE -eq 1 ]; then
-        OC_CMD="oc --dry-run=client" # a redirect to the file is needed too
-    fi
-}
-
 function create_ns_list() {
     for ns in $OPERATOR_NS $SERVICES_NS ${TETHERED_NS//,/ }; do
         create_namespace $ns

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -11,6 +11,7 @@
 # ---------- Command arguments ----------
 
 OC=oc
+YQ=yq
 ENABLE_LICENSING=0
 CHANNEL="v4.1"
 SOURCE="opencloud-operators"
@@ -64,6 +65,10 @@ function parse_arguments() {
         --oc)
             shift
             OC=$1
+            ;;
+        --yq)
+            shift
+            YQ=$1
             ;;
         --enable-licensing)
             ENABLE_LICENSING=1
@@ -136,6 +141,7 @@ function print_usage() {
     echo ""
     echo "Options:"
     echo "   --oc string                    File path to oc CLI. Default uses oc in your PATH"
+    echo "   --yq string                    File path to yq CLI. Default uses yq in your PATH"
     echo "   --enable-licensing             Set this flag to install ibm-licensing-operator"
     echo "   --operator-namespace string    Required. Namespace to install Foundational services operator"
     echo "   --services-namespace           Namespace to install operands of Foundational services, i.e. 'dataplane'. Default is the same as operator-namespace"
@@ -165,6 +171,7 @@ function pre_req() {
     fi
 
     check_command "${OC}"
+    check_command "${YQ}"
 
     # Checking oc command logged in
     user=$($OC whoami 2> /dev/null)

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -11,6 +11,7 @@
 # ---------- Command arguments ----------
 
 OC=oc
+YQ=yq
 TENANT_NAMESPACES=""
 FORCE_DELETE=0
 DEBUG=0
@@ -50,6 +51,10 @@ function parse_arguments() {
             shift
             OC=$1
             ;;
+        --yq)
+            shift
+            YQ=$1
+            ;;
         --operator-namespace)
             shift
             OPERATOR_NS=$1
@@ -83,6 +88,7 @@ function print_usage() {
     echo ""
     echo "Options:"
     echo "   --oc string                    File path to oc CLI. Default uses oc in your PATH"
+    echo "   --yq string                    File path to yq CLI. Default uses yq in your PATH"
     echo "   --operator-namespace string    Required. Namespace to uninstall Foundational services operators and the whole tenant."
     echo "   -f                             Enable force delete. It will take much more time if you add this label, we suggest run this script without -f label first"
     echo "   -v, --debug integer            Verbosity of logs. Default is 0. Set to 1 for debug logs"

--- a/isolate.sh
+++ b/isolate.sh
@@ -307,7 +307,7 @@ function update_tenant() {
 # and namesapces from arguments, to output a unique sorted list of namespaces
 # with excluded namespaces removed
 function gather_csmaps_ns() {
-    local ns_scope=$("${OC}" get cm -n "$MASTER_NS" namespace-scope -o yaml | yq '.data.namespaces')
+    local ns_scope=$("${OC}" get cm -n "$MASTER_NS" namespace-scope -o yaml | "${YQ}" '.data.namespaces')
 
     # excluding namespaces is implemented via duplicate removal with uniq -u,
     # so need to make unique the combined lists of namespaces first to avoid
@@ -555,7 +555,7 @@ function isolate_odlm() {
     fi
     #merge patch overwrites the entire array if you update any values so we need to get any other value specified and make sure it is unchanged
     #loop through all of the values specified in spec.config.env
-    env_range=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | yq '.spec.config.env[].name')
+    env_range=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | "${YQ}" '.spec.config.env[].name')
     patch_string=""
     count=0
     for name in $env_range
@@ -564,7 +564,7 @@ function isolate_odlm() {
         if [[ $name == "ISOLATED_MODE" ]]; then
             env_value="true"
         else
-            env_value=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | yq '.spec.config.env['"${count}"'].value')
+            env_value=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml | "${YQ}" '.spec.config.env['"${count}"'].value')
         fi
         #Add name value pair in json format to the patch string
         if [[ $patch_string == "" ]]; then

--- a/isolate.sh
+++ b/isolate.sh
@@ -42,6 +42,9 @@ BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 #log file
 LOG_FILE="isolate_log_$(date +'%Y%m%d%H%M%S').log"
 
+# preview mode directory
+PREVIEW_DIR="/tmp/preview"
+
 # ---------- Main functions ----------
 
 . ${BASE_DIR}/cp3pt0-deployment/common/utils.sh
@@ -83,6 +86,7 @@ function main() {
 
     save_log "cp3pt0-deployment/logs" "isolate_log" "$DEBUG"
     trap cleanup_log EXIT
+    prepare_preview_mode
 
     which "${OC}" || error "Missing oc CLI"
     which "${YQ}" || error "Missing yq"


### PR DESCRIPTION
- Add YQ variable for binary path
- Turn off Preview Mode by default
- Remove quotation mark for `arguments` when passing it into `${BASE_DIR}/setup_singleton.sh "--operator-namespace" "$OPERATOR_NS" "-c" "$CHANNEL" "--cert-manager-source" "$CERT_MANAGER_SOURCE" "--licensing-source" "$LICENSING_SOURCE" "--license-accept" $arguments`.
   - Otherwise, `"$arguments"` will be phased as a long parameter `--enable-licensing -licensingNs cs-control` as `wildcard` instead of three dedicated and valid parameters.
- Only enable Licensing Migration when it is specified in `migrate_tenant.sh` parameter
- Add wait message for licensing instance to be present
- empty directory `/tmp/preview` for scripts other than `setup_tenant.sh`