### PR TITLE
update UID and resourceVersion when restoring LS CRs

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-12-05T20:36:47Z"
+    createdAt: "2023-12-07T04:57:51Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: cloud-native-postgresql,ibm-bts-operator
     olm.skipRange: ">=3.3.0 <3.19.19"
@@ -178,6 +178,7 @@ spec:
                 - configmaps
               verbs:
                 - create
+                - delete
                 - get
                 - list
                 - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   - configmaps
   verbs:
   - create
+  - delete
   - get
   - list
   - update

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -69,7 +69,7 @@ var ctx = context.Background()
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;get;update
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles;clusterrolebindings;rolebindings,verbs=create;get;list;watch;update;delete;escalate;bind
 //+kubebuilder:rbac:groups="",resources=configmaps,resourceNames=common-service-maps;ibm-common-services-status;odlm-scope;namespace-scope,verbs=update;delete
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=create;get;list;watch;update
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=create;get;list;watch;update;delete
 //+kubebuilder:rbac:groups="",resources=serviceaccounts;events,verbs=create;get;update;patch
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;watch;update;patch;delete
 //+kubebuilder:rbac:groups=apps,resources=deployments,resourceNames=ibm-common-service-webhook;secretshare,verbs=update


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61543
- Add delete verb for `ConfigMaps` resources
- set/overwrite UID and resourceVersion when restoring LS CRs