### PR TITLE
change when housekeeping command is run

### DIFF
--- a/velero/schedule/mongodb-backup-deployment.yaml
+++ b/velero/schedule/mongodb-backup-deployment.yaml
@@ -13,8 +13,7 @@ spec:
     metadata:
       annotations:
         backup.velero.io/backup-volumes: mongodump
-        pre.hook.backup.velero.io/command: '["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongodump --oplog --out /dump/dump --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem"]'
-        post.hook.backup.velero.io/command: '["bash", "-c", "rm -rf /dump/dump/*"]'
+        pre.hook.backup.velero.io/command: '["bash", "-c", "rm -rf /dump/dump/*; cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongodump --oplog --out /dump/dump --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem"]'
         post.hook.restore.velero.io/command: '["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]'
       name: mongodb-backup
       namespace: <mongo namespace>

--- a/velero/schedule/zen-backup-deployment.yaml
+++ b/velero/schedule/zen-backup-deployment.yaml
@@ -13,9 +13,8 @@ spec:
     metadata:
       annotations:
         backup.velero.io/backup-volumes: zendump
-        pre.hook.backup.velero.io/command: '["sh", "-c", "/tmp/backup/backup_script.sh regular cron-job"]'
+        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /user-home/zen-metastoredb-backup; /tmp/backup/backup_script.sh regular cron-job"]'
         pre.hook.backup.velero.io/timeout: 120s
-        post.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /user-home/zen-metastoredb-backup"]'
         post.hook.restore.velero.io/command: '["sh", "-c", "/tmp/backup/restore_script.sh regular cron-job"]'
       name: zen-backup
       namespace: <zenservice namespace>

--- a/velero/schedule/zen5-backup-deployment.yaml
+++ b/velero/schedule/zen5-backup-deployment.yaml
@@ -13,9 +13,8 @@ spec:
     metadata:
       annotations:
         backup.velero.io/backup-volumes: zen5-backup
-        pre.hook.backup.velero.io/command: '["sh", "-c", "/zen5/backup_zen5.sh <zenservice namespace>"]'
+        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace; /zen5/backup_zen5.sh <zenservice namespace>"]'
         pre.hook.backup.velero.io/timeout: 300s
-        post.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace"]'
         post.hook.restore.velero.io/command: '["sh", "-c", "/zen5/restore_zen5.sh <zenservice namespace> <zenservice name>"]'
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s


### PR DESCRIPTION
move the clean up of backups to the beginning of the next backup instead of immediately after. This way, the backup is accessible between runs and out of the way when attempting another backup.