### PR TITLE
support CatalogSource correction in setup_singleton and setup_tenant script

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -501,25 +501,28 @@ function catalogsource_correction() {
     local channel="$5"
     local catalog_source=$source
     local catalog_namespace=$source_ns
+    local return_value=0
 
     result=$(check_catalogsource $source $source_ns $pm $operator_ns $channel)
+    # if the given catalogsource is not available for selected packagemanifest and channel (result is 1), then find the available catalogsource
     if [[ $result == "1" ]]; then
-        warning "CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace"
+        # get the available catalogsource
         result=$(get_catalogsource $pm $operator_ns $channel)
         IFS=" " read -r count catalog catalog_ns <<< "$result"
+        # if the available catalogsource is more than one, then return error
+        # if the available catalogsource is zero, then return error
+        # if the available catalogsource is one, then use the available catalogsource
         if [[ $count -gt 1 ]]; then
-            return 1
+            return_value=1
         elif [[ $count -eq 0 ]]; then
-            return 2
+            return_value=2
         else
             catalog_source="$catalog"
             catalog_namespace="$catalog_ns"
-            success "CatalogSource $catalog_source from $catalog_namespace CatalogSourceNamespace is available for $pm in $operator_ns namespace"
+            return_value=3
         fi
-    else
-        success "CatalogSource $source from $source_ns CatalogSourceNamespace is available for $pm in $operator_ns namespace"
     fi
-    echo "$catalog_source $catalog_namespace"
+    echo "$return_value $catalog_source $catalog_namespace"
 }
 
 function is_sub_exist() {

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -21,6 +21,7 @@ SOURCE="opencloud-operators"
 CERT_MANAGER_SOURCE="ibm-cert-manager-catalog"
 LICENSING_SOURCE="ibm-licensing-catalog"
 SOURCE_NS="openshift-marketplace"
+PRIVATE_NS=""
 INSTALL_MODE="Automatic"
 ENABLE_LICENSING=0
 ENABLE_PRIVATE_CATALOG=0
@@ -73,7 +74,6 @@ function main() {
         fi
     fi
 
-
     if [[ $ENABLE_PRIVATE_CATALOG -eq 1 ]]; then
         arguments+=" --enable-private-catalog"
     fi
@@ -92,9 +92,12 @@ function main() {
     # Update ibm-common-service-operator channel
     for ns in ${NS_LIST//,/ }; do
         if [ $ENABLE_PRIVATE_CATALOG -eq 0 ]; then
+            check_cs_catalogsource
             update_operator ibm-common-service-operator $ns $CHANNEL $SOURCE $SOURCE_NS $INSTALL_MODE
         else
-            update_operator ibm-common-service-operator $ns $CHANNEL $SOURCE $ns $INSTALL_MODE
+            PRIVATE_NS=$ns
+            check_cs_catalogsource
+            update_operator ibm-common-service-operator $PRIVATE_NS $CHANNEL $SOURCE $PRIVATE_NS $INSTALL_MODE
         fi
     done
 

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -312,24 +312,30 @@ function determine_topology() {
         warning "It is all namespaces topology\n"
         return
     fi
+}
     
 function check_cs_catalogsource(){
+    title "Check Foundational services CatalogSource..."
     local pm="ibm-common-service-operator"
     correct_result=$(catalogsource_correction $SOURCE $SOURCE_NS $pm $OPERATOR_NS $CHANNEL)
-    if [[ $? -eq 1 ]]; then
-        echo "$correct_result"
+    IFS=" " read -r return_value correct_source correct_source_ns <<< "$correct_result"
+    
+    # return_value: 0 - correct, 1 - multiple, 2 - none, 3 - wrong and corrected
+    if [[ $return_value -eq 0 ]]; then
+        success "CatalogSource $SOURCE from $SOURCE_NS CatalogSourceNamespace is available for $pm in $OPERATOR_NS namespace"
+    elif [[ $return_value -eq 1 ]]; then
+        warning "CatalogSource $SOURCE from $SOURCE_NS CatalogSourceNamespace is not available for $pm in $OPERATOR_NS namespace"
         error "Multiple CatalogSource are available for $pm in $OPERATOR_NS namespace, please specify the correct CatalogSource name and namespace"
-    elif [[ $? -eq 2 ]]; then
-        echo "$correct_result"
+    elif [[ $return_value -eq 2 ]]; then
+        warning "CatalogSource $SOURCE from $SOURCE_NS CatalogSourceNamespace is not available for $pm in $OPERATOR_NS namespace"
         error "No CatalogSource is available for $pm in $OPERATOR_NS namespace"
+    elif [[ $return_value -eq 3 ]]; then
+        warning "CatalogSource $SOURCE from $SOURCE_NS CatalogSourceNamespace is not available for $pm in $OPERATOR_NS namespace"
+        success "CatalogSource $correct_source from $correct_source_ns CatalogSourceNamespace is available for $pm in $OPERATOR_NS namespace"
     fi
 
-    echo "$correct_result"
-    echo ""
-
-    correct_result=${correct_result//$'\n'/,}
-    SOURCE=$(echo "$correct_result" | awk -F',' '{print $NF}' | awk -F' ' '{print $1}' )
-    SOURCE_NS=$(echo "$correct_result" | awk -F',' '{print $NF}' | awk -F' ' '{print $2}' )
+    SOURCE=$correct_source
+    SOURCE_NS=$correct_source_ns
 }
 
 function create_ns_list() {

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -23,6 +23,7 @@ EXCLUDED_NS=""
 SIZE_PROFILE=""
 INSTALL_MODE="Automatic"
 PREVIEW_MODE=0
+ENABLE_PRIVATE_CATALOG=0
 OC_CMD="oc"
 DEBUG=0
 LICENSE_ACCEPT=0
@@ -312,30 +313,6 @@ function determine_topology() {
         warning "It is all namespaces topology\n"
         return
     fi
-}
-    
-function check_cs_catalogsource(){
-    title "Check Foundational services CatalogSource..."
-    local pm="ibm-common-service-operator"
-    correct_result=$(catalogsource_correction $SOURCE $SOURCE_NS $pm $OPERATOR_NS $CHANNEL)
-    IFS=" " read -r return_value correct_source correct_source_ns <<< "$correct_result"
-    
-    # return_value: 0 - correct, 1 - multiple, 2 - none, 3 - wrong and corrected
-    if [[ $return_value -eq 0 ]]; then
-        success "CatalogSource $SOURCE from $SOURCE_NS CatalogSourceNamespace is available for $pm in $OPERATOR_NS namespace"
-    elif [[ $return_value -eq 1 ]]; then
-        warning "CatalogSource $SOURCE from $SOURCE_NS CatalogSourceNamespace is not available for $pm in $OPERATOR_NS namespace"
-        error "Multiple CatalogSource are available for $pm in $OPERATOR_NS namespace, please specify the correct CatalogSource name and namespace"
-    elif [[ $return_value -eq 2 ]]; then
-        warning "CatalogSource $SOURCE from $SOURCE_NS CatalogSourceNamespace is not available for $pm in $OPERATOR_NS namespace"
-        error "No CatalogSource is available for $pm in $OPERATOR_NS namespace"
-    elif [[ $return_value -eq 3 ]]; then
-        warning "CatalogSource $SOURCE from $SOURCE_NS CatalogSourceNamespace is not available for $pm in $OPERATOR_NS namespace"
-        success "CatalogSource $correct_source from $correct_source_ns CatalogSourceNamespace is available for $pm in $OPERATOR_NS namespace"
-    fi
-
-    SOURCE=$correct_source
-    SOURCE_NS=$correct_source_ns
 }
 
 function create_ns_list() {


### PR DESCRIPTION
For issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58967
### Content
Add some functions provide a set of operations for checking and correcting CatalogSource and their namespaces based on PackageManifest and channel information.

- The `check_singleton_catalogsource`ensures that the CatalogSource and namespaces for `CERT_MANAGER_SOURCE` and `LICENSING_SOURCE` are correct. It iterates over the predefined sources, checks and corrects the CatalogSource, and updates the variables accordingly. 
- The `check_cs_catalogsource` calls the `catalogsource_correction` function to check and correct the CatalogSource and namespace for the `ibm-common-service-operator` PackageManifest in the specified operator namespace.
- The `check_catalogsource` is used to check if a given CatalogSource is available for a selected PackageManifest and channel.
- The `get_catalogsource` retrieves the CatalogSource and CatalogSource namespace for a given PackageManifest and channel. 
- The `catalogsource_correction` checks if the CatalogSource is not found, it displays a warning message. If a single match is found, the function updates the CatalogSource and CatalogSource namespace variables and displays a success message. Finally, it returns the updated CatalogSource and CatalogSource namespace.

