### PR TITLE
Update operand requests' registryNamespace value to reflect new cs instance namespace

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -838,9 +838,9 @@ function update_opreqs(){
                 ${YQ} -i 'del(.metadata.uid)' tmp.yaml
                 ${YQ} -i 'del(.metadata.generation)' tmp.yaml
                 ${YQ} -i 'del(.metadata.managedFields)' tmp.yaml
-                ${YQ} -i '.spec.requests[0].registryNamespace = "'${csns}'"' tmp.yaml    
+                ${YQ} -i '.spec.requests[0].registryNamespace = "ibm-common-services"' tmp.yaml    
                 ${OC} apply -n $ns -f tmp.yaml || error "Failed to update registryNamespace value for operand request $opreq in namespace $ns."
-                info "Operand request $opreq in namespace $ns updated to use $csns as registryNamespace."
+                info "Operand request $opreq in namespace $ns updated to use ibm-common-services as registryNamespace."
                 rm -f tmp.yaml
             done
         done

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -38,6 +38,7 @@ function main() {
     check_cm_ns_exist
     prepare_cluster
     isolate_odlm "ibm-odlm" $master_ns
+    update_opreqs
     scale_up_pod
     restart_CS_pods
     install_new_CS
@@ -815,6 +816,35 @@ function cleanup_webhook() {
     info "Deleting ValidatingWebhookConfiguration..."
     ${OC} delete ValidatingWebhookConfiguration ibm-cs-ns-mapping-webhook-configuration --ignore-not-found
 
+}
+
+function update_opreqs(){
+    title "Updating Operand Requests to use Operand Registry in new CS namespace"
+    #check map to namespaces, get list of requested from ns from there
+    #update opreq in map to first
+    #update opreq in list of namespace from first line
+    for csns in $map_to_cs_ns
+    do
+        local namespaces=$(${OC} get cm common-service-maps -o yaml -n kube-public | $YQ '.data[]' | $YQ '.namespaceMapping[] | select(.map-to-common-service-namespace == "'$csns'").requested-from-namespace' | awk '{print $2}' | tr '\n' ' ')
+        namespaces="$namespaces $csns"
+        for ns in $namespaces
+        do
+            opreqs=$(${OC} get operandrequests -n $ns --no-headers | awk '{print $1}' | tr '\n' ' ')
+            for opreq in $opreqs
+            do
+                ${OC} get opreq $opreq -n $ns -o yaml > tmp.yaml
+                ${YQ} -i 'del(.metadata.creationTimestamp)' tmp.yaml
+                ${YQ} -i 'del(.metadata.resourceVersion)' tmp.yaml
+                ${YQ} -i 'del(.metadata.uid)' tmp.yaml
+                ${YQ} -i 'del(.metadata.generation)' tmp.yaml
+                ${YQ} -i 'del(.metadata.managedFields)' tmp.yaml
+                ${YQ} -i '.spec.requests[0].registryNamespace = "'${csns}'"' tmp.yaml    
+                ${OC} apply -n $ns -f tmp.yaml || error "Failed to update registryNamespace value for operand request $opreq in namespace $ns."
+                info "Operand request $opreq in namespace $ns updated to use $csns as registryNamespace."
+            done
+        done
+    done
+    success "Operand requests' registryNamespace values updated."
 }
 
 function msg() {

--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -841,6 +841,7 @@ function update_opreqs(){
                 ${YQ} -i '.spec.requests[0].registryNamespace = "'${csns}'"' tmp.yaml    
                 ${OC} apply -n $ns -f tmp.yaml || error "Failed to update registryNamespace value for operand request $opreq in namespace $ns."
                 info "Operand request $opreq in namespace $ns updated to use $csns as registryNamespace."
+                rm -f tmp.yaml
             done
         done
     done


### PR DESCRIPTION
Ran into an opportunity for enhancement while testing conversion script where an operand request was not updated to point to the new cs instance namespace for registryNamespace. This prevented ODLM in the new instance from reconciling the operandrequest as it tried to access the operandregistry in a namespace it did not have access to. Manually changing the registryNamespace value resolved the issue but I think this can be included in the conversion script. I have tested this on two different environments now (both amd64) successfully following this methodology:
- setup shared instance cluster with multiple cloudpak namespaces with operand requests
- convert cluster using this version of conversion script
- verify that operandrequests are updated correctly during script runtime
- verify script completes
- verify each operandrequest is reconciled and services deployed