### PR TITLE
Not allow setting tethered and excluded ns for all namespace mode upgrade

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -311,16 +311,24 @@ function determine_topology() {
         fi
     fi
 
+    # if nss is empty, nss_count is not greater than 1 and services namespace is different operator namespace, then it is a all namespaces topology
+    if [[ $is_all_ns -eq 1 ]] && [[ "$SERVICES_NS" != "$OPERATOR_NS" ]]; then
+        IS_NOT_COMPLEX_TOPOLOGY=1
+        warning "It is all namespaces topology\n"
+        # TETHERED_NS or EXCLUDED_NS is not allowed in all namespaces topology
+        if [[ "$TETHERED_NS" != "" ]]; then
+            error "--tethered-namespaces is not allowed in all namespaces topology\n"
+        fi
+        if [[ "$EXCLUDED_NS" != "" ]]; then
+            error "--excluded-namespaces is not allowed in all namespaces topology\n"
+        fi
+        return
+    fi
+
     # if nss_count is not greater than 1 and services namespace is the same as operator namespace, then it is a simple topology
     if [[ "$SERVICES_NS" == "$OPERATOR_NS" || "$SERVICES_NS" == "" ]] && [[ "$TETHERED_NS" == "" ]] && [[ "$EXCLUDED_NS" == "" ]]; then
         IS_NOT_COMPLEX_TOPOLOGY=1
-        warning "It is simple topology or all namespaces topology\n"
-        return
-    fi
-    # if nss is empty, nss_count is not greater than 1 and services namespace is different operator namespace, then it is a all namespaces topology
-    if [[ $is_all_ns -eq 1 ]] && [[ "$SERVICES_NS" != "$OPERATOR_NS" ]] && [[ "$TETHERED_NS" == "" ]] && [[ "$EXCLUDED_NS" == "" ]]; then
-        IS_NOT_COMPLEX_TOPOLOGY=1
-        warning "It is all namespaces topology\n"
+        warning "It is simple namespace topology\n"
         return
     fi
 }


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/59687

This is the enhancement on `setup_tenant.sh` for all namespaces upgrade. When it is All Namespaces Upgrade, users are NOT allowed to configure either `--tethered-namespaces` or `--excluded-namespaces`

## How to test
1. Install a old version of CS v4.0 or v4.1 in `openshift-operators` namespace
2. Execute `setup_tenant.sh` to trigger an upgrade to `v4.2`.
- Error path with `--tethered-namespaces` specified
  ```
  > ./cp3pt0-deployment/setup_tenant.sh --operator-namespace openshift-operators --license-accept -c v4.2 --tethered-namespaces cp4i
  
  # Start to validate the parameters passed into script... 
  [✔] oc command available
  [✔] yq command available
  [✔] oc command logged in as kube:admin
  [✔] Channel v4.2 is valid
  [INFO] ibm-common-service-operator subscription exists, it is upgrade scenario
  
  [✗] It is all namespaces topology
  
  [✘] --tethered-namespaces is not allowed in all namespaces topology
  ```
- Error path with `--excluded-namespaces` specified
    ```
  > ./cp3pt0-deployment/setup_tenant.sh --operator-namespace openshift-operators --license-accept -c v4.2 --excluded-namespaces cp4i
  
  # Start to validate the parameters passed into script... 
  [✔] oc command available
  [✔] yq command available
  [✔] oc command logged in as kube:admin
  [✔] Channel v4.2 is valid
  [INFO] ibm-common-service-operator subscription exists, it is upgrade scenario
  
  [✗] It is all namespaces topology
  
  [✘] --excluded-namespaces is not allowed in all namespaces topology

- Happy path with only `--operator-namespace` specified
  ```
  ./cp3pt0-deployment/setup_tenant.sh --operator-namespace openshift-operators --license-accept -c v4.2                          
  
  # Start to validate the parameters passed into script... 
  [✔] oc command available
  [✔] yq command available
  [✔] oc command logged in as kube:admin
  [✔] Channel v4.2 is valid
  [INFO] ibm-common-service-operator subscription exists, it is upgrade scenario
  
  [✗] It is all namespaces topology
  
  [✔] Profile size is valid.
  # Check Foundational services CatalogSource...
  [✔] CatalogSource opencloud-operators from openshift-marketplace CatalogSourceNamespace is available for ibm-common-service-operator in openshift-operators namespace
  
  # Checking whether Namespace openshift-operators exist...
  [✔] Namespace openshift-operators already exists. Skip creating
  
  # Checking whether Namespace ibm-common-services exist...
  [✔] Namespace ibm-common-services already exists. Skip creating
  
  # Checking whether OperatorGroup in openshift-operators exist...
  [✔] OperatorGroup already exists in openshift-operators. Skip creating
  
  #  Checking whether Cert Manager exist...
  [✔] Found only one Cert Manager exists in namespace openshift-operators
  
  [✗] NamespaceScope Configuration is not needed for simple or all namespaces topology, skip NamespaceScope setup
  ...
  # Accepting license for commonservice common-service in namespace openshift-operators...
  commonservice.operator.ibm.com/common-service patched
  [✔] License accepted for commonservice common-service
  
  [INFO] Waiting for CommonService CR common-service in openshift-operators to be ready
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (20 left)
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (19 left)
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (18 left)
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (17 left)
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (16 left)
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (15 left)
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (14 left)
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (13 left)
  [INFO] RETRYING: Waiting for CommonService CR common-service in openshift-operators to be ready (12 left)
  [✔] CommonService CR in openshift-operators is in Succeeded Phase
  ```