### PR TITLE
[4.2] detection of OCP cluster type

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-07-14T01:05:02Z"
+    createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     olm.skipRange: ">=3.3.0 <4.1.0"
@@ -217,6 +217,12 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - config.openshift.io
+              resources:
+                - infrastructures
+              verbs:
+                - get
           serviceAccountName: ibm-common-service-operator
       deployments:
         - label:

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -11,9 +11,9 @@ metadata:
     olm.skipRange: ""
     operatorChannel: v4.1
     operatorVersion: 4.1.0
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/IBM/ibm-common-service-operator
     support: IBM
   labels:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -51,6 +51,12 @@ rules:
   - patch
   - update
   - watch
+- verbs:
+  - get
+  apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
for issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/57188

- Determine whether the cluster is OCP by verifying the existence of an Infrastructure Custom Resource  named `cluster`.
- Give the cluster permission to API `config.openshift.io`
- Test image: quay.io/yuchen_shen/cs_operator:cluster_type
