### PR TITLE
enable --yq option in setup_singleton.sh

### DIFF
--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -84,6 +84,10 @@ function parse_arguments() {
             shift
             OC=$1
             ;;
+        --yq)
+            shift
+            YQ=$1
+            ;;
         --operator-namespace)
             shift
             OPERATOR_NS=$1


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60328
When run `setup_singleton.sh` script with `--yq`, `--yq` dose not work and still find default yq in $PATH.

How to test
- Execute the script wth `--yq` parameter specified
```
./cp3pt0-deployment/setup_singleton.sh --license-accept -c v4.2 --enable-licensing --yq ./bin/yq
[✔] oc command available
[✔] ./bin/yq command available

# test with echo "$YQ"
./bin/yq
# test with "eval "$YQ --version"
yq (https://github.com/mikefarah/yq/) version v4.35.1

[✔] oc command logged in as kube:admin
[✔] Channel v4.2 is valid
```