### PR TITLE
Verify yq version in "convert_to_multi_instance.sh" script

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -51,6 +51,16 @@ function prereq() {
     which "${OC}" || error "Missing oc CLI"
     which "${YQ}" || error "Missing yq"
     
+    # Verify that yq is at least version 4.18.1
+    yq_minimum_version=4.18.1
+    # Get the user's yq version and remove any leading "v" character if present
+    yq_version=$("${YQ}" --version | awk '{print $NF}' | sed 's/^v//')
+
+    # Compare yq versions using sort
+    if [[ "$(printf '%s\n' "$yq_minimum_version" "$yq_version" | sort -V | head -n 1)" != "$yq_minimum_version" ]]; then
+        error "yq version $yq_version must be at least $yq_minimum_version or higher.\nInstructions for installing/upgrading yq are available here: https://github.com/marketplace/actions/yq-portable-yaml-processor"
+    fi
+
     if [[ -z $master_ns ]]; then
         error "Please specify original cs namespace."
     fi


### PR DESCRIPTION
Set and verify minimum *yq* version at 4.18.1 as this is the earliest version that supports the *yq* syntax in the script.

Prior to yq 4.18.1, example usage is as follows: 
`echo "yamlData: value" | yq e .yamlData`

From *yq* 4.18.1 and onwards "e" (short for eval) became the default command. This matches the usage in the script where "e" (eval) has been assumed to be the default command.

*yq* 4.18.1 release notes: https://github.com/mikefarah/yq/releases/tag/v4.18.1

Fixes #1445 