### PR TITLE
Move KeyCloak BindInfo and Setup job to OperatorNs

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -510,7 +510,23 @@ spec:
                           sleep 10
                       fi
                   done
-              
+
+                  # wait for secret keycloak-edb-cluster-app and raise error msg if it does not exist after 5 minutes
+                  title "Wait for Secret keycloak-edb-cluster-app in namespace $resource_namespace"
+                  for i in {1..30}; do
+                      oc get secret keycloak-edb-cluster-app -n "$resource_namespace" >/dev/null 2>&1
+                      if [ $? -eq 0 ]; then
+                          success "Secret keycloak-edb-cluster-app found in namespace $resource_namespace"
+                          break
+                      else
+                          if [ $i -eq 30 ]; then
+                              error "Secret keycloak-edb-cluster-app not found in namespace $resource_namespace"
+                          fi
+                          warning "Secret keycloak-edb-cluster-app not found in namespace $resource_namespace, retrying in 10 seconds..."
+                          sleep 10
+                      fi
+                  done
+
                   # Wait for KeyCloak CR named cs-keycloak to be created
                   title "Wait for KeyCloak CR named cs-keycloak to be created in namespace $resource_namespace"
                   for i in {1..30}; do
@@ -526,7 +542,7 @@ spec:
                           sleep 10
                       fi
                   done
-              
+
                   # Refresh KeyCloak CR annotation to allow it to reload the secret
                   title "Refresh KeyCloak CR annotation to allow it to reload the secret"
                   oc patch keycloak cs-keycloak -n "$resource_namespace" --type merge -p '{"metadata":{"annotations":{"operator.ibm.com/reloaded-for-tls-secret":"'"$(date '+%Y-%m-%dT%T')"'"}}}'


### PR DESCRIPTION
This is to address issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60804

We move KeyCloak BindInfo deployment and setup Job into operator namespace so it has the required SA and permission to generate ConfigMap.

### How to test
1. Create `ibm-common-services` and `cp4i` namespace.
2. Deploy dev build CPFS as usual by creating common service operator subscription in `openshift-operators` namespace, wait for Common Service Operator and ODLM to be installed.
3. Delete existing OperandConfig and OperandRegistry `common-service` in this tenant
4. Replace the image in Common Service operator CSV to `quay.io/daniel_fan/common-service-operator-amd64:dev`, and set ImagePullPolicy to `Always`
5. Create OperandRequest to request keycloak-operator in `cp4i` namespace, waiting for KeyCloak to be installed
6. Check the following components
   - Verify `keycloak-bindinfo-cs-keycloak-route` ConfigMap is generated in `cp4i` namespace
   - Verify `keycloak-bindinfo-cs-keycloak-service` ConfigMap is generated in `cp4i` namespace