### PR TITLE
remove internal URLs in zen5 br ConfigMap

### DIFF
--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -112,8 +112,6 @@ data:
     # This is an internal component, bundled with an official IBM product.
     # Please refer to that particular license for additional information.
 
-    #steps copied from https://github.ibm.com/PrivateCloud-analytics/zen-dev-test-utils/blob/gh-pages/docs/zen-v5-br.md#21321-read-object-storage-connection-and-credentials
-
     #[2.2] Restore
     #[2.2.1] Set Zen namespace
     ZEN_NAMESPACE=$1 #should probably defualt this to zen with an optional parameter


### PR DESCRIPTION
- This is a fix for lint error `NoInternalURLs ` failed on travis: https://v3.travis.ibm.com/github/IBMPrivateCloud/charts/jobs/6194220#L568
- Introduction in Playbook: https://playbook.cloudpaklab.ibm.com/code-standards-linting/code-standards-libary/standards-index/nointernalurls/
- We have the same issue fixed before: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59196
- need to remove internal URLs: `github.ibm.com` in our scripts