### PR TITLE
Add NSS restart label when patching the deployment

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -384,6 +384,8 @@ function patch_watch_namespace() {
         ${YQ} -i eval '(.spec.template.spec.containers[0].env[] | select(.name == "WATCH_NAMESPACE")).valueFrom.configMapKeyRef.name = "namespace-scope"' /tmp/deployment.yaml
         ${YQ} -i eval '(.spec.template.spec.containers[0].env[] | select(.name == "WATCH_NAMESPACE")).valueFrom.configMapKeyRef.key = "namespaces"' /tmp/deployment.yaml
         ${YQ} -i eval '(.spec.template.spec.containers[0].env[] | select(.name == "WATCH_NAMESPACE")).valueFrom.configMapKeyRef.optional = true' /tmp/deployment.yaml
+        # Add new labels intent: projected in deployment template to trigger pod restart by NamespaceScope Operator
+        ${YQ} -i eval '.spec.template.metadata.labels.intent = "projected"' /tmp/deployment.yaml
 
         # Apply the patch for deployment
         ${OC} apply -f /tmp/deployment.yaml


### PR DESCRIPTION
This label should be patched together with `WATCH_NAMESPACE` ENV variable in common service operator deployment

<img width="834" alt="Screenshot 2023-07-18 at 2 01 07 AM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/2ac6a83c-0579-4145-9a90-1aa64b152d47">
