### PR TITLE
fix: get extreme value on resources field when spec field does not exist

### DIFF
--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -530,24 +530,23 @@ func (r *CommonServiceReconciler) getExtremeizes(ctx context.Context, opconServi
 
 	for _, opService := range opconServices {
 		crSummary := getItemByName(configSummary, opService.(map[string]interface{})["name"].(string))
-		if opService.(map[string]interface{})["spec"] == nil {
-			continue
-		}
-		rules := getItemByName(ruleSlice, opService.(map[string]interface{})["name"].(string))
-		serviceController := serviceControllerMappingSummary["profileController"]
-		if controller, ok := serviceControllerMappingSummary[opService.(map[string]interface{})["name"].(string)]; ok {
-			serviceController = controller
-		}
-		for cr, spec := range opService.(map[string]interface{})["spec"].(map[string]interface{}) {
-			if _, ok := nonDefaultProfileController[serviceController]; ok {
-				// clean up OperandConfig
-				opService.(map[string]interface{})["spec"].(map[string]interface{})[cr] = resetResourceInTemplate(spec.(map[string]interface{}), cr, rules)
+		if opService.(map[string]interface{})["spec"] != nil {
+			rules := getItemByName(ruleSlice, opService.(map[string]interface{})["name"].(string))
+			serviceController := serviceControllerMappingSummary["profileController"]
+			if controller, ok := serviceControllerMappingSummary[opService.(map[string]interface{})["name"].(string)]; ok {
+				serviceController = controller
 			}
-			if crSummary == nil || crSummary.(map[string]interface{})["spec"] == nil || crSummary.(map[string]interface{})["spec"].(map[string]interface{})[cr] == nil {
-				continue
+			for cr, spec := range opService.(map[string]interface{})["spec"].(map[string]interface{}) {
+				if _, ok := nonDefaultProfileController[serviceController]; ok {
+					// clean up OperandConfig
+					opService.(map[string]interface{})["spec"].(map[string]interface{})[cr] = resetResourceInTemplate(spec.(map[string]interface{}), cr, rules)
+				}
+				if crSummary == nil || crSummary.(map[string]interface{})["spec"] == nil || crSummary.(map[string]interface{})["spec"].(map[string]interface{})[cr] == nil {
+					continue
+				}
+				serviceForCR := crSummary.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
+				opService.(map[string]interface{})["spec"].(map[string]interface{})[cr] = shrinkSize(spec.(map[string]interface{}), serviceForCR, extreme)
 			}
-			serviceForCR := crSummary.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
-			opService.(map[string]interface{})["spec"].(map[string]interface{})[cr] = shrinkSize(spec.(map[string]interface{}), serviceForCR, extreme)
 		}
 
 		if opService.(map[string]interface{})["resources"] != nil {


### PR DESCRIPTION
To fix issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61204

Update the code to not skip loop when ONLY `spec` field is `nil`.
Otherwise, it will not able to reconcile `resources` field when `spec` field is `nil`

### Previously
```
for _, opService := range opconServices {
                // Skip loop if spec is nil
		if opService.(map[string]interface{})["spec"] == nil {
			continue
		}
                update_spec_field
                
                // update resources when resources is NOT nil
                if opService.(map[string]interface{})["resources"] != nil {
			update_resources_field
		}
}
```

### Now
```
for _, opService := range opconServices {
                // update spec when spec is NOT nil
		if opService.(map[string]interface{})["spec"] != nil {
			update_spec_field
		}
               
                // update resources when resources is NOT nil
                if opService.(map[string]interface{})["resources"] != nil {
			update_resources_field
		}
}
```