### PR TITLE
remove `service` namespace in secretshare default cr yaml

### DIFF
--- a/controllers/constant/secretshare.go
+++ b/controllers/constant/secretshare.go
@@ -34,7 +34,7 @@ spec:
   secretshares:
   - secretname: oauth-client-secret
     sharewith:
-    - namespace: services
+    - namespace: kube-public
   - secretname: ibmcloud-cluster-ca-cert
     sharewith:
     - namespace: kube-public

--- a/controllers/constant/secretshare.go
+++ b/controllers/constant/secretshare.go
@@ -60,7 +60,7 @@ spec:
     - namespace: kube-system
   - configmapname: oauth-client-map
     sharewith:
-    - namespace: services
+    - namespace: kube-public
   - configmapname: ibmcloud-cluster-info
     sharewith:
     - namespace: kube-public


### PR DESCRIPTION
for ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58117
change `service` namespace to `kube-public` in secretshare cr yaml.