### PR TITLE
Create Backup and Restore process for license service reporter

### DIFF
--- a/velero/restore/restore-lsr-data.yaml
+++ b/velero/restore/restore-lsr-data.yaml
@@ -1,0 +1,20 @@
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: restore-lsr-data
+  namespace: velero
+spec:
+  backupName: __BACKUP_NAME__
+  excludedResources:
+  - nodes
+  - events
+  - events.events.k8s.io
+  - backups.velero.io
+  - restores.velero.io
+  - resticrepositories.velero.io
+  hooks: {}
+  includedNamespaces:
+  - '*'
+  labelSelector:
+    matchLabels:
+      foundationservices.cloudpak.ibm.com: lsr-data

--- a/velero/restore/restore-lsr.yaml
+++ b/velero/restore/restore-lsr.yaml
@@ -1,0 +1,20 @@
+apiVersion: velero.io/v1
+kind: Restore
+metadata:
+  name: restore-lsr
+  namespace: velero
+spec:
+  backupName: __BACKUP_NAME__
+  excludedResources:
+  - nodes
+  - events
+  - events.events.k8s.io
+  - backups.velero.io
+  - restores.velero.io
+  - resticrepositories.velero.io
+  hooks: {}
+  includedNamespaces:
+  - '*'
+  labelSelector:
+    matchLabels:
+      foundationservices.cloudpak.ibm.com: lsr

--- a/velero/schedule/license_service_reporter/lsr-backup-deployment.yaml
+++ b/velero/schedule/license_service_reporter/lsr-backup-deployment.yaml
@@ -13,9 +13,9 @@ spec:
     metadata:
       annotations:
         backup.velero.io/backup-volumes: lsr-backup
-        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/backup_lsr.sh <lsr namespace>"]'
+        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace>"]'
         pre.hook.backup.velero.io/timeout: 300s
-        post.hook.restore.velero.io/command: '["sh", "-c", "/lsr/restore_lsr.sh <lsr namespace>"]'
+        post.hook.restore.velero.io/command: '["sh", "-c", "/lsr/br_lsr.sh <lsr namespace>"]'
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s
         post.hook.restore.velero.io/timeout: 600s

--- a/velero/schedule/license_service_reporter/lsr-backup-deployment.yaml
+++ b/velero/schedule/license_service_reporter/lsr-backup-deployment.yaml
@@ -1,0 +1,65 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: lsr-backup
+  namespace: <lsr namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: lsr-data
+spec:
+  selector:
+    matchLabels:
+      foundationservices.cloudpak.ibm.com: lsr-data
+  template:
+    metadata:
+      annotations:
+        backup.velero.io/backup-volumes: lsr-backup
+        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/backup_lsr.sh <lsr namespace>"]'
+        pre.hook.backup.velero.io/timeout: 300s
+        post.hook.restore.velero.io/command: '["sh", "-c", "/lsr/restore_lsr.sh <lsr namespace>"]'
+        post.hook.restore.velero.io/wait-timeout: 300s
+        post.hook.restore.velero.io/exec-timeout: 300s
+        post.hook.restore.velero.io/timeout: 600s
+      name: lsr-backup
+      namespace: <lsr namespace>
+      labels:
+        foundationservices.cloudpak.ibm.com: lsr-data
+    spec:
+        containers:
+        - command:
+          - sh
+          - -c
+          - sleep infinity
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.3.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2
+          imagePullPolicy: IfNotPresent
+          name: lsr-backup-job
+          resources:
+            limits:
+              cpu: 500m
+              ephemeral-storage: 512Mi
+              memory: 512Mi
+            requests:
+              cpu: 200m
+              ephemeral-storage: 128Mi
+              memory: 256Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /lsr-backup/
+            name: lsr-backup-mount
+          - name: scripts
+            mountPath: "/lsr"
+        dnsPolicy: ClusterFirst
+        schedulerName: default-scheduler
+        securityContext:
+          runAsNonRoot: true
+        serviceAccount: lsr-backup-sa
+        serviceAccountName: lsr-backup-sa
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: lsr-backup-mount
+          persistentVolumeClaim:
+            claimName: lsr-backup-pvc
+        - name: scripts
+          configMap:
+            name: lsr-br-configmap
+            defaultMode: 0777

--- a/velero/schedule/license_service_reporter/lsr-backup-deployment.yaml
+++ b/velero/schedule/license_service_reporter/lsr-backup-deployment.yaml
@@ -13,9 +13,9 @@ spec:
     metadata:
       annotations:
         backup.velero.io/backup-volumes: lsr-backup
-        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace>"]'
+        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace> backup"]'
         pre.hook.backup.velero.io/timeout: 300s
