### PR TITLE
Add storage class configuration for EDB-Keycloak

### DIFF
--- a/controllers/constant/storageclass.go
+++ b/controllers/constant/storageclass.go
@@ -38,4 +38,9 @@ const StorageClassTemplate = `
     mustgatherService:
       persistentVolumeClaim:
         storageClassName: placeholder
+- name: edb-keycloak
+  spec:
+    Cluster:
+      storage:
+        storageClass: placeholder
 `


### PR DESCRIPTION
Extending https://github.com/IBM/ibm-common-service-operator/pull/1385 with the storage class configuration of the EDB-Keycloak.

One thing I am not 100% sure whether the proposed change does not entirely override the `Cluster`'s `.spec.storage` , incl. `.spec.storage.size`, or just patches / adds the `.spec.storage.storageClass` .

EDB Cluster CR storageClass configuration reference https://www.enterprisedb.com/docs/postgres_for_kubernetes/latest/storage/#configuration-via-a-storage-class