### PR TITLE
add necessary files for velero br on z

### DIFF
--- a/velero/backup/mongoDB/mongo-backup.sh
+++ b/velero/backup/mongoDB/mongo-backup.sh
@@ -1,39 +1,36 @@
 #!/bin/bash
 # Used by multi-namespace
-CONVERT=${1:-'false'}
-function msg() {
-  printf '%b\n' "$1"
-}
-
-function success() {
-  msg "\33[32m[✔] ${1}\33[0m"
-}
-function warning() {
-  msg "\33[33m[✗] ${1}\33[0m"
-}
-
-function error() {
-  msg "\33[31m[✘] ${1}\33[0m"
-  exit 1
-}
+CS_NAMESPACE=$1
+CONVERT=""
+if [[ ! -z $2 ]]; then
+  CONVERT=$2
+fi
+s390x="false"
+if [[ ! -z $3 ]]; then
+  s390x=$3
+fi
 
 function cleanup() {
   if [[ -z $CS_NAMESPACE ]]; then
     export CS_NAMESPACE=ibm-common-services
   fi
-  msg "[1] Cleaning up from previous backups..."
+  info "[1] Cleaning up from previous backups..."
   oc delete job mongodb-backup --ignore-not-found -n $CS_NAMESPACE
   pv=$(oc get pvc cs-mongodump -n $CS_NAMESPACE --no-headers=true 2>/dev/null | awk '{print $3 }')
   if [[ -n $pv ]]
   then
-    oc delete pvc cs-mongodump --ignore-not-found -n $CS_NAMESPACE
+    oc delete pvc cs-mongodump -n $CS_NAMESPACE --ignore-not-found --timeout=10s
+    if [ $? -ne 0 ]; then
+        info "Failed to delete pvc cs-mongodump, patching its finalizer to null..."
+        oc patch pvc cs-mongodump -n $CS_NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
+    fi
     oc delete pv $pv --ignore-not-found
   fi
   success "Cleanup Complete"
 }
 
 function backup_mongodb(){
-  msg "[3] Backing Up MongoDB"
+  info "[3] Backing Up MongoDB"
   #
   #  Get the storage class from the existing PVCs for use in creating the backup volume
   #
@@ -42,8 +39,8 @@ function backup_mongodb(){
   #STGCLASS=$(oc get pvc --no-headers=true mongodbdir-icp-mongodb-0 -n $CS_NAMESPACE | awk '{ print $6 }')
   STGCLASS=ibmc-block-retain-gold
   # Used by multi-namespace
-  if [[ $CONVERT != 'false' ]]; then
-    STGCLASS='backup-sc'
+  if [[ $CONVERT != "" ]]; then
+    STGCLASS=$CONVERT
   fi
   #
   # Backup MongoDB
@@ -55,7 +52,7 @@ metadata:
   name: cs-mongodump
   namespace: $CS_NAMESPACE
   labels:
-    foundationservices.cloudpak.ibm.com: data
+    foundationservices.cloudpak.ibm.com: mongo-data
 spec:
   accessModes:
   - ReadWriteOnce
@@ -68,8 +65,127 @@ EOF
   #
   # Start the backup
   #
-  msg "Starting backup"
-  oc apply -f mongodbbackup.yaml -n $CS_NAMESPACE
+  info "Starting backup"
+  ibm_mongodb_image=$(oc get pod icp-mongodb-0 -n $CS_NAMESPACE -o=jsonpath='{range .spec.containers[0]}{.image}{end}')
+  if [[ $s390x == "false" ]]; then
+    cat <<EOF | oc apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongodb-backup
+  namespace: $CS_NAMESPACE
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 20
+  template:
+    spec:
+      containers:
+      - name: cs-mongodb-backup
+        image: $ibm_mongodb_image
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongodump --oplog --out /dump/dump --host mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem"]
+        volumeMounts:
+        - mountPath: "/work-dir"
+          name: tmp-mongodb
+        - mountPath: "/dump"
+          name: mongodump
+        - mountPath: "/cred/mongo-certs"
+          name: icp-mongodb-client-cert
+        - mountPath: "/cred/cluster-ca"
+          name: cluster-ca-cert
+        env:
+          - name: ADMIN_USER
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: user
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: password
+      volumes:
+      - name: mongodump
+        persistentVolumeClaim:
+          claimName: cs-mongodump
+      - name: tmp-mongodb
+        emptyDir: {}
+      - name: icp-mongodb-client-cert
+        secret:
+          secretName: icp-mongodb-client-cert
+      - name: cluster-ca-cert
+        secret:
+          secretName: mongodb-root-ca-cert
+      restartPolicy: OnFailure
+EOF
+  else
+    scale_down
+    cat <<EOF | oc apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongodb-backup
+  namespace: $CS_NAMESPACE
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 20
+  template:
+    spec:
+      containers:
+      - name: cs-mongodb-backup
+        image: $ibm_mongodb_image
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongodump --oplog --out /dump/dump --host mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin"]
+        volumeMounts:
+        - mountPath: "/work-dir"
+          name: tmp-mongodb
+        - mountPath: "/dump"
+          name: mongodump
+        - mountPath: "/cred/mongo-certs"
+          name: icp-mongodb-client-cert
+        - mountPath: "/cred/cluster-ca"
+          name: cluster-ca-cert
+        env:
+          - name: ADMIN_USER
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: user
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: password
+      volumes:
+      - name: mongodump
+        persistentVolumeClaim:
+          claimName: cs-mongodump
+      - name: tmp-mongodb
+        emptyDir: {}
+      - name: icp-mongodb-client-cert
+        secret:
+          secretName: icp-mongodb-client-cert
+      - name: cluster-ca-cert
+        secret:
+          secretName: mongodb-root-ca-cert
+      restartPolicy: OnFailure
+EOF
+    scale_up
+  fi
   sleep 15s
 
   LOOK=$(oc get po --no-headers=true -n $CS_NAMESPACE | grep mongodb-backup | awk '{ print $1 }')
@@ -81,7 +197,7 @@ EOF
 function waitforpods() {
   index=0
   retries=60
-  msg "Waiting for $1 pod(s) to start ..."
+  info "Waiting for $1 pod(s) to start ..."
   while true; do
       [[ $index -eq $retries ]] && exit 1
       if [ -z $1 ]; then
@@ -99,6 +215,140 @@ function waitforpods() {
   else
     oc get pods --no-headers=true -n $2 | grep $1
   fi
+}
+
+function scale_up(){
+    info "Z cluster detected, be prepared for multiple restarts of mongo pods. This is expected behavior."
+    mongo_op_scaled_original=$(oc get deploy -n $CS_NAMESPACE | grep ibm-mongodb-operator | egrep '1/1' || echo false)
+    if [[ $mongo_op_scaled_original == "false" ]]; then
+        info "Mongo operator in $CS_NAMESPACE still scaled down, scaling up."
+        oc scale deploy -n $CS_NAMESPACE ibm-mongodb-operator --replicas=1
+        info "Wait for mongo operator to reconcile resources"
+        sleep 60
+        delete_mongo_pods "$CS_NAMESPACE"
+    fi
+    success "Mongo reset successfully."
+}
+
+function scale_down(){
+    info "Z cluster detected, be prepared for multiple restarts of mongo pods. This is expected behavior."
+    info "Scaling down MongoDB operator"
+    oc scale deploy -n $CS_NAMESPACE ibm-mongodb-operator --replicas=0
+    #get cache size value
+    cacheSizeGB=$(oc get cm icp-mongodb -n $CS_NAMESPACE -o yaml | grep cacheSizeGB | awk '{print $2}')
+
+    info "Editing configmap icp-mongodb"
+    cat << EOF | oc apply -n $CS_NAMESPACE -f -
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: icp-mongodb
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: icp-mongodb
+    app.kubernetes.io/managed-by: operator
+    app.kubernetes.io/name: icp-mongodb
+    app.kubernetes.io/part-of: common-services-cloud-pak
+    app.kubernetes.io/version: 4.0.12-build.3
+    release: mongodb
+data:
+  mongod.conf: |-
+    storage:
+      dbPath: /data/db
+      wiredTiger:
+        engineConfig:
+          cacheSizeGB: $cacheSizeGB
+    net:
+      bindIpAll: true
+      port: 27017
+      ssl:
+        mode: preferSSL
+        CAFile: /data/configdb/tls.crt
+        PEMKeyFile: /work-dir/mongo.pem
+    replication:
+      replSetName: rs0
+    # Uncomment for TLS support or keyfile access control without TLS
+    security:
+      authorization: enabled
+      keyFile: /data/configdb/key.txt
+EOF
+    delete_mongo_pods "$CS_NAMESPACE"
+    success "Mongo prepped for backup or restore successfully."
+}
+
+function delete_mongo_pods() {
+  local namespace=$1
+  local pods=$(oc get pods -n $namespace | grep icp-mongodb | awk '{print $1}' | tr "\n" " ")
+  for pod in $pods
+  do
+    info "Deleting pod $pod"
+    oc delete pod $pod -n $CS_NAMESPACE --ignore-not-found
+    local condition="oc get pod -n $namespace --no-headers --ignore-not-found | grep ${pod} | egrep '2/2' || oc get pod -n $namespace --no-headers --ignore-not-found | grep ${pod} | egrep '1/1' || true"
+    local retries=15
+    local sleep_time=15
+    local total_time_mins=$(( sleep_time * retries / 60))
+    local wait_message="Waiting for mongo pod $pod to restart "
+    local success_message="Pod $pod restarted with new mongo config"
+    local error_message="Timeout after ${total_time_mins} minutes waiting for pod $pod "
+    wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
+  done
+}
+
+function wait_for_condition() {
+    local condition=$1
+    local retries=$2
+    local sleep_time=$3
+    local wait_message=$4
+    local success_message=$5
+    local error_message=$6
+
+    info "${wait_message}"
+    while true; do
+        result=$(eval "${condition}")
+
+        if [[ ( ${retries} -eq 0 ) && ( -z "${result}" ) ]]; then
+            error "${error_message}"
+        fi
+ 
+        sleep ${sleep_time}
+        result=$(eval "${condition}")
+        
+        if [[ -z "${result}" ]]; then
+            info "RETRYING: ${wait_message} (${retries} left)"
+            retries=$(( retries - 1 ))
+        else
+            break
+        fi
+    done
+
+    if [[ ! -z "${success_message}" ]]; then
+        success "${success_message}\n"
+    fi
+}
+
+function msg() {
+    printf '%b\n' "$1"
+}
+
+function success() {
+    msg "\33[32m[✔] ${1}\33[0m"
+}
+
+function warning() {
+    msg "\33[33m[✗] ${1}\33[0m"
+}
+
+function error() {
+    msg "\33[31m[✘] ${1}\33[0m"
+    exit 1
+}
+
+function title() {
+    msg "\33[34m# ${1}\33[0m"
+}
+
+function info() {
+    msg "[INFO] ${1}"
 }
 
 if [[ -z $CS_NAMESPACE ]]; then

--- a/velero/restore/mongoDB/mongo-restore.sh
+++ b/velero/restore/mongoDB/mongo-restore.sh
@@ -1,19 +1,12 @@
 #!/bin/bash
-function msg() {
-  printf '%b\n' "$1"
-}
-
-function success() {
-  msg "\33[32m[✔] ${1}\33[0m"
-}
-function warning() {
-  msg "\33[33m[✗] ${1}\33[0m"
-}
-
-function error() {
-  msg "\33[31m[✘] ${1}\33[0m"
-  exit 1
-}
+CS_NAMESPACE=""
+if [[ ! -z $1 ]]; then
+  CS_NAMESPACE=$1
+fi
+s390x="false"
+if [[ ! -z $2 ]]; then
+  s390x=$2
+fi
 
 #
 # Restore Mongo
@@ -21,14 +14,6 @@ function error() {
 function restore_mongodb () {
   msg "[$STEP] Restore the mongo database"
   STEP=$(( $STEP+1 ))
-
-  # Copy the PVC if needed
-  oc get pvc cs-mongodump -n $CS_NAMESPACE
-  if [ $? -ne 0 ]
-  then
-    echo PVC cs-mongodump not found!
-    exit -1
-  fi
 
   oc delete secret icp-mongo-setaccess -n $CS_NAMESPACE >/dev/null 2>&1
   oc create secret generic icp-mongo-setaccess -n $CS_NAMESPACE --from-file=set_access.js
@@ -41,11 +26,131 @@ function restore_mongodb () {
     exit -1
   else
     echo Starting restore
-    oc apply -f mongodbrestore.yaml -n $CS_NAMESPACE
+
+    ibm_mongodb_image=$(oc get pod icp-mongodb-0 -n $CS_NAMESPACE -o=jsonpath='{range .spec.containers[0]}{.image}{end}')
+    if [[ $s390x == "false" ]]; then
+      cat <<EOF | oc apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongodb-restore
+  namespace: $CS_NAMESPACE
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 20
+  template:
+    spec:
+      containers:
+      - name: icp-mongodb-restore
+        image: $ibm_mongodb_image
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --host rs0/icp-mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump"]
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: "/dump"
+          name: mongodump
+        - mountPath: "/work-dir"
+          name: tmp-mongodb
+        - mountPath: "/cred/mongo-certs"
+          name: icp-mongodb-client-cert
+        - mountPath: "/cred/cluster-ca"
+          name: cluster-ca-cert
+        env:
+          - name: ADMIN_USER
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: user
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: password
+      volumes:
+      - name: mongodump
+        persistentVolumeClaim:
+          claimName: cs-mongodump
+      - name: tmp-mongodb
+        emptyDir: {}
+      - name: icp-mongodb-client-cert
+        secret:
+          secretName: icp-mongodb-client-cert
+      - name: cluster-ca-cert
+        secret:
+          secretName: mongodb-root-ca-cert
+      restartPolicy: Never
+EOF
+    else
+      scale_down
+      cat <<EOF | oc apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mongodb-restore
+  namespace: $CS_NAMESPACE
+spec:
+  parallelism: 1
+  completions: 1
+  backoffLimit: 20
+  template:
+    spec:
+      containers:
+      - name: icp-mongodb-restore
+        image: $ibm_mongodb_image
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --host rs0/icp-mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump"]
+        resources:
+          limits:
+            cpu: 500m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: "/dump"
+          name: mongodump
+        - mountPath: "/work-dir"
+          name: tmp-mongodb
+        - mountPath: "/cred/mongo-certs"
+          name: icp-mongodb-client-cert
+        - mountPath: "/cred/cluster-ca"
+          name: cluster-ca-cert
+        env:
+          - name: ADMIN_USER
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: user
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: password
+      volumes:
+      - name: mongodump
+        persistentVolumeClaim:
+          claimName: cs-mongodump
+      - name: tmp-mongodb
+        emptyDir: {}
+      - name: icp-mongodb-client-cert
+        secret:
+          secretName: icp-mongodb-client-cert
+      - name: cluster-ca-cert
+        secret:
+          secretName: mongodb-root-ca-cert
+      restartPolicy: Never
+EOF
+    fi
     sleep 20s
 
     LOOK=$(oc get po --no-headers=true -n $CS_NAMESPACE | grep mongodb-restore | awk '{ print $1 }')
     waitforpodscompleted "mongodb-restore" $CS_NAMESPACE
+    scale_up
 
     success "Restore completed: Use the [oc logs $LOOK -n $CS_NAMESPACE] command for details on the restore operation"
   fi
@@ -85,6 +190,140 @@ function waitforpodscompleted() {
   else
     oc get pods --no-headers=true -n $2 | grep $1
   fi
+}
+
+function scale_up(){
+    info "Z cluster detected, be prepared for multiple restarts of mongo pods. This is expected behavior."
+    mongo_op_scaled_original=$(oc get deploy -n $CS_NAMESPACE | grep ibm-mongodb-operator | egrep '1/1' || echo false)
+    if [[ $mongo_op_scaled_original == "false" ]]; then
+        info "Mongo operator in $CS_NAMESPACE still scaled down, scaling up."
+        oc scale deploy -n $CS_NAMESPACE ibm-mongodb-operator --replicas=1
+        info "Wait for mongo operator to reconcile resources"
+        sleep 60
+        delete_mongo_pods "$CS_NAMESPACE"
+    fi
+    success "Mongo reset successfully."
+}
+
+function scale_down(){
+    info "Z cluster detected, be prepared for multiple restarts of mongo pods. This is expected behavior."
+    info "Scaling down MongoDB operator"
+    oc scale deploy -n $CS_NAMESPACE ibm-mongodb-operator --replicas=0
+    #get cache size value
+    cacheSizeGB=$(oc get cm icp-mongodb -n $CS_NAMESPACE -o yaml | grep cacheSizeGB | awk '{print $2}')
+
+    info "Editing configmap icp-mongodb"
+    cat << EOF | oc apply -n $CS_NAMESPACE -f -
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: icp-mongodb
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: icp-mongodb
+    app.kubernetes.io/managed-by: operator
+    app.kubernetes.io/name: icp-mongodb
+    app.kubernetes.io/part-of: common-services-cloud-pak
+    app.kubernetes.io/version: 4.0.12-build.3
+    release: mongodb
+data:
+  mongod.conf: |-
+    storage:
+      dbPath: /data/db
+      wiredTiger:
+        engineConfig:
+          cacheSizeGB: $cacheSizeGB
+    net:
+      bindIpAll: true
+      port: 27017
+      ssl:
+        mode: preferSSL
+        CAFile: /data/configdb/tls.crt
+        PEMKeyFile: /work-dir/mongo.pem
+    replication:
+      replSetName: rs0
+    # Uncomment for TLS support or keyfile access control without TLS
+    security:
+      authorization: enabled
+      keyFile: /data/configdb/key.txt
+EOF
+    delete_mongo_pods "$CS_NAMESPACE"
+    success "Mongo prepped for backup or restore successfully."
+}
+
+function delete_mongo_pods() {
+  local namespace=$1
+  local pods=$(oc get pods -n $namespace | grep icp-mongodb | awk '{print $1}' | tr "\n" " ")
+  for pod in $pods
+  do
+    info "Deleting pod $pod"
+    oc delete pod $pod -n $CS_NAMESPACE --ignore-not-found
+    local condition="oc get pod -n $namespace --no-headers --ignore-not-found | grep ${pod} | egrep '2/2' || oc get pod -n $namespace --no-headers --ignore-not-found | grep ${pod} | egrep '1/1' || true"
+    local retries=15
+    local sleep_time=15
+    local total_time_mins=$(( sleep_time * retries / 60))
+    local wait_message="Waiting for mongo pod $pod to restart "
+    local success_message="Pod $pod restarted with new mongo config"
+    local error_message="Timeout after ${total_time_mins} minutes waiting for pod $pod "
+    wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
+  done
+}
+
+function wait_for_condition() {
+    local condition=$1
+    local retries=$2
+    local sleep_time=$3
+    local wait_message=$4
+    local success_message=$5
+    local error_message=$6
+
+    info "${wait_message}"
+    while true; do
+        result=$(eval "${condition}")
+
+        if [[ ( ${retries} -eq 0 ) && ( -z "${result}" ) ]]; then
+            error "${error_message}"
+        fi
+ 
+        sleep ${sleep_time}
+        result=$(eval "${condition}")
+        
+        if [[ -z "${result}" ]]; then
+            info "RETRYING: ${wait_message} (${retries} left)"
+            retries=$(( retries - 1 ))
+        else
+            break
+        fi
+    done
+
+    if [[ ! -z "${success_message}" ]]; then
+        success "${success_message}\n"
+    fi
+}
+
+function msg() {
+    printf '%b\n' "$1"
+}
+
+function success() {
+    msg "\33[32m[✔] ${1}\33[0m"
+}
+
+function warning() {
+    msg "\33[33m[✗] ${1}\33[0m"
+}
+
+function error() {
+    msg "\33[31m[✘] ${1}\33[0m"
+    exit 1
+}
+
+function title() {
+    msg "\33[34m# ${1}\33[0m"
+}
+
+function info() {
+    msg "[INFO] ${1}"
 }
 
 if [[ -z $CS_NAMESPACE ]]; then

--- a/velero/schedule/mongodb-backup-deployment-z.yaml
+++ b/velero/schedule/mongodb-backup-deployment-z.yaml
@@ -1,0 +1,65 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: mongodb-backup
+  namespace: ibm-common-services
+  labels:
+    foundationservices.cloudpak.ibm.com: mongo-data
+spec:
+  selector:
+    matchLabels:
+      foundationservices.cloudpak.ibm.com: mongo-data
+  template:
+    metadata:
+      annotations:
+        backup.velero.io/backup-volumes: mongodump
+        pre.hook.backup.velero.io/command: '["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongodump --oplog --out /dump/dump --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin"]'
+        post.hook.backup.velero.io/command: '["bash", "-c", "rm -rf /dump/dump/*"]'
+        post.hook.restore.velero.io/command: '["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --host rs0/mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin /dump/dump"]'
+        pre.hook.backup.velero.io/wait-timeout: 300s
+        pre.hook.backup.velero.io/exec-timeout: 300s
+        pre.hook.backup.velero.io/timeout: 600s
+        post.hook.restore.velero.io/timeout: 600s
+      name: mongodb-backup
+      namespace: ibm-common-services
+      labels:
+        foundationservices.cloudpak.ibm.com: mongo-data
+    spec:
+      containers:
+      - name: mongodb-backup
+        image: icr.io/cpopen/cpfs/ibm-mongodb@sha256:3a44fcf5656cdd3f062d3ca45d7fd0a46ff3ed90f6ed34ba260ad50938e95f57
+        command: ["bash", "-c", "sleep infinity"]
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: "/dump"
+          subpath: dump
+          name: mongodump
+        - mountPath: "/cred/mongo-certs"
+          name: icp-mongodb-client-cert
+        - mountPath: "/cred/cluster-ca"
+          name: cluster-ca-cert
+        env:
+          - name: ADMIN_USER
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: user
+          - name: ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: icp-mongodb-admin
+                key: password
+      schedulerName: default-scheduler
+      volumes:
+      - name: mongodump
+        persistentVolumeClaim:
+          claimName: cs-mongodump
+      - name: icp-mongodb-client-cert
+        secret:
+          secretName: icp-mongodb-client-cert
+      - name: cluster-ca-cert
+        secret:
+          secretName: mongodb-root-ca-cert
+      - name: tmp-mongodb
+        emptyDir: {}

--- a/velero/schedule/prep-mongo-br-z.sh
+++ b/velero/schedule/prep-mongo-br-z.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# Copyright 2023 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+MODE=$1
+CS_NAMESPACE=$2
+SERVICES_NAMESPACE=$3
+if [[ -z $SERVICES_NAMESPACE ]]; then
+    $SERVICES_NAMESPACE=$CS_NAMESPACE
+fi
+
+function main(){
+    if [[ -z $CS_NAMESPACE ]]; then
+        error "Namespace parameter not specified"
+    fi
+
+    if [[ -z $MODE ]]; then
+        error "Script mode not specified, please specify either \"up\" or \"down\""
+    fi
+
+    if [[ $MODE == "up" ]]; then
+        scale_up
+    fi
+
+    if [[ $MODE == "down" ]]; then
+        scale_down
+    fi
+}
+
+function scale_up(){
+    info "Z cluster detected, be prepared for multiple restarts of mongo pods. This is expected behavior."
+    mongo_op_scaled_original=$(oc get deploy -n $CS_NAMESPACE | grep ibm-mongodb-operator | egrep '1/1' || echo false)
+    if [[ $mongo_op_scaled_original == "false" ]]; then
+        info "Mongo operator in $CS_NAMESPACE still scaled down, scaling up."
+        oc scale deploy -n $CS_NAMESPACE ibm-mongodb-operator --replicas=1
+        info "Wait for mongo operator to reconcile resources"
+        sleep 60
+        delete_mongo_pods "$SERVICES_NAMESPACE"
+    fi
+    success "Mongo reset successfully."
+}
+
+function scale_down(){
+    info "Z cluster detected, be prepared for multiple restarts of mongo pods. This is expected behavior."
+    info "Scaling down MongoDB operator"
+    oc scale deploy -n $CS_NAMESPACE ibm-mongodb-operator --replicas=0
+    #get cache size value
+    cacheSizeGB=$(oc get cm icp-mongodb -n $SERVICES_NAMESPACE -o yaml | grep cacheSizeGB | awk '{print $2}')
+
+    info "Editing configmap icp-mongodb"
+    cat << EOF | oc apply -n $SERVICES_NAMESPACE -f -
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: icp-mongodb
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: icp-mongodb
+    app.kubernetes.io/managed-by: operator
+    app.kubernetes.io/name: icp-mongodb
+    app.kubernetes.io/part-of: common-services-cloud-pak
+    app.kubernetes.io/version: 4.0.12-build.3
+    release: mongodb
+data:
+  mongod.conf: |-
+    storage:
+      dbPath: /data/db
+      wiredTiger:
+        engineConfig:
+          cacheSizeGB: $cacheSizeGB
+    net:
+      bindIpAll: true
+      port: 27017
+      ssl:
+        mode: preferSSL
+        CAFile: /data/configdb/tls.crt
+        PEMKeyFile: /work-dir/mongo.pem
+    replication:
+      replSetName: rs0
+    # Uncomment for TLS support or keyfile access control without TLS
+    security:
+      authorization: enabled
+      keyFile: /data/configdb/key.txt
+EOF
+    delete_mongo_pods "$SERVICES_NAMESPACE"
+    success "Mongo prepped for backup or restore successfully."
+}
+
+function delete_mongo_pods() {
+  local namespace=$1
+  local pods=$(oc get pods -n $namespace | grep icp-mongodb | awk '{print $1}' | tr "\n" " ")
+  for pod in $pods
+  do
+    info "Deleting pod $pod"
+    oc delete pod $pod -n $namespace --ignore-not-found
+    local condition="oc get pod -n $namespace --no-headers --ignore-not-found | grep ${pod} | egrep '2/2' || oc get pod -n $namespace --no-headers --ignore-not-found | grep ${pod} | egrep '1/1' || true"
+    local retries=15
+    local sleep_time=15
+    local total_time_mins=$(( sleep_time * retries / 60))
+    local wait_message="Waiting for mongo pod $pod to restart "
+    local success_message="Pod $pod restarted with new mongo config"
+    local error_message="Timeout after ${total_time_mins} minutes waiting for pod $pod "
+    wait_for_condition "${condition}" ${retries} ${sleep_time} "${wait_message}" "${success_message}" "${error_message}"
+  done
+}
+
+function wait_for_condition() {
+    local condition=$1
+    local retries=$2
+    local sleep_time=$3
+    local wait_message=$4
+    local success_message=$5
+    local error_message=$6
+
+    info "${wait_message}"
+    while true; do
+        result=$(eval "${condition}")
+
+        if [[ ( ${retries} -eq 0 ) && ( -z "${result}" ) ]]; then
+            error "${error_message}"
+        fi
+ 
+        sleep ${sleep_time}
+        result=$(eval "${condition}")
+        
+        if [[ -z "${result}" ]]; then
+            info "RETRYING: ${wait_message} (${retries} left)"
+            retries=$(( retries - 1 ))
+        else
+            break
+        fi
+    done
+
+    if [[ ! -z "${success_message}" ]]; then
+        success "${success_message}\n"
+    fi
+}
+
+function msg() {
+    printf '%b\n' "$1"
+}
+
+function success() {
+    msg "\33[32m[✔] ${1}\33[0m"
+}
+
+function warning() {
+    msg "\33[33m[✗] ${1}\33[0m"
+}
+
+function error() {
+    msg "\33[31m[✘] ${1}\33[0m"
+    exit 1
+}
+
+function title() {
+    msg "\33[34m# ${1}\33[0m"
+}
+
+function info() {
+    msg "[INFO] ${1}"
+}
+
+main $*


### PR DESCRIPTION
Mongodump and mongorestore commands cannot run on s390x without tweaks so this PR makes those necessary tweaks. We will not be able to run the velero br procedure completely automatically at the moment due to the need to scale down mongo operator and change `requiressl` connection setting to `preferssl` since the dump and restore commands do not support ssl on z.

Tested as part of https://github.com/IBM/ibm-common-service-operator/pull/1520