### PR TITLE
Configure IM MongoDB storageClass via CS CR

### DIFF
--- a/controllers/constant/storageclass.go
+++ b/controllers/constant/storageclass.go
@@ -17,7 +17,19 @@
 package constant
 
 const StorageClassTemplate = `
-- name: ibm-mongodb-operator
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      storageClass: placeholder
+- name: ibm-im-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      storageClass: placeholder
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      storageClass: placeholder
+- name: ibm-im-mongodb-operator-v4.2
   spec:
     mongoDB:
       storageClass: placeholder

--- a/controllers/constant/storageclass.go
+++ b/controllers/constant/storageclass.go
@@ -38,8 +38,4 @@ const StorageClassTemplate = `
     mustgatherService:
       persistentVolumeClaim:
         storageClassName: placeholder
-- name: ibm-monitoring-prometheusext-operator
-  spec:
-    prometheusExt:
-      storageClassName: placeholder
 `


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59744
When we [specify `.spec.storageClass: <storage-class>` in CommonService CR](https://ibm.com/docs/en/cloud-paks/foundational-services/4.0?topic=options-configuring-foundational-services#storage-class), this configuration should be propagated to `common-service` OperandConfig


### Preparation for Testing
1. Install Common Service operator and ODLM in one namespace, DO NOT deploy OperandRequest

### Reproduce issue
1. Update CommonService CR to specify the storageClass
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
  namespace: cloudpak-simple
spec:
  license:
    accept: true
  operatorNamespace: cloudpak-simple
  servicesNamespace: cloudpak-simple
  size: starterset
  storageClass: rook-cephfs
```
2. Wait for CommonService in `Succeeded` phase
3. Check `ibm-im-mongodb-operator` entry in OperandConfig `common-service`, there is no `storageClass` field specified.

### Apply image with fix
1. Update the Common Service Operator CSV with image `quay.io/daniel_fan/common-service-operator-amd64:dev`
2. Update the Common Service Operator CSV to `imagePullPolicy: Always`
3. Wait for new common service operator finishing the reconciliation, and wait for CommonService in `Succeeded` phase
4. Check `ibm-im-mongodb-operator` entry in OperandConfig `common-service`, there is a `storageClass` field specified.
```
    - name: ibm-im-mongodb-operator
      spec:
        mongoDB:
          metrics:
            ...
          replicas: 1
          resources:
            ...
          storageClass: rook-cephfs
        operandRequest: {}
    - name: ibm-im-mongodb-operator-v4.0
      spec:
        mongoDB:
          metrics:
            resources:
              ...
          replicas: 1
          resources:
            ...
          storageClass: rook-cephfs
        operandRequest: {}
    - name: ibm-im-mongodb-operator-v4.1
      spec:
        mongoDB:
          metrics:
            ...
          replicas: 1
          resources:
            ...
          storageClass: rook-cephfs
        operandRequest: {}
```
