### PR TITLE
make sure script can run when restore namespace not specified

### DIFF
--- a/backup_restore_mongo/backup_restore_mongo.sh
+++ b/backup_restore_mongo/backup_restore_mongo.sh
@@ -87,7 +87,7 @@ function main() {
         refresh_auth_idp
     fi
     if [[ $cleanup == "true" ]]; then
-    cleanup
+        cleanup
     fi
 }
 

--- a/backup_restore_mongo/backup_restore_mongo.sh
+++ b/backup_restore_mongo/backup_restore_mongo.sh
@@ -87,7 +87,7 @@ function main() {
         refresh_auth_idp
     fi
     if [[ $cleanup == "true" ]]; then
-        cleanup
+    cleanup
     fi
 }
 


### PR DESCRIPTION
noticed while testing https://github.com/IBM/ibm-common-service-operator/pull/1503. These changes make it possible to run just the backup by itself without specifying a restore namespace