### PR TITLE
resolve syntax error, change check command

### DIFF
--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -148,7 +148,7 @@ data:
         
         #Getting the replica count before scaling down the required pods
         IBM_NGINX_RC=$(oc get deploy ibm-nginx -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
-        ZEN_CORE_RC=$(oc get deploy zen-core -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}'--ignore-not-found )
+        ZEN_CORE_RC=$(oc get deploy zen-core -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found )
         USERMGMT_RC=$(oc get deploy usermgmt -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
         ZEN_CORE_API_RC=$(oc get deploy zen-core-api -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
         ZEN_WATCHER_RC=$(oc get deploy zen-watcher -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}'--ignore-not-found)
@@ -157,7 +157,7 @@ data:
         
         oc scale deploy ibm-nginx zen-core usermgmt zen-watcher zen-core-api --replicas=0 -n ${ZEN_NAMESPACE}
         # zen-watchdog is applicable only for CloudPak for Data 
-        zen_watchdog_present=$(oc get deploy zen-watchdog -n ${ZEN_NAMESPACE} || echo "fail")
+        zen_watchdog_present=$(oc get deploy -n ${ZEN_NAMESPACE} | grep zen-watchdog || echo "fail")
         if [[ $zen_watchdog_present != "fail" ]]; then
             info "Zen watchdog present, scaling down."
             oc scale deploy zen-watchdog --replicas=0 -n ${ZEN_NAMESPACE}


### PR DESCRIPTION
Same as #1646 

Needed to add a space before `--ignore-not-found` as the string was being included in the replica value for zen core api

Changed the check from directly grabbing zen-watchdog to grepping for it to prevent an error from being output.