### PR TITLE
mapping between CS operator and Namespace Scope operator channel

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -387,7 +387,7 @@ function install_nss() {
     local cs_channel="${CHANNEL#v}"
     local nss_channel="${NSS_CHANNEL#v}"
 
-    # Check if CHANNEL_NUMERIC is greater than or equal to 4.2, if yes, use NSS channel as v4.2
+    # Check if cs_channel is less than nss_channel, if yes, let NSS channel be the same as CS channel
     if (( $(echo "$cs_channel < $nss_channel" | bc -l) )); then
         NSS_CHANNEL="$CHANNEL"
     fi
@@ -452,7 +452,7 @@ EOF
         new_ns_list=$(echo ${TETHERED_NS//,/ } ${SERVICES_NS} | xargs -n1 | sort -u | xargs)
     fi
     debug1 "List of namespaces for common-service NSS ${new_ns_list}"
-    
+
     # add the new namespaces from list of common-service NSS to namespaceMembers
     for n in ${new_ns_list}; do
         if [[ $n == $OPERATOR_NS ]]; then

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -14,6 +14,7 @@ OC=oc
 YQ=yq
 ENABLE_LICENSING=0
 CHANNEL="v4.2"
+NSS_CHANNEL="v4.2"
 SOURCE="opencloud-operators"
 SOURCE_NS="openshift-marketplace"
 OPERATOR_NS=""
@@ -382,15 +383,24 @@ function check_singleton_service() {
 function install_nss() {
     title "Checking whether Namespace Scope operator exist..."
 
+    # Extract the numeric part from the CHANNEL variable using parameter expansion
+    local cs_channel="${CHANNEL#v}"
+    local nss_channel="${NSS_CHANNEL#v}"
+
+    # Check if CHANNEL_NUMERIC is greater than or equal to 4.2, if yes, use NSS channel as v4.2
+    if (( $(echo "$cs_channel < $nss_channel" | bc -l) )); then
+        NSS_CHANNEL="$CHANNEL"
+    fi
+
     is_sub_exist "ibm-namespace-scope-operator" "$OPERATOR_NS"
     if [ $? -eq 0 ]; then
         warning "There is an ibm-namespace-scope-operator subscription already deployed\n"
         if [ $PREVIEW_MODE -eq 0 ]; then
-            update_operator "ibm-namespace-scope-operator" "$OPERATOR_NS" $CHANNEL $SOURCE $SOURCE_NS $INSTALL_MODE
-            wait_for_operator_upgrade $OPERATOR_NS "ibm-namespace-scope-operator" $CHANNEL $INSTALL_MODE
+            update_operator "ibm-namespace-scope-operator" "$OPERATOR_NS" $NSS_CHANNEL $SOURCE $SOURCE_NS $INSTALL_MODE
+            wait_for_operator_upgrade $OPERATOR_NS "ibm-namespace-scope-operator" $NSS_CHANNEL $INSTALL_MODE
         fi
     else
-        create_subscription "ibm-namespace-scope-operator" "$OPERATOR_NS" "$CHANNEL" "ibm-namespace-scope-operator" "${SOURCE}" "${SOURCE_NS}" "${INSTALL_MODE}"
+        create_subscription "ibm-namespace-scope-operator" "$OPERATOR_NS" "$NSS_CHANNEL" "ibm-namespace-scope-operator" "${SOURCE}" "${SOURCE_NS}" "${INSTALL_MODE}"
     fi
 
     if [ $PREVIEW_MODE -eq 0 ]; then


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60615

- If the user provides `v4.2` or a higher channel version when running the script, it will choose the NSS operator from the `v4.2` channel and select the CS operator from the `v4.2` channel or any version higher.
- Conversely, if the user specifies the parameter -c with `v4.1` or a lower version when executing the script, it will select the NSS operator from the same channel as the CS operator channel.