-        post.hook.restore.velero.io/command: '["sh", "-c", "/lsr/br_lsr.sh <lsr namespace>"]'
+        post.hook.restore.velero.io/command: '["sh", "-c", "/lsr/br_lsr.sh <lsr namespace> restore"]'
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s
         post.hook.restore.velero.io/timeout: 600s
@@ -44,7 +44,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
-          - mountPath: /lsr-backup/
+          - mountPath: /lsr/lsr-backup/
             name: lsr-backup-mount
           - name: scripts
             mountPath: "/lsr"

--- a/velero/schedule/license_service_reporter/lsr-backup-pvc.yaml
+++ b/velero/schedule/license_service_reporter/lsr-backup-pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: lsr-backup-pvc
-  namespace: <mongo namespace>
+  namespace: <lsr namespace>
   labels:
     foundationservices.cloudpak.ibm.com: lsr-data
 spec:

--- a/velero/schedule/license_service_reporter/lsr-backup-pvc.yaml
+++ b/velero/schedule/license_service_reporter/lsr-backup-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lsr-backup-pvc
+  namespace: <mongo namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: lsr-data
+spec:
+  storageClassName: <storage class>
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem

--- a/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
+++ b/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
@@ -42,8 +42,9 @@ data:
     function backup {
         mkdir -p $BACKUP_DIR/database
         CNPG_PRIMARY_POD=`oc get pods -n $LSR_NAMESPACE | grep ibm-license-service-reporter-instance | awk '{print $1}'` && \
+        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- rm -rf /run/lsr_backup && \
         oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- mkdir -p /run/lsr_backup && \
-        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- pg_dump -v --username=postgres --dbname=postgres -f /run/lsr_backup/lsr_db_backup.dump
+        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- pg_dump -v --username=postgres --dbname=postgres -f /run/lsr_backup/lsr_db_backup.dump --format=c
 
         #Move backup to backup location
         oc cp $LSR_NAMESPACE/$CNPG_PRIMARY_POD:/run/lsr_backup/lsr_db_backup.dump $BACKUP_DIR/database/lsr_db_backup.dump
@@ -54,7 +55,7 @@ data:
         oc exec $CNPG_PRIMARY_POD -n $LSR_NAMESPACE -- mkdir -p /run/lsr_backup
         oc cp $BACKUP_DIR/database/lsr_db_backup.dump $LSR_NAMESPACE/$CNPG_PRIMARY_POD:/run/lsr_backup/lsr_db_backup.dump
         oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- psql -U postgres -c "\list" -c "\dn" -c "\du"
-        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- pg_restore -U postgres -f /run/lsr_backup/lsr_db_backup.dump --clean -v --if-exists
+        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- pg_restore -U postgres --dbname postgres --format=c --clean -v /run/lsr_backup/lsr_db_backup.dump
         oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- psql -U postgres -c "\list" -c "\dn" -c "\du"
     }
 

--- a/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
+++ b/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lsr-br-configmap
+  namespace: <lsr namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: lsr-data
+data:
+  br_lsr.sh: |
+    #!/usr/bin/env bash
+
+    # Licensed Materials - Property of IBM
+    # Copyright IBM Corporation 2023. All Rights Reserved
+    # US Government Users Restricted Rights -
+    # Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+    #
+    # This is an internal component, bundled with an official IBM product.
+    # Please refer to that particular license for additional information.
+
+    # ---------- Command arguments ----------
+
+    set -o errtrace
+    set -o errexit
+
+    MODE=$1
+    LSR_NAMESPACE=$2
+
+    BACKUP_DIR=/lsr/lsr-backup
+
+    function main {
+        if [[ $MODE == "backup" ]]; then
+            info "Mode set to backup, beginning backup process."
+            backup
+            success "Backup completed successfully."
+        else
+            info "Mode is set to restore, beginning restore process."
+            restore
+            success "Restore completed successfully."
+        fi
+    }
+
+    function backup {
+        mkdir -p $BACKUP_DIR/database
+        CNPG_PRIMARY_POD=`oc get pods -n $LSR_NAMESPACE | grep ibm-license-service-reporter-instance | awk '{print $1}'` && \
+        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- mkdir -p /run/lsr_backup && \
+        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- pg_dump -v --username=postgres --dbname=postgres -f /run/lsr_backup/lsr_db_backup.dump
+
+        #Move backup to backup location
+        oc cp $LSR_NAMESPACE/$CNPG_PRIMARY_POD:/run/lsr_backup/lsr_db_backup.dump $BACKUP_DIR/database/lsr_db_backup.dump
+    }
+
+    function restore {
+        CNPG_PRIMARY_POD=`oc get pods -n $LSR_NAMESPACE | grep ibm-license-service-reporter-instance | awk '{print $1}'`
+        oc exec $CNPG_PRIMARY_POD -n $LSR_NAMESPACE -- mkdir -p /run/lsr_backup
+        oc cp $BACKUP_DIR/database/lsr_db_backup.dump $LSR_NAMESPACE/$CNPG_PRIMARY_POD:/run/lsr_backup/lsr_db_backup.dump
+        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- psql -U postgres -c "\list" -c "\dn" -c "\du"
+        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- pg_restore -U postgres -f /run/lsr_backup/lsr_db_backup.dump --clean -v --if-exists
+        oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- psql -U postgres -c "\list" -c "\dn" -c "\du"
+    }
+
+    function msg() {
+        printf '%b\n' "$1"
+    }
+
+    function success() {
+        msg "\33[32m[✔] ${1}\33[0m"
+    }
+
+    function warning() {
+        msg "\33[33m[✗] ${1}\33[0m"
+    }
+
+    function error() {
+        msg "\33[31m[✘] ${1}\33[0m"
+        exit 1
+    }
+
+    function title() {
+        msg "\33[34m# ${1}\33[0m"
+    }
+
+    function info() {
+        msg "[INFO] ${1}"
+    }
+
+    main $*

