### PR TITLE
change message from error to warning for more consistent results

### DIFF
--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -336,7 +336,7 @@ data:
         # Get broker secret value from secret zen-service-broker-secret
         broker_secret=$(oc get secret zen-service-broker-secret -o yaml -n $ZEN_NAMESPACE | yq .data.token | base64 -d || echo "fail") 
         if [[ $broker_secret == "fail" ]]; then
-            error "Failed to grab broker secret zen-service-broker-secret in namespace $ZEN_NAMESPACE"
+            error "Failed to grab broker secret zen-service-broker-secret in namespace $ZEN_NAMESPACE, exiting"
         else
             info "Broker Secret obtained in namespace $ZEN_NAMESPACE"
         fi

--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -151,7 +151,7 @@ data:
         ZEN_CORE_RC=$(oc get deploy zen-core -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found )
         USERMGMT_RC=$(oc get deploy usermgmt -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
         ZEN_CORE_API_RC=$(oc get deploy zen-core-api -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
-        ZEN_WATCHER_RC=$(oc get deploy zen-watcher -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}'--ignore-not-found)
+        ZEN_WATCHER_RC=$(oc get deploy zen-watcher -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
 
         oc get deploy ibm-nginx zen-core usermgmt zen-watcher zen-core-api -n ${ZEN_NAMESPACE} --ignore-not-found
         

--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -378,19 +378,19 @@ data:
                 id_list=$(curl -H "secret: ${broker_secret}" -ks https://zen-core-api-svc:4444/v1/extensions?extension_name=${extensions} | yq eval '.data[] | select(.id == "*") | .id' | tr '\n' ' ') #space separated list of ids
                 info "id_list: $id_list bookend"
                 if [[ -z $id_list ]] || [[ $id_list == "" ]]; then
-                    error "The list of extensions provided returned an empty ID list from the database. These extensions may not be present in this database."
+                    warning "The list of extensions provided returned an empty ID list from the database. These extensions may not be present in this database."
                 else
                     info "List of extension IDs populated, continuing with deletion."
+
+                    # Delete each extension using the ID
+                    # curl -H 'secret: <broker-secret>' -ks -X DELETE https://zen-core-api-svc:4444/v1/extensions/{id}
+                    for id in $id_list; do
+                        info "Deleting extension with ID $id."
+                        curl -H "secret: ${broker_secret}" -ks -X DELETE https://zen-core-api-svc:4444/v1/extensions/{$id}
+                    done
+
+                    success "Zen extension cleanup complete."
                 fi
-
-                # Delete each extension using the ID
-                # curl -H 'secret: <broker-secret>' -ks -X DELETE https://zen-core-api-svc:4444/v1/extensions/{id}
-                for id in $id_list; do
-                    info "Deleting extension with ID $id."
-                    curl -H "secret: ${broker_secret}" -ks -X DELETE https://zen-core-api-svc:4444/v1/extensions/{$id}
-                done
-
-                success "Zen extension cleanup complete."
             else
                 info "File /zen5/extensions/extensions.txt not found, skipping zenextension cleanup."
             fi

--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -221,6 +221,20 @@ data:
         oc patch secret -n $ZEN_NAMESPACE admin-user-details --patch="{\"data\": { \"initial_admin_password\": \"$(base64 -w0 $BACKUP_DIR/secrets/initial_admin_password)\" }}"
 
         #Update zen extensions
+        if [[ $ZEN_CORE_RC == "0" ]]; then
+            info "zen-core deployment not scaled up before rerunning, setting replica value to 2"
+            ZEN_CORE_RC=2
+        fi
+        if [[ $USERMGMT_RC == "0" ]]; then
+            info "usermgmt deployment not scaled up before rerunning, setting replica value to 2"
+            USERMGMT_RC=2
+        fi
+        oc scale deploy zen-core-api --replicas=$ZEN_CORE_API_RC -n $ZEN_NAMESPACE
+        oc scale deploy usermgmt --replicas=$USERMGMT_RC -n $ZEN_NAMESPACE
+        sleep 15
+        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-core-api --timeout=180s -n ${ZEN_NAMESPACE}
+        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=usermgmt --timeout=180s -n ${ZEN_NAMESPACE}
+        
         ./zen5/customize-zen-extensions.sh $ZEN_NAMESPACE false
         
         #[2.2.5] Scale up deployments and Disable Zen operator maintenance mode
@@ -230,14 +244,7 @@ data:
             info "ibm-nginx deployment not scaled up before rerunning, setting replica value to 2"
             IBM_NGINX_RC=2
         fi
-        if [[ $ZEN_CORE_RC == "0" ]]; then
-            info "zen-core deployment not scaled up before rerunning, setting replica value to 2"
-            ZEN_CORE_RC=2
-        fi
-        if [[ $USERMGMT_RC == "0" ]]; then
-            info "usermgmt deployment not scaled up before rerunning, setting replica value to 2"
-            USERMGMT_RC=2
-        fi
+        
         if [[ $ZEN_CORE_API_RC == "0" ]]; then
             info "zen-core-api deployment not scaled up before rerunning, setting replica value to 2"
             ZEN_CORE_API_RC=2
@@ -248,8 +255,6 @@ data:
         fi
         
         oc scale deploy zen-watcher --replicas=$ZEN_WATCHER_RC -n $ZEN_NAMESPACE
-        oc scale deploy usermgmt --replicas=$USERMGMT_RC -n $ZEN_NAMESPACE
-        oc scale deploy zen-core-api --replicas=$ZEN_CORE_API_RC -n $ZEN_NAMESPACE
         oc scale deploy zen-core --replicas=$ZEN_CORE_RC -n $ZEN_NAMESPACE
         oc scale deploy ibm-nginx --replicas=$IBM_NGINX_RC -n $ZEN_NAMESPACE
         if [[ $zen_watchdog_present != "fail" ]]; then
@@ -260,9 +265,8 @@ data:
         info "Wait for deployments to come ready again."
         oc wait pod --for=condition=Ready -l app.kubernetes.io/component=ibm-nginx --timeout=180s -n ${ZEN_NAMESPACE}
         oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-core --timeout=180s -n ${ZEN_NAMESPACE}
-        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-core-api --timeout=180s -n ${ZEN_NAMESPACE}
         oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-watcher --timeout=180s -n ${ZEN_NAMESPACE}
-        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=usermgmt --timeout=180s -n ${ZEN_NAMESPACE}
+        
         if [[ $zen_watchdog_present != "fail" ]]; then # Only for CloudPak for Data
             oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-watchdog --timeout=180s -n ${ZEN_NAMESPACE}
         fi
@@ -336,7 +340,7 @@ data:
         # Get broker secret value from secret zen-service-broker-secret
         broker_secret=$(oc get secret zen-service-broker-secret -o yaml -n $ZEN_NAMESPACE | yq .data.token | base64 -d || echo "fail") 
         if [[ $broker_secret == "fail" ]]; then
-            error "Failed to grab broker secret zen-service-broker-secret in namespace $ZEN_NAMESPACE, exiting"
+            error "Failed to grab broker secret zen-service-broker-secret in namespace $ZEN_NAMESPACE, exiting."
         else
             info "Broker Secret obtained in namespace $ZEN_NAMESPACE"
         fi


### PR DESCRIPTION
same as #1649 

This message being an error will prevent the script from cleaning up the cluster after running. A warning is better suited for this situation as it denotes that the zen extensions were still not found (which may or may not be an issue) while still allowing the script to clean up after itself.