### PR TITLE
update zen channel to 4.4

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1054,7 +1054,7 @@ spec:
     sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
-    channel: v4.3
+    channel: v4.4
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}


### PR DESCRIPTION
zen 5.1.1 is now pushed to channel 4.4 so we need to change the value for zen from 4.3 to 4.4 so we are using the latest