### PR TITLE
Enhancement for performance and user readiness

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -265,9 +265,9 @@ function wait_for_cscr_status(){
     local retries=20
     local sleep_time=6
     local total_time_mins=$(( sleep_time * retries / 60))
-    local wait_message="Waiting for CommonService ${name} in ${namespace} to be ready"
-    local success_message="CommonService in ${namespace} is succeeded"
-    local error_message="Timeout after ${total_time_mins} minutes waiting for CommonService in ${namespace} to be ready"
+    local wait_message="Waiting for CommonService CR ${name} in ${namespace} to be ready"
+    local success_message="CommonService CR in ${namespace} is in Succeeded Phase"
+    local error_message="Timeout after ${total_time_mins} minutes waiting for CommonService CR in ${namespace} to be ready"
  
     wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
 }

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -624,16 +624,14 @@ EOF
     
         # Check if the patch was successful
         if [[ $? -eq 0 ]]; then
-            checkOperatorNS=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.operatorNamespace=="'${OPERATOR_NS}'"')
-            checkServicesNS=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.servicesNamespace=="'${SERVICES_NS}'"')
-            if [ $checkOperatorNS ] && [ $checkServicesNS ]; then
+            operator_ns_in_cr=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.operatorNamespace')
+            services_ns_in_cr=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.servicesNamespace')
+            if [[ "$operator_ns_in_cr" == "$OPERATOR_NS" ]] && [[ "$services_ns_in_cr" == "$SERVICES_NS" ]]; then
                 success "Successfully patched CommonService CR in ${OPERATOR_NS}"
                 break
             else
-                operatorNSinCR=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.operatorNamespace')
-                servicesNSinCR=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | yq '.spec.servicesNamespace')
-                warning "OperatorNamespace in CommonService cr should be ${OPERATOR_NS}, but it is ${operatorNSinCR}"
-                warning "ServicesNamespace in CommonService cr should be ${SERVICES_NS}, but it is ${servicesNSinCR}"
+                warning "Expected OperatorNamespace is ${OPERATOR_NS}, but existing value is ${operator_ns_in_cr} in CommonService CR, retry it in ${delay} seconds..."
+                warning "Expected ServicesNamespace is ${SERVICES_NS}, but existing value is ${services_ns_in_cr} in CommonService CR, retry it in ${delay} seconds..."
                 retries=$((retries-1))
             fi
         else


### PR DESCRIPTION
- Reduce the number of `oc get` command to relief workload on k8s apiServer
- Update log information to convey more accurate info

Test result
```
> ./cp3pt0-deployment/setup_tenant.sh --operator-namespace cp4ba-operator-3 --services-namespace cp4ba-service-3 --license-accept -c v4.2
...
commonservice.operator.ibm.com/common-service unchanged
[✔] Successfully patched CommonService CR in cp4ba-operator-3

...
[INFO] Waiting for CommonService CR common-service in cp4ba-operator-3 to be ready
[✔] CommonService CR in cp4ba-operator-3 is in Succeeded Phase
```