### PR TITLE
Support picking default channel from bundle

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -288,6 +288,8 @@ function pre_req() {
         else
             error "Channel is less than v4.0"
         fi
+    elif [[ $CHANNEL == "null" ]]; then
+        warning "Channel is not set, default channel from operator bundle will be used"
     else
         error "Channel is not semantic vx.y"
     fi

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -401,6 +401,8 @@ function pre_req() {
         else
             error "Channel $CHANNEL is less than v4.0"
         fi
+    elif [[ $CHANNEL == "null" ]]; then
+        warning "Channel is not set, default channel from operator bundle will be used"
     else
         error "Channel $CHANNEL is not semantic vx.y"
     fi

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -203,6 +203,8 @@ function pre_req() {
         else
             error "Channel $CHANNEL is less than v4.0"
         fi
+    elif [[ $CHANNEL == "null" ]]; then
+        warning "Channel is not set, default channel from operator bundle will be used"
     else
         error "Channel $CHANNEL is not semantic vx.y"
     fi


### PR DESCRIPTION
### Background
It is used to cover a scenario when user want to install operators from its default channel `.status.defaultChannel` set in operator packagemanifest.
<img width="530" alt="Screenshot 2023-08-18 at 10 58 57 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/d0d53cad-5e51-4f29-9042-5db31d9c86f6">

And it is possible that different operator has different default channel. For example,
- User would like to install `ibm-common-service-operator` from its default `v4.3` channel.
- User would like to install `ibm-namespace-scope-operator` from its default `v4.2` channel.

### Action
Script will support to set operator subscription channel to null. e.g., `.spec.channel: null`.
When channel is set to `null` in subscription, OLM will automatically pick up the default channel in operator PackageManifest.
<img width="476" alt="Screenshot 2023-08-18 at 11 09 27 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/b4c1ed71-151a-452e-8532-0bb206a0bee6">


### How to test
1. Deploy CatalogSource for Singleton Service(Cert-Manager and Licensing) and CS Services
2. Execute the script with channel specified to `null`
  - `./cp3pt0-deployment/setup_singleton.sh --license-accept --enable-licensing -c null`
  - `./cp3pt0-deployment/setup_tenant.sh --operator-namespace cp4ba-operator --services-namespace cp4ba-service --license-accept -c null`
3. The script should run successfully and install the latest version.

NOTE: `migrate_tenant.sh` script also supports picking up default channel from packagemanifest
  - `./cp3pt0-deployment/migrate_tenant.sh --license-accept --enable-licensing --operator-namespace ibm-common-services -c null`
