### PR TITLE
Expose postgresql Image list via ConfigMap

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -180,6 +180,12 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 		return err
 	}
 
+	// Temporary solution for EDB image ConfigMap reference
+	if err := b.CreateEDBImageMaps(); err != nil {
+		klog.Errorf("Failed to create EDB Image ConfigMap: %v", err)
+		return err
+	}
+
 	// Backward compatible for All Namespace Installation Mode upgrade
 	// Uninstall ODLM in servicesNamespace(ibm-common-services)
 	if b.CSData.CPFSNs != b.CSData.ServicesNs {
@@ -759,6 +765,15 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
 // CreateNsScopeConfigmap creates nss configmap for operators
 func (b *Bootstrap) CreateNsScopeConfigmap() error {
 	cmRes := constant.NamespaceScopeConfigMap
+	if err := b.renderTemplate(cmRes, b.CSData, false); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateEDBImageConfig creates a ConfigMap contains EDB image reference
+func (b *Bootstrap) CreateEDBImageMaps() error {
+	cmRes := constant.EDBImageConfigMap
 	if err := b.renderTemplate(cmRes, b.CSData, false); err != nil {
 		return err
 	}

--- a/controllers/constant/cloudNativePostgresql.go
+++ b/controllers/constant/cloudNativePostgresql.go
@@ -1,0 +1,35 @@
+//
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package constant
+
+const EDBImageConfigMap = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-native-postgresql-image-list
+  namespace: "{{ .CPFSNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+data:
+  ibm-postgresql-15-operand-image: icr.io/cpopen/edb/postgresql:15.4@sha256:7ae65a0e9f172a6882b29a629d2f727aa9b6114c82eb116df5a934bf2797c17c
+  ibm-postgresql-14-operand-image: icr.io/cpopen/edb/postgresql:14.9@sha256:90136074adcbafb5033668b07fe1efea9addf0168fa83b0c8a6984536fc22264
+  ibm-postgresql-13-operand-image: icr.io/cpopen/edb/postgresql:13.12@sha256:7f8188c114ea8d1a2f706e7e7672e3462a50f96e7eec4da137e9996c4e40b674
+  ibm-postgresql-12-operand-image: icr.io/cpopen/edb/postgresql:12.16@sha256:ff99a217198e58f89f847ddeea1ddc153593123f93b88fb0ece39d3c1f59cb6e
+  edb-postgres-license-provider-image: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
+`

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -804,7 +804,7 @@ spec:
                     templatingValueFrom:
                       default:
                         required: true
-                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:2f302acebe51e10c5ddb24e425b70eebda3cd0cc1696a01e9aa1c51558da5f99
+                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
                         configMapKeyRef:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
@@ -834,7 +834,7 @@ spec:
                     templatingValueFrom:
                       default:
                         required: true
-                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:2f302acebe51e10c5ddb24e425b70eebda3cd0cc1696a01e9aa1c51558da5f99
+                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
                         configMapKeyRef:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
@@ -861,6 +861,41 @@ spec:
                 securityContext:
                   runAsNonRoot: true
                 serviceAccountName: edb-license-sa
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: edb-license-sa
+        namespace: "{{ .OperatorNs }}"
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: edb-license-role
+        namespace: "{{ .OperatorNs }}"
+        data:
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            - secrets
+            verbs:
+            - create
+            - update
+            - patch
+            - get
+            - list
+            - delete
+            - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: edb-license-rolebinding
+        namespace: "{{ .OperatorNs }}"
+        data:
+          subjects:
+          - kind: ServiceAccount
+            name: edb-license-sa
+          roleRef:
+            kind: Role
+            name: edb-license-role
+            apiGroup: rbac.authorization.k8s.io
       - apiVersion: postgresql.k8s.enterprisedb.io/v1
         data:
           spec:
@@ -1396,7 +1431,7 @@ spec:
                     templatingValueFrom:
                       default:
                         required: true
-                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:2f302acebe51e10c5ddb24e425b70eebda3cd0cc1696a01e9aa1c51558da5f99
+                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
                         configMapKeyRef:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
@@ -1426,7 +1461,7 @@ spec:
                     templatingValueFrom:
                       default:
                         required: true
-                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:2f302acebe51e10c5ddb24e425b70eebda3cd0cc1696a01e9aa1c51558da5f99
+                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
                         configMapKeyRef:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59255#issuecomment-66165971

- Common Service Operator will create a ConfigMap as postgresql Image list for EDB CASE bundle 4.18.0.
   - This is used to simulate https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60147 that the ConfigMap will be part of EDB operator installation in the future release.
   - The detailed ConfigMap is following - might change some digests based on EDB CASE bundle changes
      ```yaml
      apiVersion: v1
      kind: ConfigMap
      metadata:
        name: cloud-native-postgresql-image-list
        namespace: <CPFS operator namespace>
      data:
        ibm-postgresql-15-operand-image: icr.io/cpopen/edb/postgresql:15.4@sha256:7ae65a0e9f172a6882b29a629d2f727aa9b6114c82eb116df5a934bf2797c17c
        ibm-postgresql-14-operand-image: icr.io/cpopen/edb/postgresql:14.9@sha256:90136074adcbafb5033668b07fe1efea9addf0168fa83b0c8a6984536fc22264
        ibm-postgresql-13-operand-image: icr.io/cpopen/edb/postgresql:13.12@sha256:7f8188c114ea8d1a2f706e7e7672e3462a50f96e7eec4da137e9996c4e40b674
        ibm-postgresql-12-operand-image: icr.io/cpopen/edb/postgresql:12.16@sha256:ff99a217198e58f89f847ddeea1ddc153593123f93b88fb0ece39d3c1f59cb6e
        edb-postgres-license-provider-image: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
      ```

- Default EDB License Image and Operand Image used for KeyCloak will be the same as the one specified in CS CASE bundle.