### PR TITLE
delete webhook configuration when cs pod down

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1330,6 +1330,21 @@ function scale_down() {
     rm sub.yaml
 }
 
+function delete_webhook_configuration(){
+    local operator_ns=$1
+    # Find the webhook that matches the labels 
+    local webhook_name=$(oc get validatingwebhookconfiguration -n $operator_ns -l olm.owner.kind=ClusterServiceVersion,olm.owner.namespace=$operator_ns -o=yaml | yq e '.items[] | select(.metadata.labels."olm.owner" | test("ibm-common-service-operator.v[0-9.]+")) | .metadata.name' -)
+
+    # Check if a matching webhook was found, and delete it if so
+    if [ -n "$webhook_name" ]; then
+        info "Deleting ValidatingWebhookConfiguration '$webhook_name' in '$operator_ns'..."
+        ${OC} delete ValidatingWebhookConfiguration "$webhook_name"
+        echo "Webhook '$webhook_name' deleted."
+    else
+        echo "No matching webhook found."
+    fi
+}
+
 function wait_for_operand_registry() {
     local namespace=$1
     local name=$2

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -91,6 +91,9 @@ function main() {
 
     local pm="ibm-common-service-operator"
     if [[ $IS_ALL_NS -eq 0 ]]; then
+        # Delete webhook configuration
+        delete_webhook_configuration "$OPERATOR_NS"
+        
         # Update CommonService CR with OPERATOR_NS and SERVICES_NS
         # Propogate CommonService CR to every namespace in the tenant
         update_cscr "$OPERATOR_NS" "$SERVICES_NS" "$NS_LIST"


### PR DESCRIPTION
When cs-operator is down, the webhook configuration block the update of CS CR, need to be deleted before updaing
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61091#issuecomment-66388356