### PR TITLE
fix yq path configuration in migrate_tenant.sh

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -64,10 +64,11 @@ function main() {
     # Scale down CS, ODLM and delete OperandReigsrty
     # It helps to prevent re-installing licensing and cert-manager services
     scale_down $OPERATOR_NS $SERVICES_NS $CHANNEL $SOURCE
-    local arguments=""
+    local arguments="--yq $YQ --oc $OC"
+
     # Migrate singleton services
     if [[ $ENABLE_LICENSING -eq 1 ]]; then
-        arguments+="--enable-licensing"
+        arguments+=" --enable-licensing"
     fi
 
     if [[ $ENABLE_PRIVATE_CATALOG -eq 1 ]]; then


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60328#issuecomment-63332984

`migrate_tenant.sh` does not pass `yq` path into `setup_singleton.sh` script

### How to test

Execute the script wth `--yq` parameter specified

```
./cp3pt0-deployment/migrate_tenant.sh --operator-namespace ibm-common-services --enable-licensing --license-accept -c v4.2 --yq ./bin/yq
...
# result from setup_singleton.sh
[✔] oc command available
[✔] ./bin/yq command available
[✔] oc command logged in as kube:admin
[✔] Channel v4.2 is valid
...
```