### PR TITLE
add cert manager smoke test to setup singleton and preload data

### DIFF
--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -441,27 +441,27 @@ function verify_cert_manager(){
     error "More than one cert-manager-webhook deployment exists on the cluster."
   fi
 
-  debug1 "Creating test issuer in namespace $OPERATOR_NS."
+  debug1 "Creating test issuer in namespace $CERT_MANAGER_NAMESPACE ."
   cat << EOF | ${OC} apply -f -
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: test-issuer
-  namespace: $OPERATOR_NS
+  namespace: $CERT_MANAGER_NAMESPACE 
 spec:
   selfSigned: {}
 EOF
-  return_value_issuer=$(${OC} get issuer -n $OPERATOR_NS --ignore-not-found | grep test-issuer || echo "false")
+  return_value_issuer=$(${OC} get issuer.v1.cert-manager.io -n $CERT_MANAGER_NAMESPACE --ignore-not-found | grep test-issuer || echo "false")
   if [[ $return_value_issuer == "false" ]]; then
     error "Failed to create test issuer."
   else
-    debug1 "Creating test certificate in namespace $OPERATOR_NS."
+    debug1 "Creating test certificate in namespace $CERT_MANAGER_NAMESPACE ."
     cat << EOF | ${OC} apply -f -
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: test-certificate
-  namespace: $OPERATOR_NS
+  namespace: $CERT_MANAGER_NAMESPACE 
 spec:
   commonName: test-certificate
   duration: 17520h0m0s
@@ -471,13 +471,13 @@ spec:
   renewBefore: 720h0m0s
   secretName: test-certificate-secret
 EOF
-    return_value_cert=$(${OC} get certificate -n $OPERATOR_NS --ignore-not-found | grep test-certificate || echo "false")
+    return_value_cert=$(${OC} get certificate.v1.cert-manager.io -n $CERT_MANAGER_NAMESPACE  --ignore-not-found | grep test-certificate || echo "false")
     if [[ $return_value_cert == "false" ]]; then
-      ${OC} delete issuer test-issuer -n $OPERATOR_NS --ignore-not-found
+      ${OC} delete issuer.v1.cert-manager.io test-issuer -n $CERT_MANAGER_NAMESPACE  --ignore-not-found
       error "Failed to create test certificate."
     else
-      ${OC} delete certificate test-certificate -n $OPERATOR_NS --ignore-not-found
-      ${OC} delete issuer test-issuer -n $OPERATOR_NS --ignore-not-found
+      ${OC} delete certificate.v1.cert-manager.io test-certificate -n $CERT_MANAGER_NAMESPACE  --ignore-not-found
+      ${OC} delete issuer.v1.cert-manager.io test-issuer -n $CERT_MANAGER_NAMESPACE  --ignore-not-found
     fi
   fi  
   success "Cert manager is ready."

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -74,6 +74,7 @@ function main() {
 
     install_cert_manager
     install_licensing
+    verify_cert_manager
 }
 
 function parse_arguments() {
@@ -419,6 +420,67 @@ function pre_req() {
 # TODO validate argument
 function get_and_validate_arguments() {
     get_control_namespace
+}
+
+function verify_cert_manager(){
+  info "Checking cert manager readiness."
+  #check webhook pod runnning
+  local name="cert-manager-webhook"
+  local retries=20
+  local sleep_time=15
+  local total_time_mins=$(( sleep_time * retries / 60))
+  local condition="${OC} get pod -A --no-headers --ignore-not-found | egrep '1/1' | grep ${name} || true"
+  local wait_message="Waiting for pod ${name} to be running ..."
+  local success_message="Pod ${name} is running."
+  local error_message="Timeout after ${total_time_mins} minutes waiting for pod ${name} to be running."
+  wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
+
+  #check no duplicate webhook pod
+  webhook_deployments=$(${OC} get deploy -A --no-headers --ignore-not-found | grep ${name} -c)
+  if [[ $webhook_deployments != "1" ]]; then
+    error "More than one cert-manager-webhook deployment exists on the cluster."
+  fi
+
+  debug1 "Creating test issuer in namespace $OPERATOR_NS."
+  cat << EOF | ${OC} apply -f -
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: test-issuer
+  namespace: $OPERATOR_NS
+spec:
+  selfSigned: {}
+EOF
+  return_value_issuer=$(${OC} get issuer -n $OPERATOR_NS --ignore-not-found | grep test-issuer || echo "false")
+  if [[ $return_value_issuer == "false" ]]; then
+    error "Failed to create test issuer."
+  else
+    debug1 "Creating test certificate in namespace $OPERATOR_NS."
+    cat << EOF | ${OC} apply -f -
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-certificate
+  namespace: $OPERATOR_NS
+spec:
+  commonName: test-certificate
+  duration: 17520h0m0s
+  issuerRef:
+    kind: Issuer
+    name: test-issuer
+  renewBefore: 720h0m0s
+  secretName: test-certificate-secret
+EOF
+    return_value_cert=$(${OC} get certificate -n $OPERATOR_NS --ignore-not-found | grep test-certificate || echo "false")
+    if [[ $return_value_cert == "false" ]]; then
+      ${OC} delete issuer test-issuer -n $OPERATOR_NS --ignore-not-found
+      error "Failed to create test certificate."
+    else
+      ${OC} delete certificate test-certificate -n $OPERATOR_NS --ignore-not-found
+      ${OC} delete issuer test-issuer -n $OPERATOR_NS --ignore-not-found
+    fi
+  fi  
+  success "Cert manager is ready."
 }
 
 main "$@"

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -1904,13 +1904,13 @@ spec:
   renewBefore: 720h0m0s
   secretName: test-certificate-secret
 EOF
-    return_value_cert=$(${OC} get certificate -n $FROM_NAMESPACE --ignore-not-found | grep test-certificate || echo "false")
+    return_value_cert=$(${OC} get certificate.v1.cert-manager.io -n $FROM_NAMESPACE --ignore-not-found | grep test-certificate || echo "false")
     if [[ $return_value_cert == "false" ]]; then
-      ${OC} delete issuer test-issuer -n $OPERATOR_NS --ignore-not-found
+      ${OC} delete issuer.v1.cert-manager.io test-issuer -n $FROM_NAMESPACE --ignore-not-found
       error "Failed to create test certificate. Verify cert manager is installed and ready on the cluster then re-run the preload script."
     else
-      ${OC} delete certificate test-certificate -n $FROM_NAMESPACE --ignore-not-found
-      ${OC} delete issuer test-issuer -n $FROM_NAMESPACE --ignore-not-found
+      ${OC} delete certificate.v1.cert-manager.io test-certificate -n $FROM_NAMESPACE --ignore-not-found
+      ${OC} delete issuer.v1.cert-manager.io test-issuer -n $FROM_NAMESPACE --ignore-not-found
     fi
   fi  
   success "Cert manager is ready, preload can proceed."


### PR DESCRIPTION
For issue 59713, added a wait for cert manager operand webhook to come ready to setup singleton and then a smoke test where it tries to create a test issuer and certificate. This was added to the end of the script. Added just the smoke test to preload data's prereqs section so the script will error out if these items cannot be created

Testing setup singleton:
- run setup singleton to fresh install cert manager
- verify script completes and the success message "Cert manager is ready." appears at the end of the script

testing preload:
- before installing cert manager, run the script
- verify the script errors out during prereqs with the message: "Failed to create test issuer. Verify cert manager is installed and ready on the cluster then re-run the preload script."
- Install cert manager
- wait for it to come ready
- run preload again, verify the preload checks complete
- Note: you do not need to have any cs installed for the preload script to complete prereq checks. It will error out after the part we are looking at (which is expected).