### PR TITLE
Update info statements

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -207,7 +207,7 @@ function collect_data() {
     cs_operator_sourceNamespace=$(${OC} get subscription.operators.coreos.com ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.sourceNamespace") 
     info "sourceNamespace:${cs_operator_sourceNamespace}"
     cs_operator_installPlanApproval=$(${OC} get subscription.operators.coreos.com ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.installPlanApproval") 
-    info "sourceNamespace:${cs_operator_installPlanApproval}"
+    info "installPlanApproval:${cs_operator_installPlanApproval}"
     catalog_source=$(${OC} get subscription.operators.coreos.com ibm-common-service-operator -n ${master_ns} -o yaml | yq ".spec.source")
     info "catalog_source:${catalog_source}"
 
@@ -394,7 +394,7 @@ function cleanupCSOperators(){
             ${YQ} -i '.spec.installPlanApproval = "'${cs_operator_installPlanApproval}'"' tmp.yaml || error "Could not replace installPlanApproval for CS operator subscription in namespace ${namespace}"
             ${YQ} -i 'del(.metadata.creationTimestamp) | del(.metadata.managedFields) | del(.metadata.resourceVersion) | del(.metadata.uid) | del(.status)' tmp.yaml || error "Failed to remove metadata fields from temp cs operator yaml for namespace ${namespace}."
             ${OC} apply -f tmp.yaml || error "Failed to apply catalogsource and channel changes to cs operator subscription in namespace ${namespace}."
-            info "Common Service Operator Subscription in namespace ${namespace} updated to use catalog source ${catalog_source} and channel ${cs_operator_channel}."
+            info "Common Service Operator Subscription in namespace ${namespace} updated to use catalog source ${catalog_source}, channel ${cs_operator_channel}, sourceNamespace ${cs_operator_sourceNamespace}, and installPlanApproval ${cs_operator_installPlanApproval}."
         else
             info "No Common Service Operator in namespace ${namespace}. Moving on..."
         fi


### PR DESCRIPTION
Accidentally made the key changes directly to scripts-dev here https://github.com/IBM/ibm-common-service-operator/commit/8f063eec349eb9c0948aad61ad9dfaebaecb9199. Made some additional changes to the info statements in this pr.

I can revert these changes and reopen this pr if that works better.

Testing:
- setup LTSR cluster ready for conversion to multi instance
- change installplanapproval value to manual in cs operator sub
- run conversion script, verify completion, look for info statement output from this pr
- verify cs sub in new cs instance has matching installplanapproval value (manual)