### PR TITLE
Missing . in objectRef path

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -513,7 +513,7 @@ spec:
                     apiVersion: route.openshift.io/v1
                     kind: Route
                     name: keycloak
-                    path: spec.host
+                    path: .spec.host
                   required: true
             http:
               tlsSecret: cs-keycloak-tls-secret


### PR DESCRIPTION
Missing . means this comes out as a string instead of reading from the route as expected.