### PR TITLE
Wait for CSV shown up in subscription status

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -232,14 +232,14 @@ function wait_for_operator() {
 
 function wait_for_csv() {
     local namespace=$1
-    local operator_name=$2
-    local condition="${OC} -n ${namespace} get csv --no-headers --ignore-not-found | grep ^${operator_name}"
+    local package_name=$2
+    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${package_name}.${namespace}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep ^${package_name}"
     local retries=30
     local sleep_time=10
     local total_time_mins=$(( sleep_time * retries / 60))
-    local wait_message="Waiting for operator ${operator_name} CSV in namespace ${namespace} to be generated"
-    local success_message="Operator ${operator_name} CSV in namespace ${namespace} is generated"
-    local error_message="Timeout after ${total_time_mins} minutes waiting for ${operator_name} CSV in namespace ${namespace} to be generated"
+    local wait_message="Waiting for operator ${package_name} CSV in namespace ${namespace} to be generated"
+    local success_message="Operator ${package_name} CSV in namespace ${namespace} is generated"
+    local error_message="Timeout after ${total_time_mins} minutes waiting for ${package_name} CSV in namespace ${namespace} to be generated"
  
     wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
 }
@@ -297,8 +297,8 @@ function wait_for_nss_patch() {
         if [[ ( ${retries} -eq 0 ) && ( -z "${result}" ) ]]; then
             warning "Deleting pod ${pod_name} in namespace ${namespace} to trigger NamespaceScope reconciliaiton"
             $OC delete pod ${pod_name} -n ${namespace}
-            # reset retries to 6 times to wait one minute
-            retries=6
+            # reset retries to 30 times to wait 5 minutes
+            retries=30
             wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
             break
         fi


### PR DESCRIPTION
### Issue
Currently, we are only checking if CSV exists in the namespace or not by doing following command, it does guarantee that a CSV is generated in the namespace. But it does not guarantee that this CSV is recorded in subscription status.
```
condition="${OC} -n ${namespace} get csv --no-headers --ignore-not-found | grep ^${operator_name}"
```

If the CSV is not recorded in subscription status, it will impact next function on `wait_for_nss_patch`.
This function gets CSV name from subscription status
```
sub_name=$(${OC} get subscription.operators.coreos.com -n ${namespace} -l operators.coreos.com/${package_name}.${namespace}='' --no-headers | awk '{print $1}')
csv_name=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${namespace} --ignore-not-found -o jsonpath={.status.installedCSV})
```

As a result, the variable `csv_name` will be empty forever, and following condition will never get fulfilled.
```
condition="${OC} -n ${namespace} get csv ${csv_name} -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[?(@.name==\"WATCH_NAMESPACE\")].valueFrom.configMapKeyRef.name}'| grep 'namespace-scope'"
```

Finally we will see the script abort with error
```
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (4 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (3 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (2 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (1 left)
[✗] Deleting pod ibm-namespace-scope-operator-8c6547457-25fzk in namespace cs-operators to trigger NamespaceScope reconciliaiton
pod "ibm-namespace-scope-operator-8c6547457-25fzk" deleted
[INFO] Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (6 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (5 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (4 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (3 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (2 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (1 left)
[✘] Timeout after 5 minutes waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap
```

### Reproduce the issue
1. Install CS operator in advanced topology by using `setup_tenant.sh`, the first time should be successful.
```
> ./cp3pt0-deployment/setup_tenant.sh --license-accept -c v4.1 --operator-namespace cs-operators --services-namespace cs-data
```

2. Create error path by deleting cs operator subscription only from command line, and leave CSV in the cluster.
```
> oc delete subscription ibm-common-service-operator -n cs-operators
subscription.operators.coreos.com "ibm-common-service-operator" deleted
```

3. Re-run the script to generate new subscription. It will hit OLM issue that CSV and subscription does not bind with each other. But the `wait_for_csv` will immediately pass, and be stuck in `wait_for_nss_patch` forever.
```
> ./cp3pt0-deployment/setup_tenant.sh --license-accept -c v4.1 --operator-namespace cs-operators --services-namespace cs-data

subscription.operators.coreos.com/ibm-common-service-operator created
[INFO] Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated
[✔] Operator ibm-common-service-operator CSV in namespace cs-operators is generated

[INFO] Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (30 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (29 left)
```
<img width="1814" alt="Screenshot 2023-07-20 at 4 56 50 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/2988b598-ccc2-452f-b8f8-3c4ba9c6ee77">


### Solution
Update `wait_for_csv` to get the CSV from subscription `.status.installedCSV`

### Test
#### Happy path that CSV is shown up in subscription `.status.InstalledCSV` after few second, and `wait_for_nss_patch` is working properly.
```
> ./cp3pt0-deployment/setup_tenant.sh --license-accept -c v4.1 --operator-namespace cs-operators --services-namespace cs-data

...
subscription.operators.coreos.com/ibm-common-service-operator created
[INFO] Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated
[✔] Operator ibm-common-service-operator CSV in namespace cs-operators is generated

[INFO] Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (30 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (29 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (28 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (27 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (26 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (25 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (24 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (23 left)
[✔] operator ibm-common-service-operator CSV is patched with NamespaceScope ConfigMap
...
```

#### Error path that CSV is never shown up in subscription `.status.InstalledCSV`.
We could hit this issue by deleting cs operator subscription only from command line, and leave CSV in the cluster. Re-run the script to generate new subscription. It will hit OLM issue that CSV and subscription does not bind with each other.
```
> oc delete subscription ibm-common-service-operator -n cs-operators
subscription.operators.coreos.com "ibm-common-service-operator" deleted

> ./cp3pt0-deployment/setup_tenant.sh --license-accept -c v4.1 --operator-namespace cs-operators --services-namespace cs-data
...
subscription.operators.coreos.com/ibm-common-service-operator created
[INFO] Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (30 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (29 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (28 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (27 left)
...
```

To fix this issue, we could manually delete CSV, and OLM will automatically re-generate it. After CSV is re-generated, it will   bind with subscription again, and script will continue the installation
```
> oc get csv -n cs-operators
NAME                                          DISPLAY                                VERSION   REPLACES   PHASE
ibm-cert-manager-operator.v4.1.0              IBM Cert Manager                       4.1.0                Succeeded
ibm-common-service-operator.v4.1.0            IBM Cloud Pak foundational services    4.1.0                Succeeded
ibm-namespace-scope-operator.v4.1.0           IBM NamespaceScope Operator            4.1.0                Succeeded
operand-deployment-lifecycle-manager.v4.1.0   Operand Deployment Lifecycle Manager   4.1.0                Succeeded

> oc delete csv ibm-common-service-operator.v4.1.0 -n cs-operators
clusterserviceversion.operators.coreos.com "ibm-common-service-operator.v4.1.0" deleted


# script keeps running
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (27 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (26 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (25 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (24 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (23 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (22 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV in namespace cs-operators to be generated (21 left)
[✔] Operator ibm-common-service-operator CSV in namespace cs-operators is generated

[INFO] Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (30 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator CSV to be patched with NamespaceScope ConfigMap (29 left)
[✔] operator ibm-common-service-operator CSV is patched with NamespaceScope ConfigMap
```