### PR TITLE
Update default Keycloak realm name to follow the Cloud Pak naming convention

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -610,7 +610,7 @@ spec:
           spec:
             keycloakCRName: cs-keycloak
             realm:
-              displayName: cloudpak
+              displayName: IBM Cloud Pak
               enabled: true
               id: cloudpak
               realm: cloudpak


### PR DESCRIPTION
The default Keycloak Realm name should follow the standard name of IBM Cloud Paks, i.e. with the white space characters

See the logon screen after the change:

<img width="750" alt="obraz" src="https://github.com/IBM/ibm-common-service-operator/assets/11057277/349a9d0a-76cb-4936-b5cc-0e5893a24a93">

Resolves https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61144