--- a/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
+++ b/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
@@ -22,8 +22,8 @@ data:
     set -o errtrace
     set -o errexit
 
-    MODE=$1
-    LSR_NAMESPACE=$2
+    LSR_NAMESPACE=$1
+    MODE=$2
 
     BACKUP_DIR=/lsr/lsr-backup
 

--- a/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
+++ b/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
@@ -32,10 +32,12 @@ data:
             info "Mode set to backup, beginning backup process."
             backup
             success "Backup completed successfully."
-        else
+        else if [[ $MODE == "restore" ]]
             info "Mode is set to restore, beginning restore process."
             restore
             success "Restore completed successfully."
+        else
+            error "Invalid mode entered. Please specify \"backup\" or \"restore\"."
         fi
     }
 

--- a/velero/schedule/license_service_reporter/lsr-role.yaml
+++ b/velero/schedule/license_service_reporter/lsr-role.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lsr-backup-role
+  namespace: <lsr instance namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: lsr-data
+rules:
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ''
+      - batch
+      - extensions
+      - apps
+      - policy
+    resources:
+      - pods
+      - pods/exec

--- a/velero/schedule/license_service_reporter/lsr-role.yaml
+++ b/velero/schedule/license_service_reporter/lsr-role.yaml
@@ -9,6 +9,7 @@ rules:
   - verbs:
       - get
       - list
+      - create
     apiGroups:
       - ''
       - batch

--- a/velero/schedule/license_service_reporter/lsr-rolebinding.yaml
+++ b/velero/schedule/license_service_reporter/lsr-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lsr-backup-rolebinding
+  namespace: <lsr instance namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: lsr-data
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lsr-backup-role
+  namespace: <lsr instance namespace>
+subjects:
+- kind: ServiceAccount
+  name: lsr-backup-sa
+  namespace: <lsr instance namespace>

--- a/velero/schedule/license_service_reporter/lsr-sa.yaml
+++ b/velero/schedule/license_service_reporter/lsr-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lsr-backup-sa
+  namespace: <lsr instance namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: lsr-data

--- a/velero/schedule/schedule-common-services.yaml
+++ b/velero/schedule/schedule-common-services.yaml
@@ -36,3 +36,5 @@ spec:
         - zen5
         - zen5-data
         - crd
+        - lsr
+        - lsr-data


### PR DESCRIPTION
The License Service Reporter has a couple things to include in their backup/restore process and this pr (along with an update to the documentation) should cover them all. This PR was also used to test the use of pg_dump and pg_restore for postgres databases. After some tinkering with the two commands, I have stabilized the process.

As of opening this pr, here are the steps required to BR LSR:
- Add labels to secrets:
    * ibm-license-service-reporter-token
    * Ibm-license-service-reporter-credentials
    * Ibm-license-service-reporter-credentials-htpasswd
    * Possible secrets for oidc client secret and oidc provider if configured
        * Secret names found in LSR CR under following fields
            * --client-secret-name=
            * --provider-ca-secret-name=
- Add labels to CRD, CR, subscription, and operatorgroup (foundationservices.cloudpak.ibm.com: lsr)
    * CRD name: ibmlicenseservicereporters.operator.ibm.com
    * CR name: Instance
    * Sub name: ibm-license-service-reporter-operator
    * Operatorgroup name: operatorgroup
- Create deployment files for Postgres db backup
    - Deploy
    - Pvc
    - Script configmap
    - Role
    - Rolebinding
    - Service account