### PR TITLE
fixed licensing upgrade regression caused by opreq

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1173,6 +1173,7 @@ function update_operator() {
     local source=$4
     local source_ns=$5
     local install_mode=$6
+    local remove_opreq_label=$7
     local retries=5 # Number of retries
     local delay=5 # Delay between retries in seconds
 
@@ -1186,6 +1187,10 @@ function update_operator() {
     while [ $retries -gt 0 ]; do
         # Retrieve the latest version of the subscription
         ${OC} get subscription.operators.coreos.com ${sub_name} -n ${ns} -o yaml > sub.yaml
+
+        if [ -z "$remove_opreq_label" ]; then
+            ${YQ} eval 'del(.metadata.labels["operator.ibm.com/opreq-control"])' sub.yaml
+        fi
 
         existing_channel=$(${YQ} eval '.spec.channel' sub.yaml)
         existing_catalogsource=$(${YQ} eval '.spec.source' sub.yaml)

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -366,7 +366,7 @@ EOF
     create_operator_group "ibm-licensing-operator-app" "${LICENSING_NAMESPACE}" "$target"
     is_sub_exist "ibm-licensing-operator-app" # this will catch the packagenames of all ibm-licensing-operator-app
     if [ $? -eq 0 ]; then
-        update_operator "ibm-licensing-operator-app" "${LICENSING_NAMESPACE}" "$CHANNEL" "${LICENSING_SOURCE}" "${LIS_SOURCE_NS}" "${INSTALL_MODE}"
+        update_operator "ibm-licensing-operator-app" "${LICENSING_NAMESPACE}" "$CHANNEL" "${LICENSING_SOURCE}" "${LIS_SOURCE_NS}" "${INSTALL_MODE}" "remove_opreq_label"
         wait_for_operator_upgrade "${LICENSING_NAMESPACE}" "ibm-licensing-operator-app" "$CHANNEL" "${INSTALL_MODE}"
     else
         create_subscription "ibm-licensing-operator-app" "${LICENSING_NAMESPACE}" "$CHANNEL" "ibm-licensing-operator-app" "${LICENSING_SOURCE}" "${LIS_SOURCE_NS}" "${INSTALL_MODE}"


### PR DESCRIPTION
- the graceful upgrade method by saving subscription yaml first caused a regression because the opreq-control label still existed, which causes ODLM v3 to still manage it even after v4 migration