### PR TITLE
Update isolation condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CONTROLLER_GEN ?= $(shell which controller-gen)
 KUSTOMIZE ?= $(shell which kustomize)
 YQ_VERSION=v4.17.2
 KUSTOMIZE_VERSION=v3.8.7
-OPERATOR_SDK_VERSION=v1.24.0
+OPERATOR_SDK_VERSION=v1.29.0
 CONTROLLER_TOOLS_VERSION ?= v0.6.1
 
 CSV_PATH=bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-10-27T16:25:39Z"
+    createdAt: "2023-12-03T05:54:52Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: cloud-native-postgresql,ibm-bts-operator
     olm.skipRange: ">=3.3.0 <3.19.19"
@@ -214,6 +214,19 @@ spec:
                 - update
                 - watch
             - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+                - validatingwebhookconfigurations
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - apiextensions.ibm.crossplane.io
               resources:
                 - compositeresourcedefinitions
@@ -237,7 +250,12 @@ spec:
                 - deployments
               verbs:
                 - create
+                - delete
                 - get
+                - list
+                - patch
+                - update
+                - watch
             - apiGroups:
                 - apps
               resourceNames:
@@ -282,6 +300,15 @@ spec:
             - apiGroups:
                 - operator.ibm.com
               resources:
+                - certmanagers
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - operator.ibm.com
+              resources:
                 - commonservices
                 - commonservices/finalizers
                 - commonservices/status
@@ -291,6 +318,15 @@ spec:
                 - list
                 - patch
                 - update
+                - watch
+            - apiGroups:
+                - operator.ibm.com
+              resources:
+                - ibmlicensings
+              verbs:
+                - delete
+                - get
+                - list
                 - watch
             - apiGroups:
                 - operator.ibm.com
@@ -536,6 +572,16 @@ spec:
               verbs:
                 - create
                 - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - clusterServiceVersions
+              verbs:
                 - get
                 - list
                 - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -48,6 +48,19 @@ rules:
   - update
   - watch
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apiextensions.ibm.crossplane.io
   resources:
   - compositeresourcedefinitions
@@ -71,7 +84,12 @@ rules:
   - deployments
   verbs:
   - create
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resourceNames:
@@ -116,6 +134,15 @@ rules:
 - apiGroups:
   - operator.ibm.com
   resources:
+  - certmanagers
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  resources:
   - commonservices
   - commonservices/finalizers
   - commonservices/status
@@ -125,6 +152,15 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  resources:
+  - ibmlicensings
+  verbs:
+  - delete
+  - get
+  - list
   - watch
 - apiGroups:
   - operator.ibm.com
@@ -292,6 +328,16 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterServiceVersions
+  verbs:
   - get
   - list
   - patch

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1852,7 +1852,7 @@ func (b *Bootstrap) Cleanup(operatorNs string, resource *Resource) error {
 		}
 		return err
 	}
-	klog.Infof("Deleting resource %s/%s", operatorNs, resource.Name)
+	klog.Infof("Deleting %s resource %s/%s", resource.Kind, operatorNs, resource.Name)
 	return nil
 }
 
