### PR TITLE
Skip LS CatalogSource check when it's not enabled

### DIFF
--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -235,9 +235,13 @@ function check_singleton_catalogsource() {
         CM_SOURCE_NS="${CERT_MANAGER_NAMESPACE}"
         LIS_SOURCE_NS="${LICENSING_NAMESPACE}"
     fi
-    
-    local sources=("$CERT_MANAGER_SOURCE,$CM_SOURCE_NS,ibm-cert-manager-operator,$CERT_MANAGER_NAMESPACE,$CHANNEL" "$LICENSING_SOURCE,$LIS_SOURCE_NS,ibm-licensing-operator-app,$LICENSING_NAMESPACE,$CHANNEL")
-    
+
+    local sources=("$CERT_MANAGER_SOURCE,$CM_SOURCE_NS,ibm-cert-manager-operator,$CERT_MANAGER_NAMESPACE,$CHANNEL")
+
+    if [ $ENABLE_LICENSING -eq 1 ]; then
+        sources+=("$LICENSING_SOURCE,$LIS_SOURCE_NS,ibm-licensing-operator-app,$LICENSING_NAMESPACE,$CHANNEL")
+    fi
+  
     for source_info in "${sources[@]}"; do
 
         IFS="," read -r source source_ns pm operator_ns channel <<< "$source_info"


### PR DESCRIPTION
Skip Licensing Service CatalogSource check when `--enable-licensing` is not passed into the script.

### Test
```
./cp3pt0-deployment/setup_singleton.sh --license-accept -c v4.2

# Check singleton services CatalogSource...
[✔] CatalogSource ibm-cert-manager-catalog from openshift-marketplace CatalogSourceNamespace is available for ibm-cert-manager-operator in ibm-cert-manager namespace
# Installing cert-manager

[✗] There is a cert-manager Subscription already
```