### PR TITLE
Skip reconciliation if CR is not in tenant scope

### DIFF
--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -108,6 +108,7 @@ func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 		if inScope = r.checkScope(csScope, req.NamespacedName.Namespace); !inScope {
 			klog.Infof("CommonService CR %v is not in the scope, only reconciles its configuration of cluster scope resource", req.NamespacedName.String())
+			return ctrl.Result{}, nil
 		}
 	} else if !errors.IsNotFound(err) {
 		klog.Errorf("Failed to get common-service-maps: %v", err)


### PR DESCRIPTION
issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/61446

CS operator v3 will [skip the reconciliation for the CS CR which is not in the current scope.](https://github.com/IBM/ibm-common-service-operator/blob/91e0f67dfccbed9f64438d9c48d260e8962e4dd1/controllers/commonservice_controller.go#L108), avoid any changes or update to that CR.