### PR TITLE
Install keycloak in serviceNs for All Ns mode

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -205,7 +205,7 @@ spec:
   - channel: fast
     installPlanApproval: {{ .ApprovalMode }}
     name: keycloak-operator
-    namespace: "{{ .CPFSNs }}"
+    namespace: "{{ .ServicesNs }}"
     packageName: keycloak-operator
     scope: public
     sourceName: community-operators


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60682

Always install KeyCloak Operator in Own namespace mode because KyeCloak operator does not support All namespace mode, and does not separation of operator and operand.

- When CPFS is installed in Own namespace mode, KeyCloak operator is installed in the same namespace as CPFS operator
- When CPFS is installed in All Namespaces mode, KeyCloak operator is installed as Own Namespace Mode in `servicesNamespace` which is typically `ibm-common-services` namespace.