### PR TITLE
new entries of operators and services with suffix -v4.1

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -132,6 +132,7 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		ZenOperatorImage:  util.GetImage("IBM_ZEN_OPERATOR_IMAGE"),
 		IsOCP:             isOCP,
 		WatchNamespaces:   util.GetWatchNamespace(),
+		OnPremMultiEnable: strconv.FormatBool(util.CheckMultiInstances(mgr.GetAPIReader())),
 	}
 
 	bs = &Bootstrap{
@@ -761,7 +762,6 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
 		}
 	} else {
 		// OperandConfig for on-prem deployment
-		b.CSData.OnPremMultiEnable = strconv.FormatBool(b.MultiInstancesEnable)
 		if err := b.renderTemplate(constant.CSV3OperandConfig, b.CSData, forceUpdateODLMCRs); err != nil {
 			return err
 		}

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -18,9 +18,8 @@ package constant
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
-	"html/template"
+	"text/template"
 
 	utilyaml "github.com/ghodss/yaml"
 
@@ -55,6 +54,13 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-im-mongodb-operator-v4.1
+    namespace: "{{ .CPFSNs }}"
+    channel: v4.1
+    packageName: ibm-mongodb-operator-app
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	IMOpReg = `
@@ -73,6 +79,14 @@ spec:
   - name: ibm-im-operator-v4.0
     namespace: "{{ .CPFSNs }}"
     channel: v4.0
+    packageName: ibm-iam-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-im-operator-v4.1
+    namespace: "{{ .CPFSNs }}"
+    channel: v4.1
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
@@ -101,6 +115,14 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-idp-config-ui-operator-v4.1
+    namespace: "{{ .CPFSNs }}"
+    channel: v4.1
+    packageName: ibm-commonui-operator-app
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	PlatformUIOpReg = `
@@ -124,6 +146,14 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+  - name: ibm-platformui-operator-v4.1
+    namespace: "{{ .CPFSNs }}"
+    channel: v4.1
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -141,6 +171,10 @@ metadata:
 spec:
   services:
   - name: ibm-im-mongodb-operator-v4.0
+    spec:
+      mongoDB: {}
+      operandRequest: {}
+  - name: ibm-im-mongodb-operator-v4.1
     spec:
       mongoDB: {}
       operandRequest: {}
@@ -172,6 +206,20 @@ spec:
               - name: ibm-im-mongodb-operator-v4.0
               - name: ibm-idp-config-ui-operator-v4.0
             registry: common-service
+  - name: ibm-im-operator-v4.1
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: {{ .OnPremMultiEnable }}
+      policydecision: {}
+      operandBindInfo: 
+        operand: ibm-im-operator
+      operandRequest:
+        requests:
+          - operands:
+              - name: ibm-im-mongodb-operator-v4.1
+              - name: ibm-idp-config-ui-operator-v4.1
+            registry: common-service
 `
 
 	IdpConfigUIOpCon = `
@@ -191,6 +239,11 @@ spec:
       commonWebUI: {}
       switcheritem: {}
       navconfiguration: {}
+  - name: ibm-idp-config-ui-operator-v4.1
+    spec:
+      commonWebUI: {}
+      switcheritem: {}
+      navconfiguration: {}
 `
 
 	PlatformUIOpCon = `
@@ -206,6 +259,69 @@ metadata:
 spec:
   services:
   - name: ibm-platformui-operator-v4.0
+    spec:
+      operandBindInfo: {}
+    resources:
+      - apiVersion: batch/v1
+        data:
+          spec:
+            activeDeadlineSeconds: 600
+            backoffLimit: 5
+            template:
+              metadata:
+                annotations:
+                  productID: 068a62892a1e4db39641342e592daa25
+                  productMetric: FREE
+                  productName: IBM Cloud Platform Common Services
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                        - matchExpressions:
+                            - key: kubernetes.io/arch
+                              operator: In
+                              values:
+                                - amd64
+                                - ppc64le
+                                - s390x
+                containers:
+                  - command:
+                      - bash
+                      - '-c'
+                      - bash /setup/pre-zen.sh
+                    env:
+                      - name: common_services_namespace
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: {{ .ZenOperatorImage }}
+                    name: pre-zen-job
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 50Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      privileged: false
+                      readOnlyRootFilesystem: false
+                restartPolicy: OnFailure
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccount: operand-deployment-lifecycle-manager
+                serviceAccountName: operand-deployment-lifecycle-manager
+                terminationGracePeriodSeconds: 30
+        force: true
+        kind: Job
+        name: pre-zen-operand-config-job
+        namespace: "{{ .OperatorNs }}"
+  - name: ibm-platformui-operator-v4.1
     spec:
       operandBindInfo: {}
     resources:
@@ -1242,7 +1358,7 @@ func ConcatenateRegistries(baseRegistryTemplate, insertedRegistryTemplate string
 	newOperators = append(newOperators, insertedRegistry.Spec.Operators...)
 
 	baseRegistry.Spec.Operators = newOperators
-	opregBytes, err := json.Marshal(baseRegistry)
+	opregBytes, err := utilyaml.Marshal(baseRegistry)
 	if err != nil {
 		return "", err
 	}
@@ -1278,7 +1394,7 @@ func ConcatenateConfigs(baseConfigTemplate, insertedConfigTemplate string, data 
 	newServices = append(newServices, insertedConfig.Spec.Services...)
 
 	baseConfig.Spec.Services = newServices
-	opconBytes, err := json.Marshal(baseConfig)
+	opconBytes, err := utilyaml.Marshal(baseConfig)
 	if err != nil {
 		return "", err
 	}

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -102,6 +102,25 @@ const ConfigurationRules = `
           limits:
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: LARGEST_VALUE
+      resources:
+        limits:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+        requests:
+          cpu: LARGEST_VALUE
+          memory: LARGEST_VALUE
+      metrics:
+        resources:
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -319,6 +338,52 @@ const ConfigurationRules = `
           requests:
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      config:
+        fipsEnabled: LARGEST_VALUE
+      replicas: LARGEST_VALUE
+      auditService:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      authService:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      clientRegistration:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      identityManager:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      identityProvider:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -429,6 +494,26 @@ const ConfigurationRules = `
               cpu: LARGEST_VALUE
               memory: LARGEST_VALUE
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: LARGEST_VALUE
+      resources:
+        requests:
+          memory: LARGEST_VALUE
+          cpu: LARGEST_VALUE
+        limits:
+          memory: LARGEST_VALUE
+          cpu: LARGEST_VALUE
+      commonWebUIConfig:
+        dashboardData:
+          resources:
+            limits:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+            requests:
+              cpu: LARGEST_VALUE
+              memory: LARGEST_VALUE
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: LARGEST_VALUE

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -101,6 +101,25 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1 
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3Gi
+        requests:
+          cpu: 500m
+          memory: 3Gi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const Large = `
           requests:
             cpu: 570m
             memory: 250Mi
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      replicas: 3
+      auditService:
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      authService:
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1090Mi
+          requests:
+            cpu: 600m
+            memory: 540Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1270Mi
+          requests:
+            cpu: 260m
+            memory: 240Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 920Mi
+          requests:
+            cpu: 570m
+            memory: 250Mi
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Large = `
           memory: 660Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 3
+      resources:
+        requests:
+          memory: 490Mi
+          cpu: 450m
+        limits:
+          memory: 660Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -101,6 +101,25 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3072Mi
+        requests:
+          cpu: 500m
+          memory: 3072Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const Large = `
             cpu: 410m
             memory: 335Mi
       replicas: 3
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      auditService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 400Mi
+          requests:
+            cpu: 75m
+            memory: 50Mi
+      authService:
+        resources:
+          limits:
+            cpu: 3000m
+            memory: 1201Mi
+          requests:
+            cpu: 725m
+            memory: 695Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 300Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 645Mi
+          requests:
+            cpu: 340m
+            memory: 385Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 480Mi
+          requests:
+            cpu: 410m
+            memory: 335Mi
+      replicas: 3
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Large = `
           cpu: 300m
           memory: 384Mi
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 1225Mi
+        requests:
+          cpu: 300m
+          memory: 384Mi
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -101,6 +101,25 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 3000m
+          memory: 3072Mi
+        requests:
+          cpu: 500m
+          memory: 3072Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const Large = `
             cpu: 410m
             memory: 335Mi
       replicas: 3
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      auditService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 75m
+            memory: 50Mi
+      authService:
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 745Mi
+          requests:
+            cpu: 725m
+            memory: 695Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 530Mi
+          requests:
+            cpu: 340m
+            memory: 385Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 480Mi
+          requests:
+            cpu: 410m
+            memory: 335Mi
+      replicas: 3
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Large = `
           cpu: 300m
           memory: 384Mi
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 430Mi
+        requests:
+          cpu: 300m
+          memory: 384Mi
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 3

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -82,6 +82,25 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2Gi
+        requests:
+          cpu: 500m
+          memory: 2Gi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:
@@ -312,6 +331,50 @@ const Medium = `
           requests:
             cpu: 570m
             memory: 250Mi
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      replicas: 2
+      auditService:
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      authService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1090Mi
+          requests:
+            cpu: 600m
+            memory: 540Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1260Mi
+          requests:
+            cpu: 260m
+            memory: 240Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 920Mi
+          requests:
+            cpu: 570m
+            memory: 250Mi
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Medium = `
           memory: 660Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 2
+      resources:
+        requests:
+          memory: 480Mi
+          cpu: 450m
+        limits:
+          memory: 660Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -101,6 +101,25 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2048Mi
+        requests:
+          cpu: 500m
+          memory: 2048Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const Medium = `
             cpu: 320m
             memory: 250Mi
       replicas: 2
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      auditService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 300Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+      authService:
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1193Mi
+          requests:
+            cpu: 230m
+            memory: 695Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 300Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 639Mi
+          requests:
+            cpu: 100m
+            memory: 140Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 438Mi
+          requests:
+            cpu: 320m
+            memory: 250Mi
+      replicas: 2
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Medium = `
           cpu: 300m
           memory: 376Mi
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 2
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 1225Mi
+        requests:
+          cpu: 300m
+          memory: 376Mi
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -101,6 +101,25 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2048Mi
+        requests:
+          cpu: 500m
+          memory: 2048Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const Medium = `
             cpu: 320m
             memory: 250Mi
       replicas: 2
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      auditService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+      authService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 745Mi
+          requests:
+            cpu: 230m
+            memory: 695Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 525Mi
+          requests:
+            cpu: 100m
+            memory: 140Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 355Mi
+          requests:
+            cpu: 320m
+            memory: 250Mi
+      replicas: 2
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Medium = `
           cpu: 300m
           memory: 376Mi
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 2
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 430Mi
+        requests:
+          cpu: 300m
+          memory: 376Mi
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 2

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -101,6 +101,25 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 640Mi
+        requests:
+          cpu: 500m
+          memory: 640Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const Small = `
           requests:
             cpu: 570m
             memory: 250Mi
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      replicas: 1
+      auditService:
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      authService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1090Mi
+          requests:
+            cpu: 600m
+            memory: 650Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 410Mi
+          requests:
+            cpu: 260m
+            memory: 240Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 420Mi
+          requests:
+            cpu: 570m
+            memory: 250Mi
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Small = `
           memory: 440Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 130m
+        limits:
+          memory: 440Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -101,6 +101,25 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const Small = `
           requests:
             cpu: 80m
             memory: 130Mi
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      replicas: 1
+      auditService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 300Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      authService:
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 950Mi
+          requests:
+            cpu: 140m
+            memory: 525Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 300Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+          requests:
+            cpu: 50m
+            memory: 120Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 250Mi
+          requests:
+            cpu: 80m
+            memory: 130Mi
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Small = `
           memory: 800Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 150m
+        limits:
+          memory: 800Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -101,6 +101,25 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 3
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const Small = `
           requests:
             cpu: 80m
             memory: 130Mi
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      replicas: 1
+      auditService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      authService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 650Mi
+          requests:
+            cpu: 140m
+            memory: 525Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 220Mi
+          requests:
+            cpu: 50m
+            memory: 120Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 230Mi
+          requests:
+            cpu: 80m
+            memory: 130Mi
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const Small = `
           memory: 440Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 150m
+        limits:
+          memory: 440Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -101,6 +101,25 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 640Mi
+        requests:
+          cpu: 500m
+          memory: 640Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const StarterSet = `
           requests:
             cpu: 570m
             memory: 250Mi
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      replicas: 1
+      auditService:
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
+      authService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 1090Mi
+          requests:
+            cpu: 600m
+            memory: 650Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 410Mi
+          requests:
+            cpu: 260m
+            memory: 240Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 420Mi
+          requests:
+            cpu: 570m
+            memory: 250Mi
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const StarterSet = `
           memory: 440Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 130m
+        limits:
+          memory: 440Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -101,6 +101,25 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const StarterSet = `
           requests:
             cpu: 80m
             memory: 130Mi
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      replicas: 1
+      auditService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 300Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      authService:
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 950Mi
+          requests:
+            cpu: 140m
+            memory: 525Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 300Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 350Mi
+          requests:
+            cpu: 50m
+            memory: 120Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 250Mi
+          requests:
+            cpu: 80m
+            memory: 130Mi
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const StarterSet = `
           memory: 800Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 150m
+        limits:
+          memory: 800Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 1

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -101,6 +101,25 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      replicas: 1
+      resources:
+        limits:
+          cpu: 1000m
+          memory: 700Mi
+        requests:
+          cpu: 500m
+          memory: 700Mi
+      metrics:
+        resources:
+          requests:
+            cpu: 100m
+            memory: 300Mi
+          limits:
+            cpu: 1000m
+            memory: 350Mi
 - name: ibm-iam-operator
   spec:
     authentication:
@@ -312,6 +331,50 @@ const StarterSet = `
           requests:
             cpu: 80m
             memory: 130Mi
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      replicas: 1
+      auditService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      authService:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 650Mi
+          requests:
+            cpu: 140m
+            memory: 525Mi
+      clientRegistration:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 50Mi
+          requests:
+            cpu: 20m
+            memory: 50Mi
+      identityManager:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 220Mi
+          requests:
+            cpu: 50m
+            memory: 120Mi
+      identityProvider:
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 230Mi
+          requests:
+            cpu: 80m
+            memory: 130Mi
 - name: ibm-management-ingress-operator
   spec:
     managementIngress:
@@ -402,6 +465,17 @@ const StarterSet = `
           memory: 440Mi
           cpu: 1000m
 - name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      replicas: 1
+      resources:
+        requests:
+          memory: 256Mi
+          cpu: 150m
+        limits:
+          memory: 440Mi
+          cpu: 1000m
+- name: ibm-idp-config-ui-operator-v4.1
   spec:
     commonWebUI:
       replicas: 1

--- a/docs/cloudpak-integration.md
+++ b/docs/cloudpak-integration.md
@@ -125,6 +125,9 @@ spec:
   - name: ibm-im-mongodb-operator-v4.0
     spec:
       mongoDB: {}
+  - name: ibm-im-mongodb-operator-v4.1
+    spec:
+      mongoDB: {}
   - name: ibm-cert-manager-operator
     spec:
       certManager: {}
@@ -145,6 +148,9 @@ spec:
   - name: ibm-im-operator-v4.0
     spec:
       authentication: {}
+  - name: ibm-im-operator-v4.1
+    spec:
+      authentication: {}
   - name: ibm-healthcheck-operator
     spec:
       healthService: {}
@@ -154,6 +160,11 @@ spec:
       legacyHeader: {}
       navconfiguration: {}
   - name: ibm-idp-config-ui-operator-v4.0
+    spec:
+      commonWebUI: {}
+      legacyHeader: {}
+      navconfiguration: {}
+  - name: ibm-idp-config-ui-operator-v4.1
     spec:
       commonWebUI: {}
       legacyHeader: {}

--- a/testdata/actual.yaml
+++ b/testdata/actual.yaml
@@ -126,6 +126,38 @@
     }
   },
   {
+    "name": "ibm-idp-config-ui-operator-v4.1",
+    "spec": {
+      "commonWebUI": {
+        "commonWebUIConfig": {
+          "dashboardData": {
+            "resources": {
+              "limits": {
+                "cpu": "3000m",
+                "memory": "600Mi"
+              },
+              "requests": {
+                "cpu": "390m",
+                "memory": "380Mi"
+              }
+            }
+          }
+        },
+        "replicas": 3,
+        "resources": {
+          "limits": {
+            "cpu": "1000m",
+            "memory": "660Mi"
+          },
+          "requests": {
+            "cpu": "450m",
+            "memory": "490Mi"
+          }
+        }
+      }
+    }
+  },
+  {
     "name": "ibm-idp-config-ui-operator",
     "spec": {
       "commonWebUI": {
@@ -442,8 +474,76 @@
       }
     }
   },
-    {
+  {
     "name": "ibm-im-operator-v4.0",
+    "spec": {
+      "authentication": {
+        "auditService": {
+          "resources": {
+            "limits": {
+              "cpu": "1000m",
+              "memory": "50Mi"
+            },
+            "requests": {
+              "cpu": "10m",
+              "memory": "40Mi"
+            }
+          }
+        },
+        "authService": {
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1090Mi"
+            },
+            "requests": {
+              "cpu": "400m",
+              "memory": "540Mi"
+            }
+          }
+        },
+        "clientRegistration": {
+          "resources": {
+            "limits": {
+              "cpu": "1000m",
+              "memory": "50Mi"
+            },
+            "requests": {
+              "cpu": "20m",
+              "memory": "50Mi"
+            }
+          }
+        },
+        "identityManager": {
+          "resources": {
+            "limits": {
+              "cpu": "1000m",
+              "memory": "1270Mi"
+            },
+            "requests": {
+              "cpu": "260m",
+              "memory": "210Mi"
+            }
+          }
+        },
+        "identityProvider": {
+          "resources": {
+            "limits": {
+              "cpu": "1000m",
+              "memory": "920Mi"
+            },
+            "requests": {
+              "cpu": "570m",
+              "memory": "210Mi"
+            }
+          }
+        },
+        "replicas": 3
+      }
+    }
+  },
+  {
+    "name": "ibm-im-operator-v4.1",
     "spec": {
       "authentication": {
         "auditService": {
@@ -628,6 +728,24 @@
   },
   {
     "name": "ibm-im-mongodb-operator-v4.0",
+    "spec": {
+      "mongoDB": {
+        "replicas": 3,
+        "resources": {
+          "limits": {
+            "cpu": "3000m",
+            "memory": "3Gi"
+          },
+          "requests": {
+            "cpu": "500m",
+            "memory": "3Gi"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "ibm-im-mongodb-operator-v4.1",
     "spec": {
       "mongoDB": {
         "replicas": 3,

--- a/testdata/expected.yaml
+++ b/testdata/expected.yaml
@@ -126,6 +126,38 @@
     }
   },
   {
+    "name": "ibm-idp-config-ui-operator-v4.1",
+    "spec": {
+      "commonWebUI": {
+        "commonWebUIConfig": {
+          "dashboardData": {
+            "resources": {
+              "limits": {
+                "cpu": "3000m",
+                "memory": "600Mi"
+              },
+              "requests": {
+                "cpu": "390m",
+                "memory": "380Mi"
+              }
+            }
+          }
+        },
+        "replicas": 3,
+        "resources": {
+          "limits": {
+            "cpu": "1000m",
+            "memory": "660Mi"
+          },
+          "requests": {
+            "cpu": "450m",
+            "memory": "490Mi"
+          }
+        }
+      }
+    }
+  },
+  {
     "name": " ibm-idp-config-ui-operator",
     "spec": {
       "commonWebUI": {
@@ -442,8 +474,76 @@
       }
     }
   },
-    {
+  {
     "name": "ibm-im-operator-v4.0",
+    "spec": {
+      "authentication": {
+        "auditService": {
+          "resources": {
+            "limits": {
+              "cpu": "1000m",
+              "memory": "50Mi"
+            },
+            "requests": {
+              "cpu": "10m",
+              "memory": "40Mi"
+            }
+          }
+        },
+        "authService": {
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1090Mi"
+            },
+            "requests": {
+              "cpu": "400m",
+              "memory": "540Mi"
+            }
+          }
+        },
+        "clientRegistration": {
+          "resources": {
+            "limits": {
+              "cpu": "1000m",
+              "memory": "50Mi"
+            },
+            "requests": {
+              "cpu": "20m",
+              "memory": "50Mi"
+            }
+          }
+        },
+        "identityManager": {
+          "resources": {
+            "limits": {
+              "cpu": "1000m",
+              "memory": "1270Mi"
+            },
+            "requests": {
+              "cpu": "260m",
+              "memory": "210Mi"
+            }
+          }
+        },
+        "identityProvider": {
+          "resources": {
+            "limits": {
+              "cpu": "1000m",
+              "memory": "920Mi"
+            },
+            "requests": {
+              "cpu": "570m",
+              "memory": "210Mi"
+            }
+          }
+        },
+        "replicas": 3
+      }
+    }
+  },
+  {
+    "name": "ibm-im-operator-v4.1",
     "spec": {
       "authentication": {
         "auditService": {
@@ -628,6 +728,24 @@
   },
   {
     "name": "ibm-im-mongodb-operator-v4.0",
+    "spec": {
+      "mongoDB": {
+        "replicas": 3,
+        "resources": {
+          "limits": {
+            "cpu": "3000m",
+            "memory": "3Gi"
+          },
+          "requests": {
+            "cpu": "500m",
+            "memory": "3Gi"
+          }
+        }
+      }
+    }
+  },
+  {
+    "name": "ibm-im-mongodb-operator-v4.1",
     "spec": {
       "mongoDB": {
         "replicas": 3,


### PR DESCRIPTION
for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57539
Add new entries of operators and services (im, im-mongodb, idp-config-ui and platformui ) with suffix `-v4.1` and channel `v4.1` into OperandRegistry and OperandConfig.

test image: quay.io/yuchen_shen/cs_operator:split_opcon