### PR TITLE
mitigate intra-channel upgrade

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -57,6 +57,7 @@ function main() {
     prepare_preview_mode
     setup_topology
     check_singleton_service
+    upgrade_mitigation
     setup_nss
     install_cs_operator
 }
@@ -628,6 +629,25 @@ EOF
     if [ $retries -eq 0 ] && [ $RETRY_CONFIG_CSCR -eq 0 ]; then
         warning "Fail to patch CommonService CR in ${OPERATOR_NS}, try to install cs-operator first"
         RETRY_CONFIG_CSCR=1
+    fi
+}
+
+# Delete release 4.0.x CSV to unblock the upgrade from v4.0.0 -> v4.0.1 -> v4.1.0
+function upgrade_mitigation() {
+    # When it is upgrade scenario, and it is complex toppology, and it is not v4.0 channel, then do the mitigation
+    if [ $IS_UPGRADE -eq 1 ] && [ $IS_NOT_COMPLEX_TOPOLOGY -eq 0 ] && [[ $CHANNEL != "v4.0" ]]; then
+        local sub_name=$(${OC} get subscription.operators.coreos.com -n ${OPERATOR_NS} -l operators.coreos.com/ibm-common-service-operator.${OPERATOR_NS}='' --no-headers | awk '{print $1}')
+        local csv_name=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${OPERATOR_NS} --ignore-not-found -o jsonpath={.status.installedCSV})
+        if [[ ! -z ${csv_name} ]]; then
+            local csv_deleted=$(${OC} get csv -n ${OPERATOR_NS} --ignore-not-found -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep ibm-common-service-operator | grep -v ${csv_name})
+            for csv in ${csv_deleted}; do
+                # only delete csv named ibm-common-service-operator.v4.0.1 or ibm-common-service-operator.v4.0.0 for upgrade mitigation
+                if [[ ${csv} == *"ibm-common-service-operator.v4.0.1"* ]] || [[ ${csv} == *"ibm-common-service-operator.v4.0.0"* ]]; then
+                    warning "Delete CSV ${csv} in ${OPERATOR_NS} for upgrade mitigation\n"
+                    ${OC} delete csv ${csv} -n ${OPERATOR_NS}
+                fi
+            done
+        fi
     fi
 }
 

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -634,8 +634,8 @@ EOF
 
 # Delete release 4.0.x CSV to unblock the upgrade from v4.0.0 -> v4.0.1 -> v4.1.0
 function upgrade_mitigation() {
-    # When it is upgrade scenario, and it is complex toppology, and it is not v4.0 channel, then do the mitigation
-    if [ $IS_UPGRADE -eq 1 ] && [ $IS_NOT_COMPLEX_TOPOLOGY -eq 0 ] && [[ $CHANNEL != "v4.0" ]]; then
+    # When it is upgrade scenario, and it is complex toppology, then do the mitigation
+    if [[ $IS_UPGRADE -eq 1 && $IS_NOT_COMPLEX_TOPOLOGY -eq 0 ]]; then
         local sub_name=$(${OC} get subscription.operators.coreos.com -n ${OPERATOR_NS} -l operators.coreos.com/ibm-common-service-operator.${OPERATOR_NS}='' --no-headers | awk '{print $1}')
         local csv_name=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${OPERATOR_NS} --ignore-not-found -o jsonpath={.status.installedCSV})
         if [[ ! -z ${csv_name} ]]; then


### PR DESCRIPTION
We will try to delete CSV `ibm-common-service-operator-4.0.0` or `ibm-common-service-operator-v4.0.1` when those CSVs are not in Subscription's `installedCSV`

This is used to solve following issue:
- User would like to do following upgrade patch: v4.0.0 -> v4.0.1 -> v4.1.0
- Common Service operator is stuck at upgrading v4.0.0 -> v4.0.1, see following screenshot for details

<img width="1615" alt="Screenshot 2023-07-28 at 1 18 13 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/2c7a0ce0-1884-4df0-a990-85d36c2dee1c">

- As a result, NamespaceScope operator could not be upgraded v4.0.0 -> v4.1.0 due to this error
```
constraints not satisfiable: @existing/test-mitigation//ibm-common-service-operator.v4.0.0 and @existing/test-mitigation//ibm-common-service-operator.v4.0.1 originate from package ibm-common-service-operator, subscription ibm-common-service-operator requires @existing/test-mitigation//ibm-common-service-operator.v4.0.1, subscription ibm-common-service-operator exists, clusterserviceversion ibm-common-service-operator.v4.0.0 exists and is not referenced by a subscription
```

### How to test
- Install a `4.0.0` base version with SOD topology, CatalogSource need to be pinned at `4.0.0` tag
```
./cp3pt0-deployment/setup_tenant.sh --license-accept -c v4.0 --operator-namespace test-mitigation --services-namespace test-miti
```
- Update CatalogSource to `cd` tag
- Execute `setup_tenant.sh` to perform the upgrade to `v4.1`
```
./cp3pt0-deployment/setup_tenant.sh --license-accept -c v4.1 --operator-namespace test-mitigation --services-namespace test-miti

...
[✗] Delete CSV ibm-common-service-operator.v4.0.0 in test-mitigation for upgrade mitigation

clusterserviceversion.operators.coreos.com "ibm-common-service-operator.v4.0.0" deleted
# Checking whether Namespace Scope operator exist...
[✗] There is an ibm-namespace-scope-operator subscription already deployed


```
- The both CS and NamespaceScope operator should be upgraded to `v4.1.0` successfully.