### PR TITLE
Fix make run by disabling webhook server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ build: ## Build manager binary
 	go build -o bin/manager main.go
 
 run: generate code-fmt code-vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
-	OPERATOR_NAMESPACE=ibm-common-services OPERATOR_NAME=ibm-common-service-operator go run ./main.go -v=2
+	ENABLE_WEBHOOKS=false OPERATOR_NAMESPACE="$${OPERATOR_NAMESPACE:-ibm-common-services}" OPERATOR_NAME=ibm-common-service-operator go run ./main.go -v=2
 
 install: manifests ## Install CRDs into a cluster
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -

--- a/main.go
+++ b/main.go
@@ -195,22 +195,24 @@ func main() {
 	}
 
 	// Start up the webhook server
-	if err = (&commonservicewebhook.Defaulter{
-		Client:    mgr.GetClient(),
-		Reader:    mgr.GetAPIReader(),
-		IsDormant: operatorNs != cpfsNs,
-	}).SetupWebhookWithManager(mgr); err != nil {
-		klog.Errorf("Unable to create CommonService webhook: %v", err)
-		os.Exit(1)
-	}
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err = (&commonservicewebhook.Defaulter{
+			Client:    mgr.GetClient(),
+			Reader:    mgr.GetAPIReader(),
+			IsDormant: operatorNs != cpfsNs,
+		}).SetupWebhookWithManager(mgr); err != nil {
+			klog.Errorf("Unable to create CommonService webhook: %v", err)
+			os.Exit(1)
+		}
 
-	if err = (&operandrequestwebhook.Defaulter{
-		Client:    mgr.GetClient(),
-		Reader:    mgr.GetAPIReader(),
-		IsDormant: operatorNs != cpfsNs,
-	}).SetupWebhookWithManager(mgr); err != nil {
-		klog.Errorf("Unable to create OperandRequest webhook: %v", err)
-		os.Exit(1)
+		if err = (&operandrequestwebhook.Defaulter{
+			Client:    mgr.GetClient(),
+			Reader:    mgr.GetAPIReader(),
+			IsDormant: operatorNs != cpfsNs,
+		}).SetupWebhookWithManager(mgr); err != nil {
+			klog.Errorf("Unable to create OperandRequest webhook: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {


### PR DESCRIPTION
make run currently does not work because there is no webhook certificate in the tmp dir. This stops the webhook server from starting when using make run, because when testing the operator locally the k8s api server won't be configured to point to your local server anyway.