### PR TITLE
create nss configmap in cs namespace for all ns upgrade

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -899,6 +899,30 @@ EOF
         error "Failed to create NSS CR in ${OPERATOR_NS}"
     fi
 }
+
+function create_nss_configmap(){
+    local services_ns=$1
+    local nss_list=$2
+    local object=$(
+        cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: namespace-scope
+  namespace: $services_ns
+data:
+    namespaces: ${nss_list}
+EOF
+    )
+
+    echo
+    info "Creating the ConfigMap namesapce-scope in ${services_ns}"
+    echo "$object" | ${OC} apply -f -
+    if [[ $? -ne 0 ]]; then
+        error "Failed to create NamespaceScope ConfigMap in ${services_ns}"
+    fi
+}
+
 # ---------- creation functions end----------#
 
 # ---------- cleanup functions start----------#

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -140,6 +140,8 @@ function main() {
         delete_operator ibm-namespace-scope-operator-restricted "$SERVICES_NS"
         delete_operator ibm-namespace-scope-operator "$SERVICES_NS"
         
+        # Create namespace-scope ConfigMap in services namespace
+        create_nss_configmap "$SERVICES_NS" "$SERVICES_NS"
     else
         # Update ibm-namespace-scope-operator channel
         is_sub_exist ibm-namespace-scope-operator-restricted $OPERATOR_NS


### PR DESCRIPTION
In all namespace migration, as all nss CR will be cleared after running the migrate_tenant script, which causes fail to delete ingress operator and operand due to no `namespace-scope` ConfigMap found. We will create a new nss configmap back in `ibm-common-services` namespace only for `ingress` operator deletion.