### PR TITLE
delete cs ca cert secret

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1295,7 +1295,7 @@ func (b *Bootstrap) ConfigCertManagerOperandManagedByOperator(ctx context.Contex
 		client.MatchingLabels(
 			map[string]string{constant.CsManagedLabel: "true"}),
 	}
-
+	// Delete idle Cert Manager CRs which are managed by CS operator, but not in ServicesNamespace
 	certsList := b.ListCerts(ctx, opts...)
 	if certsList != nil {
 		for _, cert := range certsList.Items {
@@ -1304,12 +1304,13 @@ func (b *Bootstrap) ConfigCertManagerOperandManagedByOperator(ctx context.Contex
 					klog.Errorf("Failed to delete idle Cert Manager Certificate %s/%s which is managed by CS operator, but not in ServicesNamespace %s", cert.GetNamespace(), cert.GetName(), b.CSData.ServicesNs)
 					return err
 				}
-				klog.Infof("Delete idle Cert Manager Certificate %s/%s which is managed by CS operator, but not in ServicesNamespace %s", cert.GetNamespace(), cert.GetName(), b.CSData.ServicesNs)
+				klog.Infof("Deleted idle Cert Manager Certificate %s/%s which is managed by CS operator, but not in ServicesNamespace %s", cert.GetNamespace(), cert.GetName(), b.CSData.ServicesNs)
 
 			}
 		}
 	}
 
+	// Delete idle Cert Manager CRs which are managed by CS operator, but not in ServicesNamespace
 	issuerList := b.ListIssuer(ctx, opts...)
 	if issuerList != nil {
 		for _, issuer := range issuerList.Items {
@@ -1318,7 +1319,29 @@ func (b *Bootstrap) ConfigCertManagerOperandManagedByOperator(ctx context.Contex
 					klog.Errorf("Failed to delete idle Cert Manager Issuer %s/%s which is managed by CS operator, but not in ServicesNamespace %s", issuer.GetNamespace(), issuer.GetName(), b.CSData.ServicesNs)
 					return err
 				}
-				klog.Infof("Delete idle Cert Manager Issuer %s/%s which is managed by CS operator, but not in ServicesNamespace %s", issuer.GetNamespace(), issuer.GetName(), b.CSData.ServicesNs)
+				klog.Infof("Deleted idle Cert Manager Issuer %s/%s which is managed by CS operator, but not in ServicesNamespace %s", issuer.GetNamespace(), issuer.GetName(), b.CSData.ServicesNs)
+			}
+		}
+	}
+
+	watchNamespaceList := strings.Split(b.CSData.WatchNamespaces, ",")
+	secretName := "cs-ca-certificate-secret"
+	if len(watchNamespaceList) > 1 {
+		for _, watchNamespace := range watchNamespaceList {
+			secret := &corev1.Secret{}
+			err := b.Client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: watchNamespace}, secret)
+			if err != nil && !errors.IsNotFound(err) {
+				return nil
+			} else if errors.IsNotFound(err) {
+				continue
+			} else {
+				if watchNamespace != b.CSData.ServicesNs {
+					if err := b.Client.Delete(ctx, secret); err != nil {
+						klog.Errorf("Failed to delete cs ca certificate secret %s/%s not in ServicesNamespace %s", secret.GetNamespace(), secret.GetName(), b.CSData.ServicesNs)
+						return err
+					}
+					klog.Infof("Deleted cs ca certificate secret %s/%s not in ServicesNamespace %s", secret.GetNamespace(), secret.GetName(), b.CSData.ServicesNs)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
for issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/58293
Testing image: quay.io/yuchen_shen/cs_operator:scope_handling

When the first time to deploy CP3 in the cluster, by default servicesNamespace is the same as operatorNamespace, `cs-ca-certificate-secret` secret will be generated in that tmp serivcesNamespace.
After servicesNamespace is changed, this resource should be cleaned up properly and create under the new serivcesNamespace

#### Verify

- Using setup_tenant script to deploy a CP3 (could choose Topology B with 2 different tethered ns, and same ns for services ns and operator ns)
- apply the testing image, change imagePullPolicy to `Always`
- run setuo_tenant.sh again with a new ns for ServicesNamespace
- Observation results: `cs-ca-certificate-secret` secret in original services ns are deleted and create a new one under new services ns.