### PR TITLE
updated descriptions in CRD fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ KUBECTL ?= $(shell which kubectl)
 OPERATOR_SDK ?= $(shell which operator-sdk)
 CONTROLLER_GEN ?= $(shell which controller-gen)
 KUSTOMIZE ?= $(shell which kustomize)
-YQ_VERSION=v4.3.1
+YQ_VERSION=v4.27.3
 KUSTOMIZE_VERSION=v3.8.7
 OPERATOR_SDK_VERSION=v1.24.0
 CONTROLLER_TOOLS_VERSION ?= v0.6.1
@@ -235,6 +235,7 @@ bundle-manifests: clis
 	$(OPERATOR_SDK) bundle validate ./bundle
 	$(YQ) eval -i '.metadata.annotations."olm.skipRange" = ">=3.3.0 <${RELEASE_VERSION}"' ${CSV_PATH}
 	$(YQ) eval -i '.spec.webhookdefinitions[0].deploymentName = "ibm-common-service-operator" | .spec.webhookdefinitions[1].deploymentName = "ibm-common-service-operator"' ${CSV_PATH}
+	$(YQ) eval-all -i '.spec.relatedImages = load("config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml").spec.relatedImages' bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
 
 generate-all: yq kustomize operator-sdk generate manifests ## Generate bundle manifests, metadata and package manifests
 	$(OPERATOR_SDK) generate kustomize manifests -q

