### PR TITLE
don't copy oidc credential

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -53,7 +53,6 @@ function main() {
     # copy im credentials
     copy_resource "secret" "platform-auth-idp-credentials"
     copy_resource "secret" "platform-auth-ldaps-ca-cert"
-    copy_resource "secret" "platform-oidc-credentials"
     copy_resource "configmap" "ibm-cpp-config"
     copy_resource "configmap" "common-web-ui-config"
     copy_resource "configmap" "platform-auth-idp"


### PR DESCRIPTION
A couple issues involving data migration with the secret copied over. This is the leading option to resolve them but there is still some discussion so will mark with a hold for now