### PR TITLE
Avoid overwrite fields in merged CR

### DIFF
--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -101,12 +101,16 @@ func mergeCSCRs(csSummary, csCR, ruleSlice []interface{}, serviceControllerMappi
 	for _, operator := range csCR {
 		summaryCR := getItemByName(csSummary, operator.(map[string]interface{})["name"].(string))
 		rules := getItemByName(ruleSlice, operator.(map[string]interface{})["name"].(string))
-		if summaryCR == nil || summaryCR.(map[string]interface{})["spec"] == nil || summaryCR.(map[string]interface{})["resources"] == nil {
+		if summaryCR == nil {
 			summaryCR = map[string]interface{}{
 				"name":      operator.(map[string]interface{})["name"].(string),
 				"spec":      map[string]interface{}{},
 				"resources": []interface{}{},
 			}
+		} else if summaryCR.(map[string]interface{})["spec"] == nil {
+			summaryCR.(map[string]interface{})["spec"] = map[string]interface{}{}
+		} else if summaryCR.(map[string]interface{})["resources"] == nil {
+			summaryCR.(map[string]interface{})["resources"] = []interface{}{}
 		}
 		serviceController := serviceControllerMappingSummary["profileController"]
 		if controller, ok := serviceControllerMappingSummary[operator.(map[string]interface{})["name"].(string)]; ok {


### PR DESCRIPTION
Fix issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61393

When we are merging all CS CRs in the tenant scope, we extract the profile from each individual CS CR into a list.
For example
- `common-service` CR with `starter` size
- `cp4i-cs` CR with `large` size
- `cp4ba-cs` CR with `medium` size

Then we merge different profiles together to get the LARGEST value(it respect to `large` size), and save it into a summarized profile `summaryCR`.

But I always initialized this summarized profile variable `summaryCR` **as long as either one of `resources` OR `spec` field is empty**.
```
if summaryCR == nil || summaryCR.(map[string]interface{})["spec"] == nil || summaryCR.(map[string]interface{} ["resources"] == nil {
	summaryCR = map[string]interface{}{
		"name":      operator.(map[string]interface{})["name"].(string),
		"spec":      map[string]interface{}{},
		"resources": []interface{}{},
	}
}
```

Many of our profiles only contain one field. So `summaryCR` for each operator is always be initialized
```
### Only contain spec
- name: ibm-im-operator
    spec:
      authentication:
        authService:
          resources:
            limits:
              cpu: 2000m

### Only contain resources
- name: keycloak-operator
  resources:
    - apiVersion: k8s.keycloak.org/v2alpha1
      data:
        spec:
          db:
            host: keycloak-edb-cluster-rw
      force: true
      kind: Keycloak
      name: cs-keycloak
```

To fix this, I change it to initialize the field individually, to avoid overwrite.