### PR TITLE
Add default realm security settings

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -646,6 +646,10 @@ spec:
               enabled: true
               id: cloudpak
               realm: cloudpak
+              ssoSessionIdleTimeout: 43200
+              ssoSessionMaxLifespan: 43200
+              rememberMe: true
+              passwordPolicy: "length(15) and notUsername(undefined) and notEmail(undefined) and passwordHistory(3)"
   - name: edb-keycloak
     resources:
       - apiVersion: batch/v1


### PR DESCRIPTION
Set sensible defaults for the realm security.
Addresses https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61319

These can be overridden by users because the KeycloakRealmImport CR only adds the realm once and then doesn't reconcile except on delete.