### PR TITLE
align default EDB keycloak size profiles with starterset

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -671,11 +671,11 @@ spec:
                   name: edb-license
                   resources:
                     limits:
-                      cpu: 200m
-                      memory: 768Mi
-                    requests:
-                      cpu: 200m
+                      cpu: 500m
                       memory: 512Mi
+                    requests:
+                      cpu: 100m
+                      memory: 50Mi
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
@@ -779,11 +779,11 @@ spec:
             instances: 1
             resources:
               limits:
-                cpu: 1000m
-                memory: 1Gi
+                cpu: 200m
+                memory: 512Mi
               requests:
-                cpu: 1000m
-                memory: 1Gi
+                cpu: 200m
+                memory: 512Mi
             logLevel: info
             primaryUpdateStrategy: unsupervised
             storage:


### PR DESCRIPTION
Corrected wrong default size value of EDB KeyCloak resrouce 
Fix for two issue:

- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60915#issuecomment-67033251
- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61204