### PR TITLE
new volumesnapshots resources permission from cloud-native-postgresql

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -2071,3 +2071,13 @@ rules:
   - secrets
   verbs:
   - get
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots 
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch


### PR DESCRIPTION
New resources `volumesnapshots` permission was added in `cloud-native-postgresql.v1.18.7`,  need to grant this permission to NSS in order to create EDB role in service namespace