### PR TITLE
script enahcements (catalogsource correction error msg + cert-manager smoke test namespace)

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -629,7 +629,7 @@ function validate_operator_catalogsource(){
         error "Multiple CatalogSource are available for $pm in $operator_ns namespace, please specify the correct CatalogSource name and namespace"
     elif [[ $return_value -eq 2 ]]; then
         warning "CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace"
-        error "No CatalogSource is available for $pm in $operator_ns namespace"
+        error "No CatalogSource is available for $pm in $operator_ns namespace in the given channel $channel"
     elif [[ $return_value -eq 3 ]]; then
         warning "CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace"
         success "CatalogSource $correct_source from $correct_source_ns CatalogSourceNamespace is available for $pm in $operator_ns namespace"

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -564,8 +564,9 @@ function verify_cert_manager(){
     if [[ $webhook_deployments != "1" ]]; then
     error "More than one cert-manager-webhook deployment exists on the cluster."
     fi
-
-    cm_smoke_test "test-issuer" "test-certificate" "test-certificate-secret" $CERT_MANAGER_NAMESPACE
+    local webhook_ns=$("$OC" get deployments -A | grep cert-manager-webhook | cut -d ' ' -f1)
+    
+    cm_smoke_test "test-issuer" "test-certificate" "test-certificate-secret" $webhook_ns
     success "Cert manager is ready."
 }
 


### PR DESCRIPTION
### Enhancements:
1. As the channel of singleton services are different from CPFS, when printing out the error message with given channel version that could better to indicate whether the wrong channel caused the correct CatalogSource to not be found. 
e.g. 
`[✘] No CatalogSource is available for ibm-cert-manager-operator in ibm-cert-manager namespace in the given channel v4.3`
2. Cert-Manager smoke test, the test-issuer should be created in a existent namespace. When user install a community Cert Manager, they do not need to create `CERT_MANAGER_NAMESPACE`, so using the cert-manager-webhook namespace instead of cert manager ns to create a test-issuer
To avoid error:
    ```
    Smoke test for Cert Manager existence...[0m
    [INFO] Creating following issuer:
    apiVersion: cert-manager.io/v1
    kind: Issuer
    metadata:
      name: test-issuer
      namespace: ibm-cert-manager
    spec:
      selfSigned: {}
    
    Error from server (NotFound): error when creating "STDIN": namespaces "ibm-cert-manager" not found
    Failed to create Issuer test-issuer in ibm-cert-manager 
    ```