### PR TITLE
enable leaf certificate for Keycloak

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -732,10 +732,12 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
 		constant.CSV3OperandConfig, err = constant.ConcatenateConfigs(constant.CSV3OperandConfig, con, b.CSData)
 		if err != nil {
 			klog.Errorf("failed to append CP3 services into OperandConfig: %v", err)
+			return err
 		}
 		constant.CSV3SaasOperandConfig, err = constant.ConcatenateConfigs(constant.CSV3SaasOperandConfig, con, b.CSData)
 		if err != nil {
 			klog.Errorf("failed to append CP3 services into SaaS OperandConfig: %v", err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
This task is used to address issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60688

1. It enables leaf certificate with dns name `cs-keycloak-service` for keycloak to secure the connection
2. This leaf certificate will be used to create a re-encrypted Route as well
3. It also refreshes KeyCloak CR with annotation because KeyCloak CR will not recover by itself when tls secret is missing.

### How to test
1. Deploy dev build CPFS as usual by creating common service operator subscription, wait for Common Service Operator and ODLM to be installed.

2. Delete existing OperandConfig `common-service` in this tenant

3. Replace the image in Common Service operator CSV to `quay.io/daniel_fan/common-service-operator-amd64:dev`, and set ImagePullPolicy to `Always`

4. Create OperandRequest to request keycloak-operator, waiting for KeyCloak to be installed

5. Check the following components
   - Verify `cs-keycloak-tls-secret` secret is generated
   - Verify `keycloak-setup-job` job is completed
   - Verify `keycloak` Route has field `.spec.tls.destinationCACertificate`
   - Verify URL in `keycloak` Route is accessible

6. Verify we are able to use TLS cert to secure the connection to KeyCloak
   - Create a pod to simulate the application
      ```yaml
      apiVersion: v1
      kind: Pod
      metadata:
        name: development-pod
      spec:
        containers:
        - name: development-container
          image: icr.io/cpopen/cpfs/cpfs-utils
          command: ["sleep"]
          args: ["infinity"]
          tty: true
        serviceAccountName: operand-deployment-lifecycle-manager
      ```
    - Get into container's terminal
       ```bash
       oc rsh deployment-pod 
       ```
    - In the container terminal, try to get the certificate and use this certificate to secure the connection. The command `curl` should not return any error.
       ```bash
       oc get secret cs-keycloak-tls-secret -o jsonpath='{.data.ca\.crt}' | base64 -d > /tmp/keycloak-svc.crt

       curl https://cs-keycloak-service.keycloak-cert.svc:8443 --cacert /tmp/keycloak-svc.crt
       ```