### PR TITLE
Enable and Disable CS CR reconciliation in self-isolation

### DIFF
--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
 	"github.com/IBM/ibm-common-service-operator/controllers/constant"
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
 )
@@ -770,4 +771,61 @@ func FindDifference(superset, subset []string) []string {
 	}
 
 	return difference
+}
+
+// EnableMaintenanceMode enables maintenance mode for CommonService CR
+func EnableMaintenanceMode(c client.Client, masterNs string) error {
+	// Fetch CommonService CR
+	instance := &apiv3.CommonService{}
+	if err := c.Get(context.TODO(), types.NamespacedName{
+		Name:      "common-service",
+		Namespace: masterNs,
+	}, instance); err != nil && !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get CommonService CR in %s: %v", masterNs, err)
+		return err
+	} else if errors.IsNotFound(err) {
+		klog.Infof("CommonService CR is not found in %s", masterNs)
+		return nil
+	} else {
+		// Set annotation: commonservices.operator.ibm.com/self-pause to true
+		if instance.ObjectMeta.Annotations == nil {
+			instance.ObjectMeta.Annotations = make(map[string]string)
+		}
+		instance.ObjectMeta.Annotations["commonservices.operator.ibm.com/self-pause"] = "true"
+	}
+
+	// Update CommonService CR
+	if err := c.Update(context.Background(), instance); err != nil {
+		klog.Errorf("Failed to update CommonService CR: %v", err)
+		return err
+	}
+	return nil
+}
+
+// DisableMaintenanceMode disables maintenance mode for CommonService CR
+func DisableMaintenanceMode(c client.Client, masterNs string) error {
+	// Fetch CommonService CR
+	instance := &apiv3.CommonService{}
+	if err := c.Get(context.TODO(), types.NamespacedName{
+		Name:      "common-service",
+		Namespace: masterNs,
+	}, instance); err != nil && !errors.IsNotFound(err) {
+		klog.Errorf("Failed to get CommonService CR in %s: %v", masterNs, err)
+		return err
+	} else if errors.IsNotFound(err) {
+		klog.Infof("CommonService CR is not found in %s", masterNs)
+		return nil
+	} else {
+		// Set annotation: commonservices.operator.ibm.com/self-pause to false
+		if instance.ObjectMeta.Annotations != nil {
+			instance.ObjectMeta.Annotations["commonservices.operator.ibm.com/self-pause"] = "false"
+		}
+	}
+
+	// Update CommonService CR
+	if err := c.Update(context.Background(), instance); err != nil {
+		klog.Errorf("Failed to update CommonService CR: %v", err)
+		return err
+	}
+	return nil
 }

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -774,11 +774,11 @@ func FindDifference(superset, subset []string) []string {
 }
 
 // EnableMaintenanceMode enables maintenance mode for CommonService CR
-func EnableMaintenanceMode(c client.Client, masterNs string) error {
+func EnableMaintenanceMode(c client.Client, csCR string, masterNs string) error {
 	// Fetch CommonService CR
 	instance := &apiv3.CommonService{}
 	if err := c.Get(context.TODO(), types.NamespacedName{
-		Name:      "common-service",
+		Name:      csCR,
 		Namespace: masterNs,
 	}, instance); err != nil && !errors.IsNotFound(err) {
 		klog.Errorf("Failed to get CommonService CR in %s: %v", masterNs, err)
@@ -803,11 +803,11 @@ func EnableMaintenanceMode(c client.Client, masterNs string) error {
 }
 
 // DisableMaintenanceMode disables maintenance mode for CommonService CR
-func DisableMaintenanceMode(c client.Client, masterNs string) error {
+func DisableMaintenanceMode(c client.Client, csCR string, masterNs string) error {
 	// Fetch CommonService CR
 	instance := &apiv3.CommonService{}
 	if err := c.Get(context.TODO(), types.NamespacedName{
-		Name:      "common-service",
+		Name:      csCR,
 		Namespace: masterNs,
 	}, instance); err != nil && !errors.IsNotFound(err) {
 		klog.Errorf("Failed to get CommonService CR in %s: %v", masterNs, err)

--- a/controllers/scopewatcher_controller.go
+++ b/controllers/scopewatcher_controller.go
@@ -77,7 +77,11 @@ func (r *CommonServiceReconciler) ScopeReconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	// TODO: Silence CS 3.x CR reconciliation by enabling maintenance mode
+	// Silence CS 3.x CR reconciliation by enabling maintenance mode
+	if err = util.EnableMaintenanceMode(r.Client, r.Bootstrap.CSData.MasterNs); err != nil {
+		klog.Errorf("Failed to enable maintenance mode: %v", err)
+		return ctrl.Result{}, err
+	}
 
 	// TODO: Re-construct CP2 tenant scope
 	// 1. Refresh CommonService Operator memory/cache to re-construct the tenant scope.
@@ -99,7 +103,11 @@ func (r *CommonServiceReconciler) ScopeReconcile(ctx context.Context, req ctrl.R
 
 	// 7. Delete Crossplane, webhook, and secretshare deployment
 
-	// TODO: Release the maintenance mode on CS CR reconciliation
+	// Release the maintenance mode on CS CR reconciliation
+	if err = util.DisableMaintenanceMode(r.Client, r.Bootstrap.CSData.MasterNs); err != nil {
+		klog.Errorf("Failed to disable maintenance mode: %v", err)
+		return ctrl.Result{}, err
+	}
 
 	return ctrl.Result{}, nil
 

--- a/controllers/scopewatcher_controller.go
+++ b/controllers/scopewatcher_controller.go
@@ -78,7 +78,7 @@ func (r *CommonServiceReconciler) ScopeReconcile(ctx context.Context, req ctrl.R
 	}
 
 	// Silence CS 3.x CR reconciliation by enabling maintenance mode
-	if err = util.EnableMaintenanceMode(r.Client, r.Bootstrap.CSData.MasterNs); err != nil {
+	if err = util.EnableMaintenanceMode(r.Client, "common-service", r.Bootstrap.CSData.MasterNs); err != nil {
 		klog.Errorf("Failed to enable maintenance mode: %v", err)
 		return ctrl.Result{}, err
 	}
@@ -104,7 +104,7 @@ func (r *CommonServiceReconciler) ScopeReconcile(ctx context.Context, req ctrl.R
 	// 7. Delete Crossplane, webhook, and secretshare deployment
 
 	// Release the maintenance mode on CS CR reconciliation
-	if err = util.DisableMaintenanceMode(r.Client, r.Bootstrap.CSData.MasterNs); err != nil {
+	if err = util.DisableMaintenanceMode(r.Client, "common-service", r.Bootstrap.CSData.MasterNs); err != nil {
 		klog.Errorf("Failed to disable maintenance mode: %v", err)
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/61346

#### Context

- Enable maintenance mode for CS CR at the beginning of self-isolation process
- Disable maintenance mode at the end of self-isolation