### PR TITLE
changing readiness probe config to solve the failures on cs pod

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-09-05T14:38:17Z"
+    createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -302,9 +302,9 @@ spec:
                       httpGet:
                         path: /readyz
                         port: 8081
-                      initialDelaySeconds: 3
+                      initialDelaySeconds: 5
                       periodSeconds: 20
-                      timeoutSeconds: 3
+                      timeoutSeconds: 20
                     resources:
                       limits:
                         cpu: 500m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -45,8 +45,8 @@ spec:
           httpGet:
             path: /readyz
             port: 8081
-          initialDelaySeconds: 3
-          timeoutSeconds: 3
+          initialDelaySeconds: 5
+          timeoutSeconds: 20
           periodSeconds: 20
           failureThreshold: 10
         livenessProbe:


### PR DESCRIPTION
fix for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60199

#### Kubernetes Readiness probe failed errors resolved link:

1. connection refused: https://stackoverflow.com/questions/48540929/kubernetes-readiness-probe-failed-error
2. context deadline exceeded (Client.Timeout exceeded while awaiting headers): https://stackoverflow.com/questions/70602906/kubernetes-pods-probe-failed-client-timeout-exceeded-while-awaiting-headers

#### Probe configuration
field definition: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes

