### PR TITLE
grant packagemanifest permission to namespace scope operator

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -2012,6 +2012,16 @@ rules:
   - update
   - watch
 - apiGroups:
+  - packages.operators.coreos.com
+  resources:
+  - packagemanifests
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps


### PR DESCRIPTION
related odlm basic permission changes : https://github.com/IBM/operand-deployment-lifecycle-manager/pull/989
grant nss operator to list packagemanifest resource