### PR TITLE
Add maintenance mode for Keycloak-edb

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -829,7 +829,7 @@ spec:
                     defaultValue: false
                   configMapKeyRef:
                     name: ibm-cpp-config
-                    key: keycloak-edb-maintenance
+                    key: keycloak_edb_maintenance
               reusePVC: true
             storage:
               size: 1Gi

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -822,6 +822,15 @@ spec:
                 memory: 512Mi
             logLevel: info
             primaryUpdateStrategy: unsupervised
+            nodeMaintenanceWindow:
+              inProgress:
+                templatingValueFrom:
+                  default:
+                    defaultValue: false
+                  configMapKeyRef:
+                    name: ibm-cpp-config
+                    key: keycloak-edb-maintenance
+              reusePVC: true
             storage:
               size: 1Gi
             walStorage:


### PR DESCRIPTION
Addresses https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60707#issuecomment-68164105

It introduces a new configuration option in the `ibm-cpp-config` `ConfigMap`, with boolean value `keycloak_edb_maintenance` which allows configuring the EDB maintenance mode `nodeMaintenanceWindow:true` https://www.enterprisedb.com/docs/postgres_for_kubernetes/latest/kubernetes_upgrade/