### PR TITLE
Fix FIPS enablement in 4.x release

### DIFF
--- a/controllers/constant/fipsEnable.go
+++ b/controllers/constant/fipsEnable.go
@@ -30,4 +30,24 @@ const FipsEnabledTemplate = `
   spec:
     managementIngress:
       fipsEnabled: placeholder
+- name: ibm-im-operator
+  spec:
+    authentication:
+      config:
+        fipsEnabled: placeholder
+- name: ibm-im-operator-v4.0
+  spec:
+    authentication:
+      config:
+        fipsEnabled: placeholder
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      config:
+        fipsEnabled: placeholder
+- name: ibm-im-operator-v4.2
+  spec:
+    authentication:
+      config:
+        fipsEnabled: placeholder
 `

--- a/controllers/render_template.go
+++ b/controllers/render_template.go
@@ -74,19 +74,16 @@ func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured, i
 		newConfigs = append(newConfigs, multipleinstancesenabledConfig...)
 	}
 
-	// set fipsEnabled to false by default
-	fipsEnabled := false
 	// if there is a fipsEnabled field for overall
 	if enabled := cs.Object["spec"].(map[string]interface{})["fipsEnabled"]; enabled != nil {
 		klog.Info("Applying fips configuration")
-		fipsEnabled = enabled.(bool)
+		// update config for all three services
+		fipsEnabledConfig, err := convertStringToSlice(strings.ReplaceAll(constant.FipsEnabledTemplate, "placeholder", strconv.FormatBool(enabled.(bool))))
+		if err != nil {
+			return nil, nil, err
+		}
+		newConfigs = append(newConfigs, fipsEnabledConfig...)
 	}
-	// update config for all three services
-	fipsEnabledConfig, err := convertStringToSlice(strings.ReplaceAll(constant.FipsEnabledTemplate, "placeholder", strconv.FormatBool(fipsEnabled)))
-	if err != nil {
-		return nil, nil, err
-	}
-	newConfigs = append(newConfigs, fipsEnabledConfig...)
 
 	// Update storageclass for API Catalog
 	if features := cs.Object["spec"].(map[string]interface{})["features"]; features != nil {


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60244

### Context
When Common Service Operator composes the OperandConfig template, it merges different configurations from all CommonService CRs in the tenant scope
```
> oc get commonservice

NAME                    AGE
common-service          6d9h
example-commonservice   5d14h
```

For the FIPS enablement, the Common Service CR has a parameters to turn on or turn off FIPS enablement.
```
- apiVersion: operator.ibm.com/v3
  kind: CommonService
  metadata:
    name: example-commonservice
    namespace: configure-test
  spec:
    fipsEnabled: false(or true)
    size: starterset
```

### Root cause
For each Common Service CR, it has FIPS enablement turned off by default, meaning following three configurations are equivalent in CommonService CR
- `fipsEnabled: false`
- `fipsEnabled: nil`
- leave the field empty

Meanwhile, the boolean `false` value takes precedence over boolean `true` when common service operator is merging FIPS enablement configuration from different CS CRs, meaning
- if there is one `fipsEnabled: false`/`fipsEnabled: nil`/Empty `fipsEnabled` field, the OperandConfig will always have `fipsEnabled: false`
- If there are multiple CS CRs in the tenant scope, every CS CR has to explicitly define `fipsEnabled: true` to enable `fipsEnabled: true` in OperandConfig 

### Solution
Update the logic for Common Service CR
- it will have a neutral position when FIPS parameter is not defined or `nil`, it neither specifies `fipsEnabled: true` nor `fipsEnabled: false`.
- if there is at least one `fipsEnabled: true` and no `fipsEnabled: false`, then OperandConfig has `fipsEnabled: true`
- if there is at least one `fipsEnabled: false`, then OperandConfig has `fipsEnabled: false`

When there are multiple CS CRs in the tenant scope, user only needs to update one CS CR to enable FIPS, and leave other CS CRs with FIPS unspecified.
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
  namespace: configure-test
spec:
  license:
    accept: false
  operatorNamespace: configure-test
  servicesNamespace: configure-test
  size: starterset
---
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: example-commonservice
  namespace: configure-test
spec:
  fipsEnabled: true
```

### How to test
1. Install 4.2 daily build
2. Replace the image `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:dev` in CS operator CSV, and update ImagePullPolicy to `Always`
3. Apply two CS CRs with one `fipsEnabled: true`
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
  namespace: configure-test
spec:
  license:
    accept: false
  operatorNamespace: configure-test
  servicesNamespace: configure-test
  size: starterset
---
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: example-commonservice
  namespace: configure-test
spec:
  fipsEnabled: true
```
4. Check OperandConfig is `fips` enabled
```
oc get operandConfig common-service -n ibm-common-services -oyaml | grep fips
```