### PR TITLE
skip mgmt_ingress CR check when it does not exist

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -922,7 +922,13 @@ function patch_management_ingress_cr() {
     patch_cs_cr_for_management_ingress
     wait_for_opconfig_exist
     patch_opconfig_for_management_ingress
-    wait_for_management_ingress_be_patched
+    
+    local is_mgmt_CRD_exist=$((${OC} get managementingress -n ${MASTER_NS} --ignore-not-found > /dev/null && echo exists) || echo fail)
+    if [[ "$is_mgmt_CRD_exist" == "exists" ]]; then
+        wait_for_management_ingress_be_patched
+    else 
+        warning "managementingress CR not found, skipping waiting for managementingress CR to be patched."
+    fi
 }
 
 function wait_for_cs_cr_exist() {


### PR DESCRIPTION
Issue: https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/14099
CPD has a migration scenario that the previous CPD does not have IAM installed. As a result, during the isolation process, there is no ManagementIngress CRD exists in the cluster. We will skip checking for ManagementIngress CR if it does not exist in the cluster.

### Test result
```
✗ ./isolate.sh --original-cs-ns ibm-common-services --control-ns cs-control --excluded-ns wkc

[✔] Commonservice common-service created in ibm-common-services.
# Updating commonservice common-service in namespace ibm-common-services for management ingress CR ...
[INFO] ibm-management-ingress-operator already exists in CS CR .spec.services, updating it ...
[✔] Commonservice common-service updated in ibm-common-services for management ingress CR.
[INFO] Waiting for operandconfig common-service in namespace ibm-common-services to be created ...
[INFO] RETRYING: Waiting for operandconfig common-service in namespace ibm-common-services to be created ... (20 left)
[INFO] RETRYING: Waiting for operandconfig common-service in namespace ibm-common-services to be created ... (19 left)
[✔] Operandconfig common-service created in ibm-common-services.
# Updating operandconfig common-service in namespace ibm-common-services for management ingress CR ...
[INFO] ibm-management-ingress-operator already exists in operandconfig CR .spec.services, updating it ...
[✔] Operandconfig common-service updated in ibm-common-services for management ingress CR.

error: the server doesn't have a resource type "managementingress"
[✗] managementingress CR not found, skipping waiting for managementingress CR to be patched.      <--------------- skip checking

[INFO] Waiting for IBM Common Services CR is Succeeded
[INFO] RETRYING: Waiting for IBM Common Services CR is Succeeded (29 left)
[INFO] RETRYING: Waiting for IBM Common Services CR is Succeeded (28 left)
[INFO] RETRYING: Waiting for IBM Common Services CR is Succeeded (27 left)
-----------------------------------------------------------------------
[✔] Ready use
[✔] Common Service Operator restarted.
```