### PR TITLE
remove invalid option in script

### DIFF
--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -155,7 +155,7 @@ data:
 
         oc get deploy ibm-nginx zen-core usermgmt zen-watcher zen-core-api -n ${ZEN_NAMESPACE} --ignore-not-found
         
-        oc scale deploy ibm-nginx zen-core usermgmt zen-watcher zen-core-api --replicas=0 -n ${ZEN_NAMESPACE} --ignore-not-found
+        oc scale deploy ibm-nginx zen-core usermgmt zen-watcher zen-core-api --replicas=0 -n ${ZEN_NAMESPACE}
         # zen-watchdog is applicable only for CloudPak for Data 
         zen_watchdog_present=$(oc get deploy zen-watchdog -n ${ZEN_NAMESPACE} || echo "fail")
         if [[ $zen_watchdog_present != "fail" ]]; then


### PR DESCRIPTION
--ignore-not-found cannot be used on the scale command as it will cause an error