### PR TITLE
removed all wildcard permissions

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,15 +22,15 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-04-26T17:00:51Z"
+    createdAt: "2023-07-13T21:50:01Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     olm.skipRange: ">=3.3.0 <4.1.0"
     operatorChannel: v4.1
     operatorVersion: 4.1.0
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/IBM/ibm-common-service-operator
     support: IBM
   labels:
@@ -320,9 +320,34 @@ spec:
       permissions:
         - rules:
             - apiGroups:
-                - '*'
+                - cert-manager.io
               resources:
-                - '*'
+                - certificates
+                - issuers
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - statefulsets
+                - daemonsets
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.ibm.com
+              resources:
+                - commonservices
+                - commonservices/finalizers
+                - commonservices/status
+                - operandconfigs
+                - operandregistries
               verbs:
                 - create
                 - delete
@@ -331,6 +356,85 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - subscriptions
+                - clusterserviceversions
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - certmanager.k8s.io
+              resources:
+                - certificates
+                - issuers
+              verbs:
+                - delete
+            - apiGroups:
+                - monitoring.operator.ibm.com
+              resources:
+                - exporters
+                - prometheusexts
+              verbs:
+                - delete
+            - apiGroups:
+                - operator.ibm.com
+              resources:
+                - operandrequests
+                - operandbindinfos
+                - cataloguis
+                - helmapis
+                - helmrepos
+              verbs:
+                - delete
+            - apiGroups:
+                - elasticstack.ibm.com
+              resources:
+                - elasticstacks
+              verbs:
+                - delete
           serviceAccountName: ibm-common-service-operator
     strategy: deployment
   installModes:

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-07-13T21:50:01Z"
+    createdAt: "2023-07-14T01:05:02Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     olm.skipRange: ">=3.3.0 <4.1.0"
@@ -325,6 +325,7 @@ spec:
                 - certificates
                 - issuers
               verbs:
+                - create
                 - get
                 - list
                 - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -63,6 +63,7 @@ rules:
   - certificates
   - issuers
   verbs:
+  - create
   - get
   - list
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,9 +58,34 @@ metadata:
   name: ibm-common-service-operator
 rules:
 - apiGroups:
-  - '*'
+  - cert-manager.io
   resources:
-  - '*'
+  - certificates
+  - issuers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  resources:
+  - commonservices
+  - commonservices/finalizers
+  - commonservices/status
+  - operandconfigs
+  - operandregistries
   verbs:
   - create
   - delete
@@ -69,3 +94,85 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  - clusterserviceversions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+
+
+# handle clean up of deprecated objects
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - certificates
+  - issuers
+  verbs:
+  - delete
+- apiGroups:
+  - monitoring.operator.ibm.com
+  resources:
+  - exporters
+  - prometheusexts
+  verbs:
+  - delete
+- apiGroups:
+  - operator.ibm.com
+  resources:
+  - operandrequests
+  - operandbindinfos
+  - cataloguis
+  - helmapis
+  - helmrepos
+  verbs:
+  - delete
+- apiGroups:
+  - elasticstack.ibm.com
+  resources:
+  - elasticstacks
+  verbs:
+  - delete


### PR DESCRIPTION
How to test:

1. `export QUAY_REGISTRY=quay.io/<your username>`
2. `export REGISTRY=quay.io/<your username>`
3. edit manager.yaml with image `quay.io/<your username>/common-service-operator-amd64:dev`
4. `make bundle-manifests && make build-bundle-image && make run-bundle`
5. Verify cs-operator pod starts up, no errors in logs about forbidden permissions, and `ibm-odlm` sub is created (CSV not created because of temporary catalogsource)