### PR TITLE
introduce basic maintenance mode into CS operator

### DIFF
--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -102,20 +102,20 @@ func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		klog.Error("Accept license by changing .spec.license.accept to true in the CommonService CR. Operator will not proceed until then")
 	}
 
+	// If the CommonService CR is not paused, continue to reconcile
 	if !r.reconcilePauseRequest(instance) {
 		if r.checkNamespace(req.NamespacedName.String()) {
 			return r.ReconcileMasterCR(ctx, instance)
 		}
 		return r.ReconcileGeneralCR(ctx, instance)
-	} else {
-		if err := r.updatePhase(ctx, instance, CRPending); err != nil {
-			klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
-			return ctrl.Result{}, err
-		} else {
-			klog.Infof("%s/%s is in pending status due to pause request", instance.Namespace, instance.Name)
-			return ctrl.Result{}, nil
-		}
 	}
+	// If the CommonService CR is paused, update the status to pending
+	if err := r.updatePhase(ctx, instance, CRPending); err != nil {
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		return ctrl.Result{}, err
+	}
+	klog.Infof("%s/%s is in pending status due to pause request", instance.Namespace, instance.Name)
+	return ctrl.Result{}, nil
 }
 
 func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instance *apiv3.CommonService) (ctrl.Result, error) {
@@ -415,7 +415,12 @@ func (r *CommonServiceReconciler) mappingToCsRequest() handler.MapFunc {
 
 func (r *CommonServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&apiv3.CommonService{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		// AnnotationChangedPredicate is intended to be used in conjunction with the GenerationChangedPredicate
+		For(&apiv3.CommonService{}, builder.WithPredicates(
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				predicate.AnnotationChangedPredicate{},
+				predicate.LabelChangedPredicate{}))).
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
 			handler.EnqueueRequestsFromMapFunc(r.mappingToCsRequest()),

--- a/controllers/recocile_pause.go
+++ b/controllers/recocile_pause.go
@@ -17,8 +17,9 @@
 package controllers
 
 import (
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
 	"k8s.io/klog"
+
+	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
 )
 
 const (
@@ -29,7 +30,7 @@ const (
 
 func (r *CommonServiceReconciler) reconcilePauseRequest(instance *apiv3.CommonService) bool {
 
-	klog.Info("Request Stage: reconcilePauseRequest")
+	klog.Info("Request Stage: ReconcilePauseRequest")
 
 	// if the given CommnService CR has not been existing
 	if instance == nil {
@@ -66,9 +67,8 @@ func (r *CommonServiceReconciler) pauseRequestExists(instance *apiv3.CommonServi
 			return instance.ObjectMeta.Annotations[PauseRequestAnnoKey] == PauseRequestValue
 		} else if selfpauseRequestFound {
 			return instance.ObjectMeta.Annotations[SelfPauseRequestAnnoKey] == PauseRequestValue
-		} else {
-			return false
 		}
+		return false
 	}
 	return false
 }

--- a/controllers/recocile_pause.go
+++ b/controllers/recocile_pause.go
@@ -1,0 +1,74 @@
+//
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package controllers
+
+import (
+	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
+	"k8s.io/klog"
+)
+
+const (
+	PauseRequestAnnoKey     = "commonservices.operator.ibm.com/pause"
+	SelfPauseRequestAnnoKey = "commonservices.operator.ibm.com/self-pause"
+	PauseRequestValue       = "true"
+)
+
+func (r *CommonServiceReconciler) reconcilePauseRequest(instance *apiv3.CommonService) bool {
+
+	klog.Info("Request Stage: reconcilePauseRequest")
+
+	// if the given CommnService CR has not been existing
+	if instance == nil {
+		klog.Warningf("CommonService CR %s/%s is not existing", instance.Name, instance.Namespace)
+		return false
+	}
+
+	// check if there is a pause request annotation in the CommonService CR
+	return r.pauseRequestExists(instance)
+
+	// future implementation: TO DO
+	// check and set pauseExpire annotation
+	// if the time is expired, remove the pause annotation
+}
+
+func (r *CommonServiceReconciler) pauseRequestExists(instance *apiv3.CommonService) bool {
+	klog.Info("Request Stage: Checking annotations for pause request")
+
+	// if there is pause or self-pause request annotation in the CommonService CR, pause request takes precedence over self-pause request
+	var pauseRequestFound bool
+	var selfpauseRequestFound bool
+	if instance.ObjectMeta.Annotations != nil {
+		for key := range instance.ObjectMeta.Annotations {
+			if key == PauseRequestAnnoKey {
+				pauseRequestFound = true
+				klog.Infof("Found pause request annotation: %v", instance.ObjectMeta.Annotations[PauseRequestAnnoKey])
+			} else if key == SelfPauseRequestAnnoKey {
+				selfpauseRequestFound = true
+				klog.Infof("Found self-pause request annotation: %v", instance.ObjectMeta.Annotations[SelfPauseRequestAnnoKey])
+			}
+		}
+		// Pause request takes precedence over self-pause request
+		if pauseRequestFound {
+			return instance.ObjectMeta.Annotations[PauseRequestAnnoKey] == PauseRequestValue
+		} else if selfpauseRequestFound {
+			return instance.ObjectMeta.Annotations[SelfPauseRequestAnnoKey] == PauseRequestValue
+		} else {
+			return false
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/59018

#### Introduciton
New maintenance mode is introduced for the CS operator that is able to pause the reconciliation of CommonService CRs, allow user/operator to perform additional maintenance, and resume the reconciliation after such maintenance mode is released.

#### System Context
To pause reconciliation of the CS custom resources, an annotation can be added to the CommonService instance. 
```yaml
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  annotations:
    commonservices.operator.ibm.com/pause: 'true'
    commonservices.operator.ibm.com/self-pause: 'true'
  name: common-service
```

- The value of the annotation `<api>/pause` and `<api>/self-pause` can be `true` and `false`.
  - If the value is `true`, the reconciliation of the CR will be paused.
  - If the value is `false`, the reconciliation of the CR will be resumed.

- The priority of annotation `<api>/pause` takes precedence over `<api>/self-pause`. If both annotations are present, the value of `<api>/pause` will be used.

#### How to test
test image: quay.io/yuchen_shen/cs_operator:maintenance_mode
1. install a v4 cs operator in a simple topology
2. create several CS CRs according to the following truth table

| Annotation `<api>/pause` | Annotation `<api>/self-pause` | Reconciliation Behavior |
| --- | --- | --- |
| `true` | `true` | :x: Paused |
| `true` | `false` | :x: Paused |
| `true` | Not present | :x: Paused |
| `false` | `true` | :white_check_mark: Reconciled |
| `false` | `false` | :white_check_mark: Reconciled |
| `false` | Not present | :white_check_mark: Reconciled |
| Not present | `true` | :x: Paused |
| Not present | `false` | :white_check_mark: Reconciled |
| Not present | Not present | :white_check_mark: Reconciled |
3. check the staus for each CS CR
    - `phase: Succeeded` when resuming the reconciliation
    - `phase: Pending` when pausing the reconciliation
 
result:
![image](https://github.com/IBM/ibm-common-service-operator/assets/59578388/648fdc55-7898-46e0-aec9-e9ae5c29c0e5)

