### PR TITLE
Re-construct CP2 tenant scope in self-isolation

### DIFF
--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -837,10 +837,10 @@ func EnableMaintenanceMode(c client.Client, csCR string, masterNs string) error 
 		Name:      csCR,
 		Namespace: masterNs,
 	}, instance); err != nil && !errors.IsNotFound(err) {
-		klog.Errorf("Failed to get CommonService CR in %s: %v", masterNs, err)
+		klog.Errorf("Failed to get CommonService CR %s in %s: %v", csCR, masterNs, err)
 		return err
 	} else if errors.IsNotFound(err) {
-		klog.Infof("CommonService CR is not found in %s", masterNs)
+		klog.Infof("CommonService CR %s is not found in %s", csCR, masterNs)
 		return nil
 	} else {
 		// Set annotation: commonservices.operator.ibm.com/self-pause to true
@@ -852,7 +852,7 @@ func EnableMaintenanceMode(c client.Client, csCR string, masterNs string) error 
 
 	// Update CommonService CR
 	if err := c.Update(context.Background(), instance); err != nil {
-		klog.Errorf("Failed to update CommonService CR: %v", err)
+		klog.Errorf("Failed to update CommonService CR %s/%s: %v", masterNs, csCR, err)
 		return err
 	}
 	return nil
@@ -866,10 +866,10 @@ func DisableMaintenanceMode(c client.Client, csCR string, masterNs string) error
 		Name:      csCR,
 		Namespace: masterNs,
 	}, instance); err != nil && !errors.IsNotFound(err) {
-		klog.Errorf("Failed to get CommonService CR in %s: %v", masterNs, err)
+		klog.Errorf("Failed to get CommonService CR %s in %s: %v", csCR, masterNs, err)
 		return err
 	} else if errors.IsNotFound(err) {
-		klog.Infof("CommonService CR is not found in %s", masterNs)
+		klog.Infof("CommonService CR %s is not found in %s", csCR, masterNs)
 		return nil
 	} else {
 		// Set annotation: commonservices.operator.ibm.com/self-pause to false
@@ -880,7 +880,85 @@ func DisableMaintenanceMode(c client.Client, csCR string, masterNs string) error
 
 	// Update CommonService CR
 	if err := c.Update(context.Background(), instance); err != nil {
-		klog.Errorf("Failed to update CommonService CR: %v", err)
+		klog.Errorf("Failed to update CommonService CR %s/%s: %v", masterNs, csCR, err)
+		return err
+	}
+	return nil
+}
+
+// TurnOffRouteChangeInMgmtIngress set multipleInstancesEnabled to false for ibm-management-ingress-operator in CommonService CR
+func TurnOffRouteChangeInMgmtIngress(c client.Client, csCR string, masterNs string) error {
+	// Fetch CommonService CR
+	instance := NewUnstructured("operator.ibm.com", "CommonService", "v3")
+	if err := c.Get(context.TODO(), types.NamespacedName{
+		Name:      csCR,
+		Namespace: masterNs,
+	}, instance); err != nil && !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get CommonService CR %s in %s: %v", csCR, masterNs, err)
+		return err
+	} else if errors.IsNotFound(err) {
+		klog.Infof("CommonService CR %s is not found in %s", csCR, masterNs)
+		return nil
+	}
+
+	services, found, err := unstructured.NestedSlice(instance.Object, "spec", "services")
+	if err != nil {
+		klog.Errorf("Failed to get services in CommonService CR %s/%s: %v", masterNs, csCR, err)
+		return err
+	}
+	if !found {
+		// add services, and add managementIngress template
+		services = []interface{}{
+			map[string]interface{}{
+				"name": "ibm-management-ingress-operator",
+				"spec": map[string]interface{}{
+					"managementIngress": map[string]interface{}{
+						"multipleInstancesEnabled": false,
+					},
+				},
+			},
+		}
+		if err := unstructured.SetNestedSlice(instance.Object, services, "spec", "services"); err != nil {
+			klog.Errorf("Failed to set services in CommonService CR %s/%s: %v", masterNs, csCR, err)
+			return err
+		}
+	} else {
+		// add managementIngress template
+		for _, service := range services {
+			serviceMap, ok := service.(map[string]interface{})
+			if !ok {
+				klog.Errorf("Failed to convert service to map[string]interface{}: %v", err)
+				return err
+			}
+			if serviceMap["name"] == "ibm-management-ingress-operator" {
+				managementIngress, found, err := unstructured.NestedMap(serviceMap, "spec", "managementIngress")
+				if err != nil {
+					klog.Errorf("Failed to get managementIngress in CommonService CR %s/%s: %v", masterNs, csCR, err)
+					return err
+				}
+				if !found {
+					// add managementIngress template
+					managementIngress = map[string]interface{}{
+						"multipleInstancesEnabled": false,
+					}
+					if err := unstructured.SetNestedMap(serviceMap, managementIngress, "spec", "managementIngress"); err != nil {
+						klog.Errorf("Failed to set managementIngress in CommonService CR %s/%s: %v", masterNs, csCR, err)
+						return err
+					}
+				} else {
+					// set multipleInstancesEnabled to false
+					if err := unstructured.SetNestedField(serviceMap, false, "spec", "managementIngress", "multipleInstancesEnabled"); err != nil {
+						klog.Errorf("Failed to set multipleInstancesEnabled as false in CommonService CR %s/%s: %v", masterNs, csCR, err)
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	// Update CommonService CR
+	if err := c.Update(context.Background(), instance); err != nil {
+		klog.Errorf("Failed to update CommonService CR %s/%s: %v", masterNs, csCR, err)
 		return err
 	}
 	return nil

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -931,14 +931,14 @@ func TurnOffRouteChangeInMgmtIngress(c client.Client, csCR string, masterNs stri
 				return err
 			}
 			if serviceMap["name"] == "ibm-management-ingress-operator" {
-				managementIngress, found, err := unstructured.NestedMap(serviceMap, "spec", "managementIngress")
+				_, found, err := unstructured.NestedMap(serviceMap, "spec", "managementIngress")
 				if err != nil {
 					klog.Errorf("Failed to get managementIngress in CommonService CR %s/%s: %v", masterNs, csCR, err)
 					return err
 				}
 				if !found {
 					// add managementIngress template
-					managementIngress = map[string]interface{}{
+					managementIngress := map[string]interface{}{
 						"multipleInstancesEnabled": false,
 					}
 					if err := unstructured.SetNestedMap(serviceMap, managementIngress, "spec", "managementIngress"); err != nil {

--- a/controllers/scopewatcher_controller.go
+++ b/controllers/scopewatcher_controller.go
@@ -48,7 +48,7 @@ func (r *CommonServiceReconciler) ScopeReconcile(ctx context.Context, req ctrl.R
 	// Determine if the cluster is multi instance enabled, if it is not enabled, no isolation process is required
 	r.Bootstrap.CSData.ControlNs = util.GetControlNs(r.Reader)
 	MultiInstanceStatusFromCluster := util.CheckMultiInstances(r.Reader)
-	if MultiInstanceStatusFromCluster == false {
+	if !MultiInstanceStatusFromCluster {
 		klog.Infof("MultiInstancesEnable is not enabled in cluster, skip isolation process")
 		return ctrl.Result{}, nil
 	}
@@ -131,7 +131,7 @@ func (r *CommonServiceReconciler) ScopeReconcile(ctx context.Context, req ctrl.R
 	// TODO: Re-construct CP2 tenant scope
 	// 1. Refresh CommonService Operator memory/cache to re-construct the tenant scope.
 	klog.Infof("Converting MultiInstancesEnable from %v to %v", r.Bootstrap.MultiInstancesEnable, MultiInstanceStatusFromCluster)
-	if r.Bootstrap.MultiInstancesEnable == false && MultiInstanceStatusFromCluster == true {
+	if !r.Bootstrap.MultiInstancesEnable && MultiInstanceStatusFromCluster {
 		if err := util.TurnOffRouteChangeInMgmtIngress(r.Client, "common-service", r.Bootstrap.CSData.MasterNs); err != nil {
 			klog.Errorf("Failed to keep Route unchanged for %s/common-service: %v", r.Bootstrap.CSData.MasterNs, err)
 			return ctrl.Result{}, err


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/61347

- Patch CommonService CR with `multiInstanceEnabled: false` to disable mgmt-ingress for Route changes.
  ```bash
  oc get commonservice common-service -n <operator-namespace> -o json |
     jq '.spec.services |= (if type == "array" then map(if .name == "ibm-management-ingress-operator" then .spec.managementIngress.multipleInstancesEnabled = false else . end) else . end // []) |
        if (.spec.services | map(.name == "ibm-management-ingress-operator") | any == false) then .spec.services += [{"name": "ibm-management-ingress-operator", "spec": {"managementIngress": {"multipleInstancesEnabled": false}}}] else . end' |
     oc apply -f -
  ```
- Delete the existing OperandConfig and OperandRegistry CRs in `ibm-common-services` namespace.
  ```bash
  oc delete operandregistry common-service -n <operator-namespace>
  oc delete operandconfig common-service -n <operator-namespace>
  ```
- Refresh CommonService Operator memory/cache to re-construct the tenant scope.
      - Update [`Bootstrap`](https://github.com/IBM/ibm-common-service-operator/blob/91e0f67dfccbed9f64438d9c48d260e8962e4dd1/controllers/bootstrap/init.go#L169) and [`CSdata`](https://github.com/IBM/ibm-common-service-operator/blob/91e0f67dfccbed9f64438d9c48d260e8962e4dd1/controllers/bootstrap/init.go#L156) structure.
- Patch ODLM subscription
  - A new ENV variable `PARTIAL_WATCH_NAMESPACE` with the above intersection of the two lists.
  - Update `ISOLATED_MODE` to `true`.
     ```yaml
     apiVersion: operators.coreos.com/v1alpha1
     kind: Subscription
     metadata:
        name: operand-deployment-lifecycle-manager-app
        namespace: ibm-common-services
     spec:
        channel: v3.23
        config:
           env:
              - name: ISOLATED_MODE
              value: 'true'
              - name: PARTIAL_WATCH_NAMESPACE
              value: `cp4i,...`
        name: ibm-odlm
        ...
     ```
- Re-construct the NamespaceScope CRs in `ibm-common-services` namespace.
  - It will remove existing NamespaceScope CRs `nss-managedby-odlm` and `odlm-scope-managedby-odlm`
     ```bash
     oc delete namespacescopes.operator.ibm.com nss-managedby-odlm odlm-scope-managedby-odlm -n <namespace>
     ```
  - It will update existing NamespaceScope CRs `nss-odlm-scope` and `common-service` to exclude detached namespace. In this case, it is `cp4i` namespace.