### PR TITLE
introduce initMongoDB into Authentication CR

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -232,7 +232,6 @@ spec:
       authentication:
         config:
           onPremMultipleDeploy: {{ .OnPremMultiEnable }}
-      policydecision: {}
       operandBindInfo: 
         operand: ibm-im-operator
       operandRequest:
@@ -246,7 +245,6 @@ spec:
       authentication:
         config:
           onPremMultipleDeploy: {{ .OnPremMultiEnable }}
-      policydecision: {}
       operandBindInfo: 
         operand: ibm-im-operator
       operandRequest:
@@ -260,7 +258,6 @@ spec:
       authentication:
         config:
           onPremMultipleDeploy: {{ .OnPremMultiEnable }}
-      policydecision: {}
       operandBindInfo: 
         operand: ibm-im-operator
       operandRequest:
@@ -709,7 +706,6 @@ spec:
       authentication:
         config:
           onPremMultipleDeploy: {{ .OnPremMultiEnable }}
-      policydecision: {}
       operandBindInfo:  
         operand: ibm-im-operator
       operandRequest: 
@@ -998,7 +994,6 @@ spec:
       authentication:
         config:
           onPremMultipleDeploy: {{ .OnPremMultiEnable }}
-      policydecision: {}
       operandBindInfo:
         operand: ibm-im-operator
         bindings: {}

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -311,6 +311,14 @@ const ConfigurationRules = `
           requests:
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
+      initMongodb:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
 - name: ibm-im-operator-v4.0
   spec:
     authentication:
@@ -350,6 +358,14 @@ const ConfigurationRules = `
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
       identityProvider:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      initMongodb:
         resources:
           limits:
             cpu: LARGEST_VALUE
@@ -403,6 +419,14 @@ const ConfigurationRules = `
           requests:
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
+      initMongodb:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
 - name: ibm-im-operator-v4.2
   spec:
     authentication:
@@ -442,6 +466,14 @@ const ConfigurationRules = `
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
       identityProvider:
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+      initMongodb:
         resources:
           limits:
             cpu: LARGEST_VALUE

--- a/testdata/actual.yaml
+++ b/testdata/actual.yaml
@@ -502,6 +502,18 @@
             }
           }
         },
+        "initMongodb": {
+          "resources": {
+            "limits": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          }
+        },
         "replicas": 3
       }
     }
@@ -567,6 +579,18 @@
             "requests": {
               "cpu": "570m",
               "memory": "210Mi"
+            }
+          }
+        },
+        "initMongodb": {
+          "resources": {
+            "limits": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
             }
           }
         },
@@ -638,6 +662,18 @@
             }
           }
         },
+        "initMongodb": {
+          "resources": {
+            "limits": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          }
+        },
         "replicas": 3
       }
     }
@@ -703,6 +739,18 @@
             "requests": {
               "cpu": "570m",
               "memory": "210Mi"
+            }
+          }
+        },
+        "initMongodb": {
+          "resources": {
+            "limits": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
             }
           }
         },

--- a/testdata/expected.yaml
+++ b/testdata/expected.yaml
@@ -502,6 +502,18 @@
             }
           }
         },
+        "initMongodb": {
+          "resources": {
+            "limits": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          }
+        },
         "replicas": 3
       }
     }
@@ -567,6 +579,18 @@
             "requests": {
               "cpu": "570m",
               "memory": "210Mi"
+            }
+          }
+        },
+        "initMongodb": {
+          "resources": {
+            "limits": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
             }
           }
         },
@@ -638,6 +662,18 @@
             }
           }
         },
+        "initMongodb": {
+          "resources": {
+            "limits": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          }
+        },
         "replicas": 3
       }
     }
@@ -703,6 +739,18 @@
             "requests": {
               "cpu": "570m",
               "memory": "210Mi"
+            }
+          }
+        },
+        "initMongodb": {
+          "resources": {
+            "limits": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
             }
           }
         },


### PR DESCRIPTION
issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/56920

- Introduced new entry `initMongoDB` into `Authentication` CR and update the corresponding size profile
- Removed `policydecision` CR from IM OperandConfig