### PR TITLE
Add Kind Certificate as NativeAPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CONTROLLER_GEN ?= $(shell which controller-gen)
 KUSTOMIZE ?= $(shell which kustomize)
 YQ_VERSION=v4.27.3
 KUSTOMIZE_VERSION=v3.8.7
-OPERATOR_SDK_VERSION=v1.24.0
+OPERATOR_SDK_VERSION=v1.31.0
 CONTROLLER_TOOLS_VERSION ?= v0.6.1
 
 CSV_PATH=bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-08-24T20:55:01Z"
+    createdAt: "2023-09-05T14:38:17Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -311,8 +311,8 @@ spec:
                         memory: 512Mi
                       requests:
                         cpu: 100m
-                        memory: 200Mi
                         ephemeral-storage: 256Mi
+                        memory: 200Mi
                     securityContext:
                       allowPrivilegeEscalation: false
                       capabilities:
@@ -474,6 +474,10 @@ spec:
       name: IBM Support
   maturity: alpha
   minKubeVersion: 1.19.0
+  nativeAPIs:
+    - group: cert-manager.io
+      kind: Certificate
+      version: v1
   provider:
     name: IBM
   version: 4.2.0
@@ -513,7 +517,7 @@ spec:
             - CREATE
             - UPDATE
           resources:
-            - commonservices
+            - commonservice
       sideEffects: None
       targetPort: 9443
       type: ValidatingAdmissionWebhook

--- a/bundle/manifests/operator.ibm.com_commonservices.yaml
+++ b/bundle/manifests/operator.ibm.com_commonservices.yaml
@@ -21,7 +21,13 @@ spec:
   - name: v3
     schema:
       openAPIV3Schema:
-        description: CommonService is the Schema for the commonservices API
+        description: CommonService is the Schema for the commonservices API. This
+          API is used to configure general foundational services configurations, such
+          as sizing, catalogsource, etc. See description of fields for more details.
+          An instance of this CRD is automatically created by the ibm-common-service-operator
+          upon installation to trigger the installation of critical installer components
+          such as operand-deployment-lifecycle-manager (ODLM), which is required to
+          further install other services from foundational services, such as IM.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -39,12 +45,20 @@ spec:
             description: CommonServiceSpec defines the desired state of CommonService
             properties:
               BYOCACertificate:
+                description: BYOCACertificate enables the option to replace the cs-ca-certificate
+                  with your own CA certificate
                 type: boolean
               catalogName:
+                description: CatalogName is the name of the CatalogSource that will
+                  be used for ODLM and other services in foundational services
                 type: string
               catalogNamespace:
+                description: CatalogNamespace is the namespace of the CatalogSource
+                  that will be used for ODLM and other services in foundational services
                 type: string
               defaultAdminUser:
+                description: DefalutAdminUser is the name of the default admin user
+                  for foundational services IM, default is cpadmin
                 type: string
               features:
                 description: Features defines the configurations of Cloud Pak Services
@@ -65,10 +79,11 @@ spec:
                     type: object
                 type: object
               fipsEnabled:
+                description: FipsEnabled enables FIPS mode for foundational services
                 type: boolean
               installPlanApproval:
-                description: Approval is the user approval policy for an InstallPlan.
-                  It must be one of "Automatic" or "Manual".
+                description: 'InstallPlanApproval sets the approval mode for ODLM
+                  and other foundational services: Manual or Automatic'
                 type: string
               license:
                 description: LicenseList defines the license specification in CSV
@@ -90,12 +105,22 @@ spec:
               manualManagement:
                 type: boolean
               operatorNamespace:
+                description: OperatorNamespace describes the namespace where operators
+                  will be installed in such as ODLM. This will also apply to all services
+                  in foundational services, e.g. ODLM will install IM operator in
+                  this namespace
                 type: string
               profileController:
+                description: ProfileController enables turbonomic to automatically
+                  handle sizing of foundational services. Default value is 'default'
                 type: string
               routeHost:
+                description: RouteHost describes the hostname for the foundational
+                  services route, and can only be configured pre-installation of IM
                 type: string
               services:
+                description: Services describes the CPU, memory, and replica configuration
+                  for individual services in foundational services
                 items:
                   properties:
                     managementStrategy:
@@ -104,7 +129,7 @@ spec:
                       type: string
                     spec:
                       additionalProperties:
-                        x-kubernetes-preserve-unknown-fields: true
+                        type: object
                       type: object
                   required:
                   - name
@@ -112,10 +137,18 @@ spec:
                   type: object
                 type: array
               servicesNamespace:
+                description: ServicesNamespace describes the namespace where operands
+                  will be created in such as OperandRegistry and OperandConfig. This
+                  will also apply to all services in foundational services, e.g. IM
+                  will create operands in this namespace
                 type: string
               size:
+                description: 'Size describes the T-shirt size of foundational services:
+                  starterset, small, medium, or large'
                 type: string
               storageClass:
+                description: StorageClass describes the storage class to use for the
+                  foundational services PVCs
                 type: string
             type: object
             x-kubernetes-preserve-unknown-fields: true
@@ -124,7 +157,8 @@ spec:
             properties:
               bedrockOperators:
                 items:
-                  description: BedrockOperator maintains a list of bedrock operators
+                  description: BedrockOperator describes a list of foundational services'
+                    operators currently installed for this tenant.
                   properties:
                     installPlanName:
                       type: string
@@ -141,38 +175,68 @@ spec:
                   type: object
                 type: array
               configStatus:
+                description: ConfigStatus describes various configuration currently
+                  applied onto the foundational services installer.
                 properties:
                   catalogName:
+                    description: CatalogName is the name of the CatalogSource foundational
+                      services is using
                     type: string
                   catalogNamespace:
+                    description: CatalogNamespace is the namesapce of the CatalogSource
                     type: string
                   configurable:
+                    description: Configurable indicates whether this CommonService
+                      CR is the one that can be used to configure the foundational
+                      services' installer. Other CommonService CRs configurations
+                      will not take effect, except for sizing
                     type: boolean
                   operatorDeployed:
+                    description: OperatorDeployed indicates whether the OperandRegistry
+                      has been created or not.
                     type: boolean
                   operatorNamespace:
+                    description: OperatorNamespace is the namespace of where the foundational
+                      services' operators will be installed in.
                     type: string
                   servicesDeployed:
+                    description: ServicesDeployed indicates whether the OperandConfig
+                      has been created or not.
                     type: boolean
                   servicesNamespace:
+                    description: ServicesNamespace is the namespace where the foundational
+                      services' operands will be created in.
                     type: string
                   topologyConfigurableCRs:
+                    description: TopologyConfigurableCRs describes the configurable
+                      CommonService CR
                     items:
                       properties:
                         apiVersion:
+                          description: ApiVersion is the api version of the configurable
+                            CommonService CR
                           type: string
                         kind:
+                          description: Kind is the kind of the configurable CommonService
+                            CR
                           type: string
                         namespace:
+                          description: Namespace is the namespace of the configurable
+                            CommonService CR
                           type: string
                         objectName:
+                          description: ObjectName is the name of the configurable
+                            CommonService CR
                           type: string
                       type: object
                     type: array
                 type: object
               overallStatus:
+                description: OverallStatus describes whether the Installation for
+                  the foundational services has succeeded or not
                 type: string
               phase:
+                description: Phase describes the phase of the overall installation
                 type: string
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -185,7 +185,7 @@ spec:
                     type: string
                   configurable:
                     description: Configurable indicates whether this CommonService
-                      CR is the one that can that can be used to configure the foundational
+                      CR is the one that can be used to configure the foundational
                       services' installer. Other CommonService CRs configurations
                       will not take effect, except for sizing
                     type: boolean

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -179,6 +179,10 @@ spec:
     name: IBM Support
   maturity: alpha
   minKubeVersion: 1.19.0
+  nativeAPIs:
+  - group: cert-manager.io
+    kind: Certificate
+    version: v1
   provider:
     name: IBM
   relatedImages:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -52,5 +52,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - commonservices
+    - commonservice
   sideEffects: None


### PR DESCRIPTION
to block installation until Cert-Manager is present

Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57484

### How to test
1. Delete Cert-Manager Operator in the cluster if it is present in cluster
2. Check if Kind Certificate is present in cluster
```
oc get crd | grep certificates.cert-manager.io
```
3. Delete the Kind Certificate if it is present in cluster
```
oc delete crd certificates.cert-manager.io
```
4. Deploy new CatalogSource to install new CS operator
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: cs-test-operators
  namespace: openshift-marketplace
spec:
  displayName: TEST ONLY
  image: 'quay.io/daniel_fan/common-service-operator-catalog:b1686ef4-dirty'
  publisher: IBM
  sourceType: grpc
  updateStrategy:
    registryPoll:
      interval: 45m
```
5. Create new Namespace and create OperatorGroup
```
kind: Project
apiVersion: project.openshift.io/v1
metadata:
  name: native-api-test
---
apiVersion: operators.coreos.com/v1
kind: OperatorGroup
metadata:
  name: native-api-test
  namespace: native-api-test
spec:
  targetNamespaces:
    - native-api-test
```
5. Create CS operator subscription to deploy it from new CatalogSource
```
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: ibm-common-service-operator
  namespace: native-api-test
spec:
  channel: v4.2
  installPlanApproval: Automatic
  name: ibm-common-service-operator
  source: cs-test-operators
  sourceNamespace: openshift-marketplace
```
6. Observe that CS operator CSV is in `Pending` Status as expected because `Certificate` API is unavailable
<img width="1601" alt="Screenshot 2023-09-05 at 11 01 51 AM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/5d1bd35b-74de-4028-b415-87a241b7029c">

- We could also see following info from operator CSV yaml file

<img width="732" alt="Screenshot 2023-09-05 at 11 06 40 AM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/fd3de7c3-0355-4d17-8eeb-5cd89e82a128">



7. Install Cert-Manager from OperatorHub - either Community/Red Hat or IBM Cert-Manager would work
<img width="594" alt="Screenshot 2023-09-05 at 11 07 51 AM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/75a6f16b-8383-46ee-b512-b728c079eddb">


9. CS operator CSV goes from `Pending` status to `Succeed` after Cert-Manager is installed
<img width="1601" alt="Screenshot 2023-09-05 at 11 15 33 AM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/8426f885-3bae-483d-a1f6-1bd6c3493699">


