### PR TITLE
Remove cert-manager API dependency

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-11-06T04:32:47Z"
+    createdAt: "2024-01-04T22:59:50Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -479,10 +479,6 @@ spec:
       name: IBM Support
   maturity: alpha
   minKubeVersion: 1.19.0
-  nativeAPIs:
-    - group: cert-manager.io
-      kind: Certificate
-      version: v1
   provider:
     name: IBM
   version: 4.4.0

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -179,10 +179,6 @@ spec:
     name: IBM Support
   maturity: alpha
   minKubeVersion: 1.19.0
-  nativeAPIs:
-  - group: cert-manager.io
-    kind: Certificate
-    version: v1
   provider:
     name: IBM
   relatedImages:


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60327
To prevent installation blocks in the absence of cert-manager, removed OLM dependency on cert-manager APIs from cs-operator.