### PR TITLE
Fix swapped EDB image override configmap reference key/name

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -808,8 +808,8 @@ spec:
                     key: ibm-postgresql-14-operand-image
                     namespace: {{ .OperatorNs }}
                 configMapKeyRef:
-                    name: edb-keycloak-operand-image
-                    key: ibm-cpp-config
+                    name: ibm-cpp-config
+                    key: edb-keycloak-operand-image
             imagePullSecrets:
               - name: ibm-entitlement-key
             instances: 1


### PR DESCRIPTION
The key/name values for EDB image override configmap entry in ibm-cpp-config are swapped. Fixed this.