@@ -1866,17 +1866,44 @@ func (b *Bootstrap) IsolateODLM(excludedNsList []string) error {
 	if odlmSub.Object["spec"].(map[string]interface{})["config"] != nil {
 		if odlmSub.Object["spec"].(map[string]interface{})["config"].(map[string]interface{})["env"] != nil {
 			env := odlmSub.Object["spec"].(map[string]interface{})["config"].(map[string]interface{})["env"].([]interface{})
-			for _, e := range env {
+			// Update ISOLATED_MODE, if it doesn't exist, add it
+			// Update PARTIAL_WATCH_NAMESPACE, if it doesn't exist, add it
+			updatedIsolated := false
+			updatedPartialNs := false
+			for i, e := range env {
 				if e.(map[string]interface{})["name"] == "ISOLATED_MODE" {
-					e.(map[string]interface{})["value"] = "true"
+					env[i].(map[string]interface{})["value"] = "true"
+					updatedIsolated = true
 				}
 				if e.(map[string]interface{})["name"] == "PARTIAL_WATCH_NAMESPACE" {
-					if e.(map[string]interface{})["value"] == nil {
-						e.(map[string]interface{})["value"] = ""
+					if env[i].(map[string]interface{})["value"] == nil {
+						env[i].(map[string]interface{})["value"] = ""
 					}
-					e.(map[string]interface{})["value"] = e.(map[string]interface{})["value"].(string) + "," + strings.Join(excludedNsList, ",")
+					// check if the excludedNsList is already in PARTIAL_WATCH_NAMESPACE
+					// if it is, skip
+					// if it isn't, add it
+					partialNsList := strings.Split(env[i].(map[string]interface{})["value"].(string), ",")
+					for _, ns := range excludedNsList {
+						if !util.Contains(partialNsList, ns) {
+							env[i].(map[string]interface{})["value"] = e.(map[string]interface{})["value"].(string) + "," + ns
+						}
+					}
+					updatedPartialNs = true
 				}
 			}
+			if !updatedIsolated {
+				env = append(env, map[string]interface{}{
+					"name":  "ISOLATED_MODE",
+					"value": "true",
+				})
+			}
+			if !updatedPartialNs {
+				env = append(env, map[string]interface{}{
+					"name":  "PARTIAL_WATCH_NAMESPACE",
+					"value": strings.Join(excludedNsList, ","),
+				})
+			}
+			odlmSub.Object["spec"].(map[string]interface{})["config"].(map[string]interface{})["env"] = env
 		} else {
 			odlmSub.Object["spec"].(map[string]interface{})["config"].(map[string]interface{})["env"] = []interface{}{
 				map[string]interface{}{

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -951,7 +951,7 @@ func (b *Bootstrap) DeleteFromYaml(objectTemplate string, data interface{}) erro
 func (b *Bootstrap) GetSubscription(ctx context.Context, name, namespace string) (*unstructured.Unstructured, error) {
 	klog.Infof("Fetch Subscription: %v/%v", namespace, name)
 	sub := &unstructured.Unstructured{}
-	sub.SetGroupVersionKind(olmv1alpha1.SchemeGroupVersion.WithKind("subscription"))
+	sub.SetGroupVersionKind(olmv1alpha1.SchemeGroupVersion.WithKind("Subscription"))
 	subKey := types.NamespacedName{
 		Name:      name,
 		Namespace: namespace,

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -71,7 +71,7 @@ var ctx = context.Background()
 //+kubebuilder:rbac:groups="",resources=configmaps,resourceNames=common-service-maps;ibm-common-services-status;odlm-scope;namespace-scope,verbs=update;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=create;get;list;watch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts;events,verbs=create;get;update;patch
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,resourceNames=ibm-common-service-webhook;secretshare,verbs=update
 //+kubebuilder:rbac:groups=pkg.ibm.crossplane.io,resources=locks;configurations,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=kubernetes.crossplane.io;ibmcloud.crossplane.io,resources=providerconfigs,verbs=create;get;list;watch;update;patch;delete
@@ -81,6 +81,9 @@ var ctx = context.Background()
 //+kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=create;get;list;watch
 //+kubebuilder:rbac:groups=operator.ibm.com,resources=meteringreportservers,verbs=get;delete
 //+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get
+//+kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=create;get;list;watch;update;patch;delete
+//+kubebuilder:rbac:groups=operator.ibm.com,resources=ibmlicensings,verbs=get;list;watch;delete
+//+kubebuilder:rbac:groups=operator.ibm.com,resources=certmanagers,verbs=get;list;watch;delete
 
 //+kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=commonservices,verbs=create
 //+kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=operandregistries;operandconfigs,verbs=create;get;list;watch;update;patch;delete
@@ -89,6 +92,7 @@ var ctx = context.Background()
 //+kubebuilder:rbac:groups=monitoring.operator.ibm.com,namespace="placeholder",resources=exporters;prometheusexts,verbs=delete
 //+kubebuilder:rbac:groups=cert-manager.io,namespace="placeholder",resources=certificates;issuers,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=batch,namespace="placeholder",resources=jobs,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups=operators.coreos.com,namespace="placeholder",resources=clusterServiceVersions,verbs=get;list;patch;update;watch
 
 func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 


### PR DESCRIPTION
- Update isolation condition:
  - Continue reconciliation when CS CR has paused annotation

- Scale Down ODLM at the beginning to avoid it from reconciliation v4 tenant

- Migrate Licensing and Cert manager component from master namespace to control namespace