### PR TITLE
add reduced rbac for nss in operator namespace

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -165,7 +165,7 @@ function print_usage() {
     echo "   --excluded-namespaces string   Optional. Remove namespaces from this tenant, comma-delimited, e.g. 'ns1,ns2'"
     echo "   --license-accept               Required. Set this flag to accept the license agreement"
     echo "   --enable-private-catalog       Optional. Set this flag to use namespace scoped CatalogSource. Default is in openshift-marketplace namespace"
-    echo "   --with-minimal-rbac string     Optional. File path to the minimal RBAC permissions required by the namespace scope operator for all to be deployed services"
+    echo "   --with-minimal-rbac string     Optional. Provide "skip" or file path to the minimal RBAC permissions required by the namespace scope operator for all to be deployed services"
     echo "   -c, --channel string           Optional. Channel for Subscription(s). Default is v4.3"
     echo "   -i, --install-mode string      Optional. InstallPlan Approval Mode. Default is Automatic. Set to Manual for manual approval mode"
     echo "   -s, --source string            Optional. CatalogSource name. This assumes your CatalogSource is already created. Default is opencloud-operators"


### PR DESCRIPTION
for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60519

#### Context
1. After remove wildcard * permissions in NSS CSV PR: https://github.com/IBM/ibm-namespace-scope-operator/pull/285
2. Creating a Role named `nss-managed-role-from-<operator-namespace>` and RoleBinding with granted permissions for NSS operator instead in the operator namespace
3. Introducing a new flag `--with_minimal_rbac` that allows users to enter available `path` or `skip` to choose whether they want to provide a role template or skip the role created by the script