### PR TITLE
Support simple topology upgrade from v3.x to v4.x

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -333,7 +333,7 @@ function wait_for_nss_patch() {
     fi
     
     # wait for deployment to be ready
-    local deployment_name=$(${OC} get deployment -n ${namespace} -l operators.coreos.com/${package_name}.${namespace}='' --no-headers | awk '{print $1}')
+    local deployment_name="ibm-common-service-operator"
     wait_for_nss_env_var ${namespace} ${deployment_name}
     wait_for_deployment ${namespace} ${deployment_name}
     


### PR DESCRIPTION
This is to support CP4BA isolate upgrade scenario.
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59867#issuecomment-61557413

The original deployment is multiple CP4BA namespaces share the same CS instance in `ibm-common-services` namespace.
The original `common-service-maps` ConfigMap looks like following example
```
 data:
   common-service-maps.yaml: |
     controlNamespace: cs-control
     namespaceMapping:
     - requested-from-namespace:
       - cp1-ns
       - cp2-ns
       map-to-common-service-namespace: ibm-common-services
```

After isolation, the expected ConfigMap looks like following example. Each isolated tenant is a simple topology deployment.
```
 data:
   common-service-maps.yaml: |
     controlNamespace: cs-control
     namespaceMapping:
     - requested-from-namespace:
       - cp1-ns
       map-to-common-service-namespace: cp1-ns
     - requested-from-namespace:
       - cp2-ns
       map-to-common-service-namespace: cp2-ns
     - requested-from-namespace:
       - ibm-common-services
       map-to-common-service-namespace: ibm-common-services
```

The script should support upgrading common-service-operator in `cp1-ns` and `cp2-ns` from `v3.x` to `v4.x`
```
./setup_tenant.sh --operator-namespace cp1-ns -c v4.0 -s opencloud-operators --license-accept -v 1
./setup_tenant.sh --operator-namespace cp2-ns -c v4.0 -s opencloud-operators --license-accept -v 1
```

### How to test
1. Deploy a shared ibm-common-service-operator v3.x in `cp1-ns` namespace
   - It will install CS instance in default `ibm-common-services` namespace.
2. Execute `isolate.sh` script to isolate `cp1-ns` from original `ibm-common-services` namespace
   - `./isolate.sh --original-cs-ns ibm-common-services --control-ns cs-control --excluded-ns cp1-ns`
3. Execute `setup_singleton.sh` to migrate cluster singleton services
   - `./setup_singleton.sh --operator-namespace ibm-common-services --enable-licensing --cert-manager-source ibm-cert-manager-catalog --licensing-source ibm-licensing-catalog --license-accept -v 1`
4. pre-load data
   - `./preload_data.sh --original-cs-ns ibm-common-services --services-ns cp1-ns`
5. Execute `./setup_tenant.sh --operator-namespace cp1-ns -c v4.0 -s opencloud-operators --license-accept -v 1`

This is the expected script output.
And common service operator in `cp1-ns` is upgraded, also a new CS instance is brought up in `cp1-ns` namespace.
```
./cp3pt0-deployment/setup_tenant.sh --operator-namespace cp1-ns --license-accept

# Start to validate the parameters passed into script... 
[✔] oc command available
[✔] yq command available
[✔] oc command logged in as kube:admin
[✔] Channel v4.1 is valid
[INFO] CommonService CRD exists but main CommonService CR does not exist, skipping defaulting from original CommonService CR

[INFO] ibm-common-service-operator subscription exists, it is upgrade scenario

[✗] It is simple topology or all namespaces topology
```


### Additional testing
Fresh installation of simple topology is still not allowed via `setup_tenant.sh`
```
./cp3pt0-deployment/setup_tenant.sh --operator-namespace simple-install --license-accept

# Start to validate the parameters passed into script... 
[✔] oc command available
[✔] yq command available
[✔] oc command logged in as kube:admin
[✔] Channel v4.1 is valid
[INFO] CommonService CRD exists but main CommonService CR does not exist, skipping defaulting from original CommonService CR

[✗] It is simple topology or all namespaces topology

[✔] Profile size is not specified. Use default value: starterset
[✘] Must provide additional namespaces for --tethered-namespaces or --excluded-namespaces when services-namespace is the same as operator-namespace
```