### PR TITLE
[4.2] using fully qualified sub resource name

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -199,9 +199,9 @@ function collect_data() {
     msg "-----------------------------------------------------------------------"
     
     info "MasterNS:${master_ns}"
-    cs_operator_channel=$(${OC} get sub ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.channel") 
+    cs_operator_channel=$(${OC} get subscription.operators.coreos.com ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.channel") 
     info "channel:${cs_operator_channel}"   
-    catalog_source=$(${OC} get sub ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.source")
+    catalog_source=$(${OC} get subscription.operators.coreos.com ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.source")
     info "catalog_source:${catalog_source}"
 
     #this command gets all of the ns listed in requested from namesapce fields
@@ -377,10 +377,10 @@ function cleanupCSOperators(){
     msg "-----------------------------------------------------------------------"
     for namespace in $requested_ns
     do
-        return_value=$(${OC} get sub -n ${namespace} | (grep ibm-common-service-operator || echo "fail"))
+        return_value=$(${OC} get subscription.operators.coreos.com -n ${namespace} | (grep ibm-common-service-operator || echo "fail"))
         if [[ $return_value != "fail" ]]; then
-            local sub=$(${OC} get sub -n ${namespace} | grep ibm-common-service-operator | awk '{print $1}')
-            ${OC} get sub ${sub} -n ${namespace} -o yaml > tmp.yaml 
+            local sub=$(${OC} get subscription.operators.coreos.com -n ${namespace} | grep ibm-common-service-operator | awk '{print $1}')
+            ${OC} get subscription.operators.coreos.com ${sub} -n ${namespace} -o yaml > tmp.yaml 
             ${YQ} -i '.spec.source = "'${catalog_source}'"' tmp.yaml || error "Could not replace catalog source for CS operator in namespace ${namespace}"
             ${YQ} -i '.spec.channel = "'${cs_operator_channel}'"' tmp.yaml || error "Could not replace channel for CS operator in namespace ${namespace}"
             ${YQ} -i 'del(.metadata.creationTimestamp) | del(.metadata.managedFields) | del(.metadata.resourceVersion) | del(.metadata.uid) | del(.status)' tmp.yaml || error "Failed to remove metadata fields from temp cs operator yaml for namespace ${namespace}."

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1204,7 +1204,7 @@ function fetch_sub_from_package() {
     local package=$1
     local ns=$2
 
-    ${OC} get sub -n "$ns" -o jsonpath="{.items[?(@.spec.name=='$package')].metadata.name}"
+    ${OC} get subscription.operators.coreos.com -n "$ns" -o jsonpath="{.items[?(@.spec.name=='$package')].metadata.name}"
 }
 
 function fetch_csv_from_sub() {

--- a/force-uninstall.sh
+++ b/force-uninstall.sh
@@ -130,7 +130,7 @@ function delete_operator() {
   local subs=$1
   local namespace=$2
   for sub in ${subs}; do
-    csv=$(${KUBECTL} get sub ${sub} -n ${namespace} -o=jsonpath='{.status.installedCSV}' --ignore-not-found)
+    csv=$(${KUBECTL} get subscription.operators.coreos.com ${sub} -n ${namespace} -o=jsonpath='{.status.installedCSV}' --ignore-not-found)
     if [[ "X${csv}" != "X" ]]; then
       msg "Delete operator ${sub} from namespace ${namespace}"
       ${KUBECTL} delete csv ${csv} -n ${namespace} --ignore-not-found
@@ -194,7 +194,7 @@ function delete_rbac_resource() {
 
 function cleanup_cluster() {
   # Delete the previous version ODLM operator
-  if ${KUBECTL} get sub operand-deployment-lifecycle-manager-app -n openshift-operators &>/dev/null; then
+  if ${KUBECTL} get subscription.operators.coreos.com operand-deployment-lifecycle-manager-app -n openshift-operators &>/dev/null; then
     title "Deleting ODLM Operator"
     delete_operator "operand-deployment-lifecycle-manager-app" "openshift-operators"
   fi
@@ -314,7 +314,7 @@ if [[ "$FORCE_DELETE" == "false" ]]; then
   delete_unavailable_apiservice
 
   title "Deleting ibm-common-service-operator"
-  for sub in $(${KUBECTL} get sub --all-namespaces --ignore-not-found | awk '{if ($3 =="ibm-common-service-operator") print $1"/"$2}'); do
+  for sub in $(${KUBECTL} get subscription.operators.coreos.com --all-namespaces --ignore-not-found | awk '{if ($3 =="ibm-common-service-operator") print $1"/"$2}'); do
     namespace=$(echo $sub | awk -F'/' '{print $1}')
     name=$(echo $sub | awk -F'/' '{print $2}')
     delete_operator "$name" "$namespace"

--- a/health-check.sh
+++ b/health-check.sh
@@ -92,14 +92,14 @@ function checking_operator_status() {
 function checking_sub_status() {
   local namespace=$1
   output "List Subscriptions: ${OC} -n ${namespace} get sub"
-  ${OC} -n ${namespace} get sub | tee -a $logfile
+  ${OC} -n ${namespace} get subscription.operators.coreos.com | tee -a $logfile
   rc=0
-  ${OC} -n ${namespace} get sub -o=jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.state}{"\n"}{end}' | while read -r line; do
+  ${OC} -n ${namespace} get subscription.operators.coreos.com -o=jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.state}{"\n"}{end}' | while read -r line; do
     sub=$(echo $line | awk '{print $1}')
     state=$(echo $line | awk '{print $2}')
     if [[ "$state" != "AtLatestKnown" ]]; then
-      output "Check subscription: ${OC} -n ${namespace} get sub ${sub} -oyaml"
-      ${OC} -n ${namespace} get sub ${sub} -oyaml | tee -a $logfile
+      output "Check subscription: ${OC} -n ${namespace} get subscription.operators.coreos.com ${sub} -oyaml"
+      ${OC} -n ${namespace} get subscription.operators.coreos.com ${sub} -oyaml | tee -a $logfile
       ((rc++))
     fi
   done

--- a/operator_checker_patch.sh
+++ b/operator_checker_patch.sh
@@ -134,7 +134,7 @@ function edit_odlm_sub() {
         fi
 
         msg ""
-    done < <(oc get subscription -n ${namespace} | grep operand-deployment-lifecycle-manager-app | awk '{print $1}')
+    done < <(oc get subscription.operators.coreos.com -n ${namespace} | grep operand-deployment-lifecycle-manager-app | awk '{print $1}')
     success "Disable ${odlm_sub} operator checker in ${namespace} successfully."
 }
 

--- a/rollback-multi-instance.sh
+++ b/rollback-multi-instance.sh
@@ -85,9 +85,9 @@ function collect_data() {
     msg "-----------------------------------------------------------------------"
     
     # info "MasterNS:${master_ns}"
-    # cs_operator_channel=$(${OC} get sub ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.channel") 
+    # cs_operator_channel=$(${OC} get subscription.operators.coreos.com ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.channel") 
     # info "channel:${cs_operator_channel}"   
-    # catalog_source=$(${OC} get sub ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.source")
+    # catalog_source=$(${OC} get subscription.operators.coreos.com ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.source")
     # info "catalog_source:${catalog_source}" 
     #this command gets all of the ns listed in requested from namesapce fields
     requested_ns=$("${OC}" get configmap -n kube-public -o yaml ${cm_name} | yq '.data[]' | yq '.namespaceMapping[].requested-from-namespace' | awk '{print $2}' | tr '\n' ' ')

--- a/rollback_to_eus.sh
+++ b/rollback_to_eus.sh
@@ -116,7 +116,7 @@ function switch_to_eus() {
 
     while read -r ns cssub; do
         delete_operator $cssub $ns
-    done < <(oc get sub --all-namespaces --ignore-not-found | grep ibm-common-service-operator | awk '{print $1" "$2}')
+    done < <(oc get subscription.operators.coreos.com --all-namespaces --ignore-not-found | grep ibm-common-service-operator | awk '{print $1" "$2}')
 
     success "Remove all Common Service Operators successfully."
     msg ""
@@ -152,7 +152,7 @@ function delete_operator() {
     ns=$2
     msg "Deleting ${sub} in namespace ${ns}..."
     msg "-----------------------------------------------------------------------"
-    csv=$(oc get sub ${sub} -n ${ns} -o=jsonpath='{.status.installedCSV}' --ignore-not-found)
+    csv=$(oc get subscription.operators.coreos.com ${sub} -n ${ns} -o=jsonpath='{.status.installedCSV}' --ignore-not-found)
     in_step=1
     msg "[${in_step}] Removing the subscription of ${sub} in namespace ${ns} ..."
     oc delete sub ${sub} -n ${ns} --ignore-not-found

--- a/uninstall-dedicated-cs-instance.sh
+++ b/uninstall-dedicated-cs-instance.sh
@@ -73,7 +73,7 @@ function delete_all(){
     fi
   done
   #delete automation foundation subs and csvs
-  auto_ops=$(${KUBECTL} get sub -n ${namespace} --ignore-not-found | (grep automation-foundation || echo fail) | awk '{print $1}')
+  auto_ops=$(${KUBECTL} get subscription.operators.coreos.com -n ${namespace} --ignore-not-found | (grep automation-foundation || echo fail) | awk '{print $1}')
   for af_op in $auto_ops; do
     delete_operator "${namespace}" "$af_op"
   done
@@ -271,7 +271,7 @@ function delete_operator() {
   local subs=$2 
   local namespace=$1 
   for sub in ${subs}; do
-    csv=$(${KUBECTL} get sub ${sub} -n ${namespace} -o=jsonpath='{.status.installedCSV}' --ignore-not-found)
+    csv=$(${KUBECTL} get subscription.operators.coreos.com ${sub} -n ${namespace} -o=jsonpath='{.status.installedCSV}' --ignore-not-found)
     if [[ "X${csv}" != "X" ]]; then
       msg "Delete operator ${sub} from namespace ${namespace}"
       ${KUBECTL} delete csv ${csv} -n ${namespace} --ignore-not-found
@@ -424,19 +424,19 @@ fi
 
 if [[ "$FORCE_DELETE" == "false" ]]; then
   title "Deleting ibm-common-service-operator in namespace ${COMMON_SERVICES_NS}"
-  for sub in $(${KUBECTL} get sub --all-namespaces --ignore-not-found | grep ${COMMON_SERVICES_NS} | awk '{if ($3 =="ibm-common-service-operator") print $1"/"$2}'); do
+  for sub in $(${KUBECTL} get subscription.operators.coreos.com --all-namespaces --ignore-not-found | grep ${COMMON_SERVICES_NS} | awk '{if ($3 =="ibm-common-service-operator") print $1"/"$2}'); do
     namespace=$(echo $sub | awk -F'/' '{print $1}')
     name=$(echo $sub | awk -F'/' '{print $2}')
     delete_operator "${COMMON_SERVICES_NS}" "$name" 
   done
   title "Deleting ODLM in namespace ${COMMON_SERVICES_NS}"
-  for sub in $(${KUBECTL} get sub --all-namespaces --ignore-not-found | grep ${COMMON_SERVICES_NS} | awk '{if ($3 =="ibm-odlm") print $1"/"$2}'); do
+  for sub in $(${KUBECTL} get subscription.operators.coreos.com --all-namespaces --ignore-not-found | grep ${COMMON_SERVICES_NS} | awk '{if ($3 =="ibm-odlm") print $1"/"$2}'); do
     namespace=$(echo $sub | awk -F'/' '{print $1}')
     name=$(echo $sub | awk -F'/' '{print $2}')
     delete_operator "${COMMON_SERVICES_NS}" "$name" 
   done
   title "Deleting ibm-namespace-scope-operator in namespace ${COMMON_SERVICES_NS}"
-  for sub in $(${KUBECTL} get sub --all-namespaces --ignore-not-found | grep ${COMMON_SERVICES_NS} | awk '{if ($3 =="ibm-namespace-scope-operator") print $1"/"$2}'); do
+  for sub in $(${KUBECTL} get subscription.operators.coreos.com --all-namespaces --ignore-not-found | grep ${COMMON_SERVICES_NS} | awk '{if ($3 =="ibm-namespace-scope-operator") print $1"/"$2}'); do
     namespace=$(echo $sub | awk -F'/' '{print $1}')
     name=$(echo $sub | awk -F'/' '{print $2}')
     delete_operator "${COMMON_SERVICES_NS}" "$name" 
@@ -455,13 +455,13 @@ fi
 if [[ "$REMOVE_IAM_CP_NS" == "true" ]]; then
   for ns in $cloudpak_ns; do
     title "Deleting ibm-common-service-operator in namespace ${ns}"
-    for sub in $(${KUBECTL} get sub --all-namespaces --ignore-not-found | grep ${ns} | awk '{if ($3 =="ibm-common-service-operator") print $1"/"$2}'); do
+    for sub in $(${KUBECTL} get subscription.operators.coreos.com --all-namespaces --ignore-not-found | grep ${ns} | awk '{if ($3 =="ibm-common-service-operator") print $1"/"$2}'); do
         namespace=$(echo $sub | awk -F'/' '{print $1}')
         name=$(echo $sub | awk -F'/' '{print $2}')
         delete_operator "${ns}" "$name" 
     done
     title "Deleting ibm-namespace-scope-operator in namespace ${ns}"
-    for sub in $(${KUBECTL} get sub --all-namespaces --ignore-not-found | grep ${ns} | awk '{if ($3 =="ibm-namespace-scope-operator") print $1"/"$2}'); do
+    for sub in $(${KUBECTL} get subscription.operators.coreos.com --all-namespaces --ignore-not-found | grep ${ns} | awk '{if ($3 =="ibm-namespace-scope-operator") print $1"/"$2}'); do
       namespace=$(echo $sub | awk -F'/' '{print $1}')
       name=$(echo $sub | awk -F'/' '{print $2}')
       delete_operator "${ns}" "$name" 

--- a/upgrade_to_continuous_delivery.sh
+++ b/upgrade_to_continuous_delivery.sh
@@ -182,7 +182,7 @@ function switch_to_continous_delivery() {
         oc patch sub ${cssub} -n ${ns} --type="json" -p '[{"op": "replace", "path":"/spec/channel", "value":"v3"}]' 2> /dev/null
 
         msg ""
-    done < <(oc get sub --all-namespaces | grep ibm-common-service-operator | awk '{print $1" "$2}')
+    done < <(oc get subscription.operators.coreos.com --all-namespaces | grep ibm-common-service-operator | awk '{print $1" "$2}')
 }
 
 function check_switch_complete() {
@@ -201,12 +201,12 @@ function check_switch_complete() {
         msg "Checking subscription ${cssub} in namespace ${ns} ..."
         msg "-----------------------------------------------------------------------"
         
-        channel=$(oc get sub ${cssub} -n ${ns} -o jsonpath='{.spec.channel}')
+        channel=$(oc get subscription.operators.coreos.com ${cssub} -n ${ns} -o jsonpath='{.spec.channel}')
         if [[ "$channel" != "v3" ]]; then
             error "the channel of subscription ${cssub} in namespace ${ns} is not v3, please try to re-run the script"
         fi
 
-    done < <(oc get sub --all-namespaces | grep ibm-common-service-operator | awk '{print $1" "$2}')
+    done < <(oc get subscription.operators.coreos.com --all-namespaces | grep ibm-common-service-operator | awk '{print $1" "$2}')
 
     success "Updated all ibm-common-service-operator subscriptions successfully."
     info "Please wait a moment for ibm-common-service-operator to upgrade all foundational services."

--- a/upgrade_to_continuous_delivery_airgap.sh
+++ b/upgrade_to_continuous_delivery_airgap.sh
@@ -85,7 +85,7 @@ function switch_to_continous_delivery() {
         oc patch sub ${cssub} -n ${ns} --type="json" -p '[{"op": "replace", "path":"/spec/channel", "value":"v3"}]' 2> /dev/null
 
         msg ""
-    done < <(oc get sub --all-namespaces | grep ibm-common-service-operator | awk '{print $1" "$2}')
+    done < <(oc get subscription.operators.coreos.com --all-namespaces | grep ibm-common-service-operator | awk '{print $1" "$2}')
 
     success "Updated all ibm-common-service-operator subscriptions successfully."
     msg ""
@@ -115,7 +115,7 @@ function switch_to_continous_delivery() {
         oc patch sub ${sub} -n ibm-common-services --type="json" -p '[{"op": "replace", "path":"/spec/channel", "value":"v3"}]' 2> /dev/null
 
         msg ""
-    done < <(oc get sub -n ibm-common-services | awk '{print $1}')
+    done < <(oc get subscription.operators.coreos.com -n ibm-common-services | awk '{print $1}')
 
 
     msg "Creating namespace scope config in namespace ibm-common-services..."
@@ -153,12 +153,12 @@ function check_switch_complete() {
         msg "Checking subscription ${sub} in namespace ibm-common-services..."
         msg "-----------------------------------------------------------------------"
         
-        channel=$(oc get sub ${sub} -n ibm-common-services -o jsonpath='{.spec.channel}')
+        channel=$(oc get subscription.operators.coreos.com ${sub} -n ibm-common-services -o jsonpath='{.spec.channel}')
         if [[ "$channel" != "v3" ]]; then
             error "the channel of subscription ${sub} in namespace ibm-common-services is not v3, please try to re-run the script"
         fi
 
-    done < <(oc get sub -n ibm-common-services | awk '{print $1}')
+    done < <(oc get subscription.operators.coreos.com -n ibm-common-services | awk '{print $1}')
 
     success "Updated all operator subscriptions in namespace ibm-common-services successfully."
 }
@@ -169,7 +169,7 @@ function delete_operator() {
     for sub in ${subs}; do
         msg "Deleting ${sub} in namesapce ${ns}, it will be re-installed after the upgrade is successful ..."
         msg "-----------------------------------------------------------------------"
-        csv=$(oc get sub ${sub} -n ${ns} -o=jsonpath='{.status.installedCSV}' --ignore-not-found)
+        csv=$(oc get subscription.operators.coreos.com ${sub} -n ${ns} -o=jsonpath='{.status.installedCSV}' --ignore-not-found)
         in_step=1
         msg "[${in_step}] Removing the subscription of ${sub} in namesapce ${ns} ..."
         oc delete sub ${sub} -n ${ns} --ignore-not-found


### PR DESCRIPTION
for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59727
Fix subscription listing in case of failure by using fully qualified sub-resource name `subscription.operators.coreos.com` for accuracy when `Open Cluster Management` is deployed in the same OCP cluster.