### PR TITLE
config keycloak resources

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -189,6 +189,37 @@ spec:
 )
 
 const (
+	KeyCloakOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+spec:
+  operators:
+  - channel: fast
+    installPlanApproval: {{ .ApprovalMode }}
+    name: keycloak-operator
+    namespace: "{{ .CPFSNs }}"
+    packageName: keycloak-operator
+    scope: public
+    sourceName: community-operators
+    sourceNamespace: openshift-marketplace
+  - channel: stable
+    installPlanApproval: {{ .ApprovalMode }}
+    name: edb-keycloak
+    namespace: "{{ .CPFSNs }}"
+    packageName: cloud-native-postgresql
+    scope: public
+`
+)
+
+const (
 	MongoDBOpCon = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig
@@ -318,6 +349,126 @@ spec:
   - name: ibm-platformui-operator-v4.2
     spec:
       operandBindInfo: {}
+`
+)
+
+const (
+	KeyCloakOpCon = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+spec:
+  services:
+  - name: keycloak-operator
+    resources:
+      - apiVersion: operator.ibm.com/v1alpha1
+        data:
+          spec:
+            requests:
+              - operands:
+                  - name: edb-keycloak
+                registry: common-service
+                registryNamespace: {{ .ServicesNs }}
+        force: false
+        kind: OperandRequest
+        name: edb-keycloak-request
+      - apiVersion: route.openshift.io/v1
+        data:
+          port:
+            targetPort: 8443
+          spec:
+            tls:
+              termination: passthrough
+            to:
+              kind: Service
+              name: cs-keycloak-service
+            wildcardPolicy: None
+        force: false
+        kind: Route
+        name: keycloak
+      - apiVersion: operator.ibm.com/v1alpha1
+        data:
+          spec:
+            bindings:
+              public-keycloak-initial-admin:
+                secret: cs-keycloak-initial-admin
+            description: Binding information that should be accessible to Keycloak adopters
+            operand: keycloak-operator
+            registry: common-service
+            registryNamespace: {{ .ServicesNs }}
+        force: false
+        kind: OperandBindInfo
+        name: keycloak-bindinfo
+      - apiVersion: k8s.keycloak.org/v2alpha1
+        data:
+          spec:
+            db:
+              host: keycloak-edb-cluster-rw
+              passwordSecret:
+                key: password
+                name: keycloak-edb-cluster-app
+              usernameSecret:
+                key: username
+                name: keycloak-edb-cluster-app
+              vendor: postgres
+            hostname:
+              strict: false
+            http:
+              tlsSecret: cs-ca-certificate-secret
+            ingress:
+              className: openshift-default
+              enabled: true
+            instances: 1
+            unsupported:
+              podTemplate:
+                spec:
+                  containers:
+                    - resources:
+                        limits:
+                          cpu: 1000m
+                          memory: 1Gi
+                        requests:
+                          cpu: 1000m
+                          memory: 1Gi
+        force: false
+        kind: Keycloak
+        name: cs-keycloak
+  - name: edb-keycloak
+    resources:
+      - apiVersion: postgresql.k8s.enterprisedb.io/v1
+        data:
+          spec:
+            bootstrap:
+              initdb:
+                database: keycloak
+                owner: app
+            imageName: >-
+              icr.io/cpopen/edb/postgresql:14.7@sha256:d2e21251c5b0e3a4a45bdef592f9293e258124793b529e622808dc010900b7ea
+            imagePullSecrets:
+              - name: ibm-entitlement-key
+            instances: 1
+            resources:
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+              requests:
+                cpu: 1000m
+                memory: 1Gi
+            logLevel: info
+            primaryUpdateStrategy: unsupervised
+            storage:
+              size: 1Gi
+            walStorage:
+              size: 1Gi
+        force: false
+        kind: Cluster
+        name: keycloak-edb-cluster
 `
 )
 
@@ -1128,139 +1279,6 @@ spec:
     spec:
       operandBindInfo: {}
 `
-
-const (
-	KeyCloakOpReg = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandRegistry
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
-spec:
-  operators:
-  - channel: fast
-    installPlanApproval: {{ .ApprovalMode }}
-    name: keycloak-operator
-    namespace: "{{ .CPFSNs }}"
-    packageName: keycloak-operator
-    scope: public
-    sourceName: community-operators
-    sourceNamespace: openshift-marketplace
-  - channel: stable
-    installPlanApproval: {{ .ApprovalMode }}
-    name: edb-keycloak
-    namespace: "{{ .CPFSNs }}"
-    packageName: cloud-native-postgresql
-    scope: public
-`
-)
-
-const (
-	KeyCloakOpCon = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandConfig
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-spec:
-  services:
-  - name: keycloak-operator
-    resources:
-      - apiVersion: operator.ibm.com/v1alpha1
-        data:
-          spec:
-            requests:
-              - operands:
-                  - name: edb-keycloak
-                registry: common-service
-                registryNamespace: {{ .ServicesNs }}
-        force: false
-        kind: OperandRequest
-        name: edb-keycloak-request
-      - apiVersion: route.openshift.io/v1
-        data:
-          port:
-            targetPort: 8443
-          spec:
-            tls:
-              termination: passthrough
-            to:
-              kind: Service
-              name: cs-keycloak-service
-            wildcardPolicy: None
-        force: false
-        kind: Route
-        name: keycloak
-      - apiVersion: operator.ibm.com/v1alpha1
-        data:
-          spec:
-            bindings:
-              public-keycloak-initial-admin:
-                secret: cs-keycloak-initial-admin
-            description: Binding information that should be accessible to Keycloak adopters
-            operand: keycloak-operator
-            registry: common-service
-            registryNamespace: {{ .ServicesNs }}
-        force: false
-        kind: OperandBindInfo
-        name: keycloak-bindinfo
-      - apiVersion: k8s.keycloak.org/v2alpha1
-        data:
-          spec:
-            db:
-              host: keycloak-edb-cluster-rw
-              passwordSecret:
-                key: password
-                name: keycloak-edb-cluster-app
-              usernameSecret:
-                key: username
-                name: keycloak-edb-cluster-app
-              vendor: postgres
-            hostname:
-              strict: false
-            http:
-              tlsSecret: cs-ca-certificate-secret
-            ingress:
-              className: openshift-default
-              enabled: true
-            instances: 1
-        force: false
-        kind: Keycloak
-        name: cs-keycloak
-  - name: edb-keycloak
-    resources:
-      - apiVersion: postgresql.k8s.enterprisedb.io/v1
-        data:
-          spec:
-            bootstrap:
-              initdb:
-                database: keycloak
-                owner: app
-            imageName: >-
-              icr.io/cpopen/edb/postgresql:14.7@sha256:d2e21251c5b0e3a4a45bdef592f9293e258124793b529e622808dc010900b7ea
-            imagePullSecrets:
-              - name: ibm-entitlement-key
-            instances: 1
-            logLevel: info
-            primaryUpdateStrategy: unsupervised
-            storage:
-              size: 1Gi
-            walStorage:
-              size: 1Gi
-        force: false
-        kind: Cluster
-        name: keycloak-edb-cluster
-`
-)
 
 const ODLMSubscription = `
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
issue requested: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60159
test image: quay.io/yuchen_shen/cs_operator:keycloak_config
could be check in `cs-keycloak-0` and `keycloak-edb-cluster-1` pods

- Unsupported field introduction of `KeyCloak` configuration: https://github.com/vmuzikar/keycloak/blob/f19b00bd7204f33e6bc3fc8b3775f2accee1777d/docs/guides/operator/advanced-configuration.adoc#unsupported-features
- `Cluster` resource configuration is the same as the example shows in: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes