### PR TITLE
remove redhat-operators from excluded list

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -44,7 +44,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
   - name: ibm-im-mongodb-operator-v4.0
@@ -80,7 +80,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
   - name: ibm-im-operator-v4.0
@@ -127,7 +127,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
   - name: ibm-idp-config-ui-operator-v4.0
@@ -174,7 +174,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
   - name: ibm-platformui-operator-v4.0
@@ -223,7 +223,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
   - channel: stable-v22
@@ -807,7 +807,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: "{{ .Version }}"
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
   - name: ibm-licensing-operator
@@ -936,7 +936,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
   - name: ibm-im-operator
@@ -1022,7 +1022,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,redhat-operators,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
   - name: ibm-licensing-operator


### PR DESCRIPTION
When Keycloak is GAed, it will be included in `redhat-operators` CatalogSource.
Removing `redhat-operators` from excluded CatalogSource list, so that ODLM could discover and reference Keycloak from `redhat-operators` CatalogSource.

### Test result
After building new image and deploy in the cluster, CS operator renders a OperandRegistry whose excluded list does not contain `redhat-operators`.
```yaml
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRegistry
metadata:
  annotations:
    excluded-catalogsource: >-
      certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
    version: 4.3.0
  resourceVersion: '232789769'
  name: common-service
```

Also, I manually edit OperandRegistry to include one operator available in `redhat-operators` CatalogSource., in order to simulate Keycloak installation from `redhat-operators` CatalogSource.
```yaml
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRegistry
metadata:
  annotations:
    excluded-catalogsource: >-
      certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
    version: 4.3.0
  resourceVersion: '232789769'
  name: common-service
spec:
  ...
  - channel: release-2.8
    name: advanced-cluster-management
    namespace: cp-control
    packageName: advanced-cluster-management
    scope: public
```

After creating OperandRequest to request this Operator, `Advanced Cluster Management for Kubernetes` is installed successfully from `redhat-operators` CatalogSource.
```yaml
kind: OperandRequest
apiVersion: operator.ibm.com/v1alpha1
metadata:
  name: example-service
  namespace: cp-data
spec:
  requests:
    - operands:
        - name: advanced-cluster-management
      registry: common-service
      registryNamespace: cp-data
---
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  name: advanced-cluster-management
  namespace: cp-control
spec:
  channel: release-2.8
  installPlanApproval: Automatic
  name: advanced-cluster-management
  source: redhat-operators
  sourceNamespace: openshift-marketplace
```