--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -51,24 +51,50 @@ type ServiceConfig struct {
 
 // CommonServiceSpec defines the desired state of CommonService
 type CommonServiceSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	Features            *Features            `json:"features,omitempty"`
+	Features *Features `json:"features,omitempty"`
+	// InstallPlanApproval sets the approval mode for ODLM and other
+	// foundational services: Manual or Automatic
 	InstallPlanApproval olmv1alpha1.Approval `json:"installPlanApproval,omitempty"`
 	ManualManagement    bool                 `json:"manualManagement,omitempty"`
-	FipsEnabled         bool                 `json:"fipsEnabled,omitempty"`
-	RouteHost           string               `json:"routeHost,omitempty"`
-	Size                string               `json:"size,omitempty"`
-	Services            []ServiceConfig      `json:"services,omitempty"`
-	StorageClass        string               `json:"storageClass,omitempty"`
-	BYOCACertificate    bool                 `json:"BYOCACertificate,omitempty"`
-	ProfileController   string               `json:"profileController,omitempty"`
-	ServicesNamespace   ServicesNamespace    `json:"servicesNamespace,omitempty"`
-	OperatorNamespace   OperatorNamespace    `json:"operatorNamespace,omitempty"`
-	CatalogName         CatalogName          `json:"catalogName,omitempty"`
-	CatalogNamespace    CatalogNamespace     `json:"catalogNamespace,omitempty"`
-	DefaultAdminUser    string               `json:"defaultAdminUser,omitempty"`
+	// FipsEnabled enables FIPS mode for foundational services
+	FipsEnabled bool `json:"fipsEnabled,omitempty"`
+	// RouteHost describes the hostname for the foundational services route,
+	// and can only be configured pre-installation of IM
+	RouteHost string `json:"routeHost,omitempty"`
+	// Size describes the T-shirt size of foundational services: starterset,
+	// small, medium, or large
+	Size string `json:"size,omitempty"`
+	// Services describes the CPU, memory, and replica configuration for
+	// individual services in foundational services
+	Services []ServiceConfig `json:"services,omitempty"`
+	// StorageClass describes the storage class to use for the foundational
+	// services PVCs
+	StorageClass string `json:"storageClass,omitempty"`
+	// BYOCACertificate enables the option to replace the cs-ca-certificate with
+	// your own CA certificate
+	BYOCACertificate bool `json:"BYOCACertificate,omitempty"`
+	// ProfileController enables turbonomic to automatically handle sizing of
+	// foundational services. Default value is 'default'
+	ProfileController string `json:"profileController,omitempty"`
+	// ServicesNamespace describes the namespace where operands will be created
+	// in such as OperandRegistry and OperandConfig. This will also apply to all
+	// services in foundational services, e.g. IM will create operands in this
+	// namespace
+	ServicesNamespace ServicesNamespace `json:"servicesNamespace,omitempty"`
+	// OperatorNamespace describes the namespace where operators will be
+	// installed in such as ODLM. This will also apply to all services in
+	// foundational services, e.g. ODLM will install IM operator in this
+	// namespace
+	OperatorNamespace OperatorNamespace `json:"operatorNamespace,omitempty"`
+	// CatalogName is the name of the CatalogSource that will be used for ODLM
+	// and other services in foundational services
+	CatalogName CatalogName `json:"catalogName,omitempty"`
+	// CatalogNamespace is the namespace of the CatalogSource that will be used
+	// for ODLM and other services in foundational services
+	CatalogNamespace CatalogNamespace `json:"catalogNamespace,omitempty"`
+	// DefalutAdminUser is the name of the default admin user for foundational
+	// services IM, default is cpadmin
+	DefaultAdminUser string `json:"defaultAdminUser,omitempty"`
 
 	// +optional
 	License LicenseList `json:"license"`
@@ -108,7 +134,7 @@ type Bedrockshim struct {
 	CrossplaneProviderRemoval bool `json:"crossplaneProviderRemoval,omitempty"`
 }
 
-// BedrockOperator maintains a list of bedrock operators
+// BedrockOperator describes a list of foundational services' operators currently installed for this tenant.
 type BedrockOperator struct {
 	Name               string `json:"name,omitempty"`
 	Version            string `json:"version,omitempty"`
@@ -127,36 +153,63 @@ type CatalogName string
 type CatalogNamespace string
 
 type ConfigurableCR struct {
+	// ObjectName is the name of the configurable CommonService CR
 	ObjectName string `json:"objectName,omitempty"`
+	// ApiVersion is the api version of the configurable CommonService CR
 	APIVersion string `json:"apiVersion,omitempty"`
-	Namespace  string `json:"namespace,omitempty"`
-	Kind       string `json:"kind,omitempty"`
+	// Namespace is the namespace of the configurable CommonService CR
+	Namespace string `json:"namespace,omitempty"`
+	// Kind is the kind of the configurable CommonService CR
+	Kind string `json:"kind,omitempty"`
 }
 
+// ConfigStatus describes various configuration currently applied onto the foundational services installer.
 type ConfigStatus struct {
-	CatalogName             CatalogName       `json:"catalogName,omitempty"`
-	CatalogNamespace        CatalogNamespace  `json:"catalogNamespace,omitempty"`
-	OperatorNamespace       OperatorNamespace `json:"operatorNamespace,omitempty"`
-	OperatorDeployed        bool              `json:"operatorDeployed,omitempty"`
-	ServicesNamespace       ServicesNamespace `json:"servicesNamespace,omitempty"`
-	ServicesDeployed        bool              `json:"servicesDeployed,omitempty"`
-	Configurable            bool              `json:"configurable,omitempty"`
-	TopologyConfigurableCRs []ConfigurableCR  `json:"topologyConfigurableCRs,omitempty"`
+	// CatalogName is the name of the CatalogSource foundational services is using
+	CatalogName CatalogName `json:"catalogName,omitempty"`
+	// CatalogNamespace is the namesapce of the CatalogSource
+	CatalogNamespace CatalogNamespace `json:"catalogNamespace,omitempty"`
+	// OperatorNamespace is the namespace of where the foundational services'
+	// operators will be installed in.
+	OperatorNamespace OperatorNamespace `json:"operatorNamespace,omitempty"`
+	// OperatorDeployed indicates whether the OperandRegistry has been created
+	// or not.
+	OperatorDeployed bool `json:"operatorDeployed,omitempty"`
+	// ServicesNamespace is the namespace where the foundational services'
+	// operands will be created in.
+	ServicesNamespace ServicesNamespace `json:"servicesNamespace,omitempty"`
+	// ServicesDeployed indicates whether the OperandConfig has been created or
+	// not.
+	ServicesDeployed bool `json:"servicesDeployed,omitempty"`
+	// Configurable indicates whether this CommonService CR is the one that can
+	// that can be used to configure the foundational services' installer. Other
+	// CommonService CRs configurations will not take effect, except for sizing
+	Configurable bool `json:"configurable,omitempty"`
+	// TopologyConfigurableCRs describes the configurable CommonService CR
+	TopologyConfigurableCRs []ConfigurableCR `json:"topologyConfigurableCRs,omitempty"`
 }
 
 // CommonServiceStatus defines the observed state of CommonService
 type CommonServiceStatus struct {
+	// Phase describes the phase of the overall installation
 	Phase            string            `json:"phase,omitempty"`
 	BedrockOperators []BedrockOperator `json:"bedrockOperators,omitempty"`
-	OverallStatus    string            `json:"overallStatus,omitempty"`
-	ConfigStatus     ConfigStatus      `json:"configStatus,omitempty"`
+	// OverallStatus describes whether the Installation for the foundational services has succeeded or not
+	OverallStatus string       `json:"overallStatus,omitempty"`
+	ConfigStatus  ConfigStatus `json:"configStatus,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="CommonService"
 
-// CommonService is the Schema for the commonservices API
+// CommonService is the Schema for the commonservices API. This API is used to
+// configure general foundational services configurations, such as sizing,
+// catalogsource, etc. See description of fields for more details. An instance
+// of this CRD is automatically created by the ibm-common-service-operator upon
+// installation to trigger the installation of critical installer components
+// such as operand-deployment-lifecycle-manager (ODLM), which is required to
+// further install other services from foundational services, such as IM.
 type CommonService struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -181,7 +181,7 @@ type ConfigStatus struct {
 	// ServicesDeployed indicates whether the OperandConfig has been created or
 	// not.
 	ServicesDeployed bool `json:"servicesDeployed,omitempty"`
-	// Configurable indicates whether this CommonService CR is the one that can
+	// Configurable indicates whether this CommonService CR is the one
 	// that can be used to configure the foundational services' installer. Other
 	// CommonService CRs configurations will not take effect, except for sizing
 	Configurable bool `json:"configurable,omitempty"`

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ibm-common-service-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=v4.2
 LABEL operators.operatorframework.io.bundle.channel.default.v1=v4.2
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.28.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.31.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-08-24T17:26:50Z"
+    createdAt: "2023-08-24T17:32:16Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -475,11 +475,6 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: IBM
-  relatedImages:
-  - image: icr.io/cpopen/common-service-operator:4.2.0
-    name: COMMON_SERVICE_OPERATOR_IMAGE
-  - image: icr.io/cpopen/cpfs/cpfs-utils:latest
-    name: CPFS_UTILS_IMAGE
   version: 4.2.0
   webhookdefinitions:
     - admissionReviewVersions:
@@ -522,3 +517,8 @@ spec:
       targetPort: 9443
       type: ValidatingAdmissionWebhook
       webhookPath: /validate-operator-ibm-com-v3-commonservice
+  relatedImages:
+    - image: icr.io/cpopen/common-service-operator:4.2.0
+      name: COMMON_SERVICE_OPERATOR_IMAGE
+    - image: icr.io/cpopen/cpfs/cpfs-utils:latest
+      name: CPFS_UTILS_IMAGE

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-07-26T17:27:50Z"
+    createdAt: "2023-08-24T17:26:50Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -30,7 +30,7 @@ metadata:
     operatorChannel: v4.2
     operatorVersion: 4.2.0
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.28.0
+    operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/ibm-common-service-operator
     support: IBM
@@ -282,7 +282,7 @@ spec:
                         value: icr.io/cpopen/cpfs/ibm-secretshare-operator:1.19.0
                       - name: IBM_ZEN_OPERATOR_IMAGE
                         value: icr.io/cpopen/ibm-zen-operator:1.7.0
-                    image: icr.io/cpopen/common-service-operator:latest 
+                    image: icr.io/cpopen/common-service-operator:latest
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       failureThreshold: 10

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-08-24T17:32:16Z"
+    createdAt: "2023-08-24T20:55:01Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: ibm-common-service-operator
   operators.operatorframework.io.bundle.channels.v1: v4.2
   operators.operatorframework.io.bundle.channel.default.v1: v4.2
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.31.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -19,7 +19,13 @@ spec:
   - name: v3
     schema:
       openAPIV3Schema:
-        description: CommonService is the Schema for the commonservices API
+        description: CommonService is the Schema for the commonservices API. This
+          API is used to configure general foundational services configurations, such
+          as sizing, catalogsource, etc. See description of fields for more details.
+          An instance of this CRD is automatically created by the ibm-common-service-operator
+          upon installation to trigger the installation of critical installer components
+          such as operand-deployment-lifecycle-manager (ODLM), which is required to
+          further install other services from foundational services, such as IM.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -37,12 +43,20 @@ spec:
             description: CommonServiceSpec defines the desired state of CommonService
             properties:
               BYOCACertificate:
+                description: BYOCACertificate enables the option to replace the cs-ca-certificate
+                  with your own CA certificate
                 type: boolean
               catalogName:
+                description: CatalogName is the name of the CatalogSource that will
+                  be used for ODLM and other services in foundational services
                 type: string
               catalogNamespace:
+                description: CatalogNamespace is the namespace of the CatalogSource
+                  that will be used for ODLM and other services in foundational services
                 type: string
               defaultAdminUser:
+                description: DefalutAdminUser is the name of the default admin user
+                  for foundational services IM, default is cpadmin
                 type: string
               features:
                 description: Features defines the configurations of Cloud Pak Services
@@ -63,10 +77,11 @@ spec:
                     type: object
                 type: object
               fipsEnabled:
+                description: FipsEnabled enables FIPS mode for foundational services
                 type: boolean
               installPlanApproval:
-                description: Approval is the user approval policy for an InstallPlan.
-                  It must be one of "Automatic" or "Manual".
+                description: 'InstallPlanApproval sets the approval mode for ODLM
+                  and other foundational services: Manual or Automatic'
                 type: string
               license:
                 description: LicenseList defines the license specification in CSV
@@ -88,12 +103,22 @@ spec:
               manualManagement:
                 type: boolean
               operatorNamespace:
+                description: OperatorNamespace describes the namespace where operators
+                  will be installed in such as ODLM. This will also apply to all services
+                  in foundational services, e.g. ODLM will install IM operator in
+                  this namespace
                 type: string
               profileController:
+                description: ProfileController enables turbonomic to automatically
+                  handle sizing of foundational services. Default value is 'default'
                 type: string
               routeHost:
+                description: RouteHost describes the hostname for the foundational
+                  services route, and can only be configured pre-installation of IM
                 type: string
               services:
+                description: Services describes the CPU, memory, and replica configuration
+                  for individual services in foundational services
                 items:
                   properties:
                     managementStrategy:
@@ -110,10 +135,18 @@ spec:
                   type: object
                 type: array
               servicesNamespace:
+                description: ServicesNamespace describes the namespace where operands
+                  will be created in such as OperandRegistry and OperandConfig. This
+                  will also apply to all services in foundational services, e.g. IM
+                  will create operands in this namespace
                 type: string
               size:
+                description: 'Size describes the T-shirt size of foundational services:
+                  starterset, small, medium, or large'
                 type: string
               storageClass:
+                description: StorageClass describes the storage class to use for the
+                  foundational services PVCs
                 type: string
             type: object
             x-kubernetes-preserve-unknown-fields: true
@@ -122,7 +155,8 @@ spec:
             properties:
               bedrockOperators:
                 items:
-                  description: BedrockOperator maintains a list of bedrock operators
+                  description: BedrockOperator describes a list of foundational services'
+                    operators currently installed for this tenant.
                   properties:
                     installPlanName:
                       type: string
@@ -139,38 +173,68 @@ spec:
                   type: object
                 type: array
               configStatus:
+                description: ConfigStatus describes various configuration currently
+                  applied onto the foundational services installer.
                 properties:
                   catalogName:
+                    description: CatalogName is the name of the CatalogSource foundational
+                      services is using
                     type: string
                   catalogNamespace:
+                    description: CatalogNamespace is the namesapce of the CatalogSource
                     type: string
                   configurable:
+                    description: Configurable indicates whether this CommonService
+                      CR is the one that can that can be used to configure the foundational
+                      services' installer. Other CommonService CRs configurations
+                      will not take effect, except for sizing
                     type: boolean
                   operatorDeployed:
+                    description: OperatorDeployed indicates whether the OperandRegistry
+                      has been created or not.
                     type: boolean
                   operatorNamespace:
+                    description: OperatorNamespace is the namespace of where the foundational
+                      services' operators will be installed in.
                     type: string
                   servicesDeployed:
+                    description: ServicesDeployed indicates whether the OperandConfig
+                      has been created or not.
                     type: boolean
                   servicesNamespace:
+                    description: ServicesNamespace is the namespace where the foundational
+                      services' operands will be created in.
                     type: string
                   topologyConfigurableCRs:
+                    description: TopologyConfigurableCRs describes the configurable
+                      CommonService CR
                     items:
                       properties:
                         apiVersion:
+                          description: ApiVersion is the api version of the configurable
+                            CommonService CR
                           type: string
                         kind:
+                          description: Kind is the kind of the configurable CommonService
+                            CR
                           type: string
                         namespace:
+                          description: Namespace is the namespace of the configurable
+                            CommonService CR
                           type: string
                         objectName:
+                          description: ObjectName is the name of the configurable
+                            CommonService CR
                           type: string
                       type: object
                     type: array
                 type: object
               overallStatus:
+                description: OverallStatus describes whether the Installation for
+                  the foundational services has succeeded or not
                 type: string
               phase:
+                description: Phase describes the phase of the overall installation
                 type: string
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -52,5 +52,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - commonservice
+    - commonservices
   sideEffects: None

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -52,5 +52,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - commonservices
+    - commonservice
   sideEffects: None


### PR DESCRIPTION
Can run `make manifests` and `make bundle-manifests` from now on to properly generate manifests/bundle (except need to revert the preserve-unknown-fields` change that happens)