### PR TITLE
grant zen parallel job permission to Namespace Scope

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -2091,3 +2091,13 @@ rules:
   - list
   - patch
   - watch
+- apiGroups:
+  - ibm.com
+  resources:
+  - paralleljob
+  - paralleljobs
+  - paralleljob/status
+  - paralleljobs/status
+  verbs:
+  - get
+  - list


### PR DESCRIPTION
Zen parallel job permission is newly added into [Zen (5.1.0-125), Operator (5.1.0) ](https://ibm-cloudplatform.slack.com/archives/G01KTNY2ZCL/p1699296823695459) build, we woule need to add it into nss-managed-role yaml file.

According to zen permission PR: https://github.ibm.com/PrivateCloud/zen-operator/pull/274/files#diff-4c1776e6be6e452efc221ae18247856221bd4ff348d8d1bff8d2ffa92035ad2cR388

issue: https://console-openshift-console.apps.lundong-isolate-upgrade.cp.fyre.ibm.com/dashboards