### PR TITLE
bump up zen restore timeout, add error handling for custom secrets

### DIFF
--- a/velero/backup/cert-manager/label-cert-manager.sh
+++ b/velero/backup/cert-manager/label-cert-manager.sh
@@ -103,27 +103,35 @@ do
 done
 
 #ensure zenservice custom route secrets are labeled
-zen_namespace_list=$(oc get zenservice -A | awk '{if (NR!=1) {print $1}}')
-for zen_namespace in $zen_namespace_list
-do
-    zenservice_list=$(oc get zenservice -n $zen_namespace | awk '{if (NR!=1) {print $2}}')
-    for zenservice in $zenservice_list
+zen_namespace_list=$(oc get zenservice -A | awk '{if (NR!=1) {print $1}}' || echo "fail")
+if [[ $zen_namespace_list != "fail" ]]; then 
+    for zen_namespace in $zen_namespace_list
     do
-        zen_secret_name=$(oc get zenservice $zenservice -n $zen_namespace -o=jsonpath='{.spec.zenCustomRoute.route_secret}')
-        echo $zen_secret_name
-        echo $zen_namespace
-        echo "---"
-        oc label secret $zen_secret_name -n $zen_namespace foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+        zenservice_list=$(oc get zenservice -n $zen_namespace | awk '{if (NR!=1) {print $2}}')
+        for zenservice in $zenservice_list
+        do
+            zen_secret_name=$(oc get zenservice $zenservice -n $zen_namespace -o=jsonpath='{.spec.zenCustomRoute.route_secret}')
+            echo $zen_secret_name
+            echo $zen_namespace
+            echo "---"
+            oc label secret $zen_secret_name -n $zen_namespace foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+        done
     done
-done
+else
+    echo "[INFO] No zenservices found on cluster, skipping labeling zen custom route secrets..."
+fi
 
 #ensure iam custom route secrets are labeled
-cm_namespace_list=$(oc get configmap -A | grep cs-onprem-tenant-config | awk '{if (NR!=1) {print $1}}')
-for tenant_config_namespace in $cm_namespace_list
-do
-    iam_secret_name=$(oc get configmap cs-onprem-tenant-config -n $tenant_config_namespace -o=jsonpath='{.data.custom_host_certificate_secret}')
-    echo $iam_secret_name
-    echo $tenant_config_namespace
-    echo "---"
-    oc label secret $iam_secret_name -n $tenant_config_namespace foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
-done
+cm_namespace_list=$(oc get configmap -A | grep cs-onprem-tenant-config | awk '{if (NR!=1) {print $1}}' || echo "fail")
+if [[ $cm_namespace_list != "fail" ]]; then
+    for tenant_config_namespace in $cm_namespace_list
+    do
+        iam_secret_name=$(oc get configmap cs-onprem-tenant-config -n $tenant_config_namespace -o=jsonpath='{.data.custom_host_certificate_secret}')
+        echo $iam_secret_name
+        echo $tenant_config_namespace
+        echo "---"
+        oc label secret $iam_secret_name -n $tenant_config_namespace foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+    done
+else
+    echo "[INFO] Configmap cs-onprem-tenant-config not found, skipping copying custom secrets..."
+fi

--- a/velero/schedule/zen5-backup-deployment.yaml
+++ b/velero/schedule/zen5-backup-deployment.yaml
@@ -19,6 +19,7 @@ spec:
         post.hook.restore.velero.io/command: '["sh", "-c", "/zen5/restore_zen5.sh <zenservice namespace> <zenservice name>"]'
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s
+        post.hook.restore.velero.io/timeout: 600s
       name: zen5-backup
       namespace: zen
       labels:


### PR DESCRIPTION
Zen restore can take a long time depending on a couple factors, better to give a timeout it won't hit prematurely. We need to label the secrets used for either the iam custom route or the zen custom route since they may or may not be labeled correctly. We also need to make sure the script can gracefully handle when these secrets/configmaps do not exist.