### PR TITLE
Adding watch verb to edb-license-role

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -879,6 +879,7 @@ spec:
             - get
             - list
             - delete
+            - watch
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         name: edb-license-rolebinding


### PR DESCRIPTION
https://github.com/kubernetes/kubectl/issues/1411

The kubectl binary was updated the `edb-postgres-license-provider` image; this new version of kubectl lists and watches resources after deletion; before it just listed them. So we need additional rbac for the role.