### PR TITLE
add plural for CS CR in webhook configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21.1-bullseye as builder
+FROM docker.io/golang:1.21.1-bullseye as builder
 ARG GOARCH
 
 WORKDIR /workspace

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2020-10-19T21:38:33Z"
+    createdAt: "2023-09-13T16:10:36Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -517,7 +517,7 @@ spec:
             - CREATE
             - UPDATE
           resources:
-            - commonservice
+            - commonservices
       sideEffects: None
       targetPort: 9443
       type: ValidatingAdmissionWebhook

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -52,5 +52,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - commonservice
+    - commonservices
   sideEffects: None

--- a/controllers/webhooks/commonservice/validatingwebhook.go
+++ b/controllers/webhooks/commonservice/validatingwebhook.go
@@ -37,7 +37,7 @@ import (
 	"github.com/IBM/ibm-common-service-operator/controllers/constant"
 )
 
-// +kubebuilder:webhook:path=/validate-operator-ibm-com-v3-commonservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=operator.ibm.com,resources=commonservice,verbs=create;update,versions=v3,name=vcommonservice.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-operator-ibm-com-v3-commonservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=operator.ibm.com,resources=commonservices,verbs=create;update,versions=v3,name=vcommonservice.kb.io,admissionReviewVersions=v1
 
 // CommonServiceDefaulter points to correct ServiceNamespace
 type Defaulter struct {


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60354

How to test
We could verify the fix on existing daily build
1. Deploy CS 4.2 from daily build
2. Find the validating webhook configuration deployed by OLM
```
> oc get validatingwebhookconfiguration -l olm.owner=ibm-common-service-operator.v4.2.0,olm.owner.namespace=<operator-namespace>

NAME                         WEBHOOKS   AGE
vcommonservice.kb.io-qzhs7   1          4d22h
```
3. Edit this webhook configuration
```
oc edit validatingwebhookconfiguration vcommonservice.kb.io-qzhs7

rules:
      - operations:
          - CREATE
          - UPDATE
        apiGroups:
          - operator.ibm.com
        apiVersions:
          - v3
        resources:
          - commonservice --------> commonservices
        scope: '*'
    matchPolicy: Equivalent
```
4. Create a new CS CR in tenant scope
5. Verify the common service operator logs indicate following message
```
I0913 15:48:08.173611 1 validatingwebhook.go:52] Webhook is invoked by Commonservice simple-cloudpak/example-commonservice
```