### PR TITLE
Remove SecretShare for ibm-cpp-config in isolation

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -648,7 +648,7 @@ function cleanup_webhook() {
     podpreset_exist=$(${OC} get podpresets.operator.ibm.com -n $MASTER_NS --no-headers || echo "false")
     if [[ $podpreset_exist != "false" ]] && [[ $podpreset_exist != "" ]]; then
         info "Deleting podpresets in namespace $MASTER_NS..."
-	    ${OC} get podpresets.operator.ibm.com -n $MASTER_NS --no-headers --ignore-not-found | awk '{print $1}' | xargs ${OC} delete -n $MASTER_NS --ignore-not-found podpresets.operator.ibm.com
+        ${OC} get podpresets.operator.ibm.com -n $MASTER_NS --no-headers --ignore-not-found | awk '{print $1}' | xargs ${OC} delete -n $MASTER_NS --ignore-not-found podpresets.operator.ibm.com
         msg ""
     fi
 


### PR DESCRIPTION
During the isolation for Bedrock v3.x - converting cluster single shared instance into dedicated instance, we will
- move `secretshare` deployment into control namespace as well.
- reset(delete and re-generated by cs operator) `Secretshare` CR, so it does not include the namespaces which has been excluded

Here is an example to reset `ibm-cpp-config` SecretShare CR, excluding namespaces which will be used for Bedrock v4.x.

### Original `ibm-cpp-config` SecretShare CR
```
apiVersion: ibmcpcs.ibm.com/v1
kind: SecretShare
metadata:
  name: ibm-cpp-config
  namespace: ibm-common-services
spec:
  configmapshares:
    - configmapname: ibm-cpp-config
      sharewith:
        - namespace: cp4d-1
        - namespace: cp4d-2
        - namespace: ibm-common-services
```

### Test without excluding namespace
```
> ./isolate.sh --original-cs-ns ibm-common-services --control-ns cs-control

...
[INFO] Deleting secretshares in namespace ibm-common-services...
secretshare.ibmcpcs.ibm.com "ibm-cpp-config" deleted

[INFO] Deleting existing Deployment secretshare in namespace ibm-common-services...
...
```

#### New generated secretshare contains all existing namespaces
```
apiVersion: ibmcpcs.ibm.com/v1
kind: SecretShare
metadata:
  name: ibm-cpp-config
  namespace: ibm-common-services
spec:
  configmapshares:
    - configmapname: ibm-cpp-config
      sharewith:
        - namespace: cp4d-1
        - namespace: cp4d-2
        - namespace: ibm-common-services
```

### Test to exclude one namespace
```
> ./isolate.sh --original-cs-ns ibm-common-services --control-ns cs-control --excluded-ns cp4d-1
```

#### New generated secretshare without `cp4d-1`
```
apiVersion: ibmcpcs.ibm.com/v1
kind: SecretShare
metadata:
  name: ibm-cpp-config
  namespace: ibm-common-services
spec:
  configmapshares:
    - configmapname: ibm-cpp-config
      sharewith:
        - namespace: ibm-common-services
        - namespace: cp4d-2
```

### Test to exclude another namespace
```
> ./isolate.sh --original-cs-ns ibm-common-services --control-ns cs-control --excluded-ns cp4d-2
```

#### New generated secretshare with `ibm-common-service` only
```
apiVersion: ibmcpcs.ibm.com/v1
kind: SecretShare
metadata:
  name: ibm-cpp-config
  namespace: ibm-common-services
spec:
  configmapshares:
    - configmapname: ibm-cpp-config
      sharewith:
        - namespace: ibm-common-services
```