### PR TITLE
Add managedByCsOperator label for ConfigMap

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -703,6 +703,12 @@ func (b *Bootstrap) CreateCsMaps() error {
 		Data: data,
 	}
 
+	if !(cm.Labels != nil && cm.Labels[constant.CsManagedLabel] == "true") {
+		util.EnsureLabelsForConfigMap(cm, map[string]string{
+			constant.CsManagedLabel: "true",
+		})
+	}
+
 	if err := b.Client.Create(ctx, cm); err != nil {
 		klog.Errorf("could not create common-service-map in kube-public: %v", err)
 	}


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61558

When `common-service-maps` ConfigMap does not contain label `operator.ibm.com/managedByCsOperator: true`, any creation, deletion, update and other generic event on the ConfigMap will not trigger the reconciliation of v3 LTSR self-isolation.

We need to make sure v4 operator add this label into the ConfigMap when v4 operator updates or creates `common-service-maps` ConfigMap.