### PR TITLE
label cert-manager.io specific resources and custom route secrets

### DIFF
--- a/velero/backup/cert-manager/label-cert-manager.sh
+++ b/velero/backup/cert-manager/label-cert-manager.sh
@@ -16,8 +16,38 @@ do
     oc label issuer $NAME -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
 done
 
+CURRENT_ISSUERS=($(oc get issuers.cert-manager.io --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:metadata.namespace --no-headers=True))
+i=0
+len=${#CURRENT_ISSUERS[@]}
+while [ $i -lt $len ];
+do
+    NAME=${CURRENT_ISSUERS[$i]}
+    let i++
+    NAMESPACE=${CURRENT_ISSUERS[$i]}
+    let i++
+    echo $NAME
+    echo $NAMESPACE
+    echo "---"
+    oc label issuer $NAME -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+done
+
 # Get all certificates in all namespaces and add foundationservices.cloudpak.ibm.com=cert-manager
 CURRENT_CERTIFICATES=($(oc get certificates --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:metadata.namespace --no-headers=True))
+i=0
+len=${#CURRENT_CERTIFICATES[@]}
+while [ $i -lt $len ];
+do
+    NAME=${CURRENT_CERTIFICATES[$i]}
+    let i++
+    NAMESPACE=${CURRENT_CERTIFICATES[$i]}
+    let i++
+    echo $NAME
+    echo $NAMESPACE
+    echo "---"
+    oc label certificates $NAME -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+done
+
+CURRENT_CERTIFICATES=($(oc get certificates.cert-manager.io --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:metadata.namespace --no-headers=True))
 i=0
 len=${#CURRENT_CERTIFICATES[@]}
 while [ $i -lt $len ];
@@ -70,4 +100,30 @@ do
     echo $NAME
     echo "---"
     oc label crd $NAME foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+done
+
+#ensure zenservice custom route secrets are labeled
+zen_namespace_list=$(oc get zenservice -A | awk '{if (NR!=1) {print $1}}')
+for zen_namespace in $zen_namespace_list
+do
+    zenservice_list=$(oc get zenservice -n $zen_namespace | awk '{if (NR!=1) {print $2}}')
+    for zenservice in $zenservice_list
+    do
+        zen_secret_name=$(oc get zenservice $zenservice -n $zen_namespace -o=jsonpath='{.spec.zenCustomRoute.route_secret}')
+        echo $zen_secret_name
+        echo $zen_namespace
+        echo "---"
+        oc label secret $zen_secret_name -n $zen_namespace foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+    done
+done
+
+#ensure iam custom route secrets are labeled
+cm_namespace_list=$(oc get configmap -A | grep cs-onprem-tenant-config | awk '{if (NR!=1) {print $1}}')
+for tenant_config_namespace in $cm_namespace_list
+do
+    iam_secret_name=$(oc get configmap cs-onprem-tenant-config -n $tenant_config_namespace -o=jsonpath='{.data.custom_host_certificate_secret}')
+    echo $iam_secret_name
+    echo $tenant_config_namespace
+    echo "---"
+    oc label secret $iam_secret_name -n $tenant_config_namespace foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
 done


### PR DESCRIPTION
Add logic to specifically label secrets, certificates, and issuers using cert-manager.io version of the CRD to make sure no secrets fall through the cracks. Also included: labeling the custom secrets for the custom routes created for iam and zen.