### PR TITLE
Create default CR even services Ns does not exist for all namespace mode, move services Ns check into reconciliation logic

### DIFF
--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -443,6 +443,10 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 						namespace = opconKey.Namespace
 					}
 
+					if newConfigForOperator.(map[string]interface{})["resources"] == nil {
+						continue
+					}
+
 					newResource := getItemByGVKNameNamespace(newConfigForOperator.(map[string]interface{})["resources"].([]interface{}), opconKey.Namespace, apiVersion, kind, name, namespace)
 					if newResource != nil {
 						opResources[i] = mergeCRsIntoOperandConfigWithDefaultRules(opResource.(map[string]interface{}), newResource.(map[string]interface{}))

--- a/controllers/webhooks/commonservice/validatingwebhook.go
+++ b/controllers/webhooks/commonservice/validatingwebhook.go
@@ -24,8 +24,6 @@ import (
 
 	// certmanagerv1alpha1 "github.com/ibm/ibm-cert-manager-operator/apis/certmanager/v1alpha1"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -138,21 +136,7 @@ func (r *Defaulter) CheckNamespace(name string) (bool, error) {
 	if name == "" {
 		return false, nil
 	}
-	// in cluster scope
-	if len(watchNamespaces) == 0 {
-		ctx := context.Background()
-		ns := &corev1.Namespace{}
-		nsKey := types.NamespacedName{
-			Name: name,
-		}
-		// check if this namespace exist
-		if err := r.Client.Get(ctx, nsKey, ns); err != nil {
-			klog.Errorf("Failed to get namespace %v: %v", name, err)
-			return true, err
-
-		}
-		// if it is not cluster scope
-	} else if len(watchNamespaces) != 0 && !util.Contains(strings.Split(watchNamespaces, ","), name) {
+	if len(watchNamespaces) != 0 && !util.Contains(strings.Split(watchNamespaces, ","), name) {
 		denied = true
 	}
 	return denied, nil


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61097

**Currently** the CS operator will pause and NOT create CS CR until user creates `ibm-common-services` namespace.

**The expectation** is to have CS operator creating the CS CR, pause the further installation until user creates `ibm-common-services` namespace.

The main purpose of this change is to provide a interface(CS CR) for CP4I to read the `servicesNamespace` aka `ibm-common-services`, to ask the user to create `ibm-common-services` namespace.

### How to test
1. Deploy CS daily CD CatalogSource
2. Install Cert-Manager as dependency
3. Install CS operator in `openshift-operators` namespace as All Namespace Mode
4. We will observe the warning message in CS operator pod log, and no CS CR is created in `openshift-operators` namespace
```
W1107 09:42:34.060513 1 init.go:306] Not found well-known default namespace ibm-common-services, please manually create the namespace
W1107 09:42:44.123706 1 init.go:306] Not found well-known default namespace ibm-common-services, please manually create the namespace
```
5. Patch the CS operator image in CSV by executing following command
```
oc -n openshift-operators patch csv ibm-common-service-operator.v4.3.0 --type="json" -p '[{"op": "replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/imagePullPolicy", "value":"Always"}]'

oc -n openshift-operators patch csv ibm-common-service-operator.v4.3.0 --type="json" -p '[{"op": "replace", "path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/image", "value":"quay.io/daniel_fan/common-service-operator-amd64:dev"}]'
```
6. After CS operator's image is updated,
    - operator will create CS CR in the `openshift-operators` namespace, pointing `servicesNamespace` to `ibm-common-services`.
    - CS CR status will indicate `phase: Failed` because servicesNamespace `ibm-common-services` is not created yet.
      ```yaml
      apiVersion: operator.ibm.com/v3
      kind: CommonService
      metadata:
        name: common-service
        namespace: openshift-operators
      spec:
        license:
          accept: false
        operatorNamespace: openshift-operators
        servicesNamespace: ibm-common-services
        size: starterset
      status:
        configStatus:
          catalogName: opencloud-operators
          catalogNamespace: openshift-marketplace
          configurable: true
          operatorDeployed: true
          operatorNamespace: openshift-operators
          servicesDeployed: true
          servicesNamespace: ibm-common-services
          topologyConfigurableCRs:
            - apiVersion: operator.ibm.com/v3
              kind: CommonService
              namespace: openshift-operators
              objectName: common-service
        overallStatus: Succeeded
        phase: Failed
      ```
