### PR TITLE
Add label and comment for sync PR

### DIFF
--- a/.github/workflows/open_pr_for_review.yml
+++ b/.github/workflows/open_pr_for_review.yml
@@ -19,6 +19,7 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Create PR
+        id: create_pr
         run: |
           git checkout scripts-dev
           timestamp=$(date +%Y-%m-%d-%H-%M-%S)
@@ -28,10 +29,30 @@ jobs:
           result=$(gh pr list --search "base:scripts-adopter head:scripts-dev is:open")
           if [ -z "$result" ]; then
             echo "No PR found, creating a new one"
-            gh pr create -B $base_branch -H $branch_to_merge --title "Review changes from $branch_to_merge to $base_branch" --body "$message"
+            pr_url=$(gh pr create -B $base_branch -H $branch_to_merge --title "Review changes from $branch_to_merge to $base_branch" --body "$message")
+            pr_number=$(echo "$pr_url" | awk -F'/' '{print $NF}')
+            echo "new_created=1" >> $GITHUB_OUTPUT
           else
             echo "PR already exists, skipping gh pr create"
-            exit 0
+            pr_number=$(echo "$result" | awk -F' ' '{print $1}')
+            echo "new_created=0" >> $GITHUB_OUTPUT
           fi
+          echo "pr_number=$pr_number" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Add label to the PR
+        if: steps.create_pr.outputs.pr_number != '' && steps.create_pr.outputs.new_created == '1'
+        run: |
+          pr_number=$(echo "${{ steps.create_pr.outputs.pr_number }}")
+          gh pr edit $pr_number --add-label "do-not-merge/hold"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Add comment to the PR
+        if: steps.create_pr.outputs.pr_number != ''
+        run: |
+          pr_number=$(echo "${{ steps.create_pr.outputs.pr_number }}")
+          gh pr comment $pr_number --body "please add label \`ok-to-sync\` and remove label \`do-not-merge/hold\` to merge the PR"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Add a `do-not-merge/hold` label when the PR for sync-up is created.
- Add a comment about the instructions on how to merge the PR.