### PR TITLE
Patching mgmtIngress CR only when converting from shared to dedicated mode

### DIFF
--- a/convert_to_multi_instance.sh
+++ b/convert_to_multi_instance.sh
@@ -576,7 +576,7 @@ function check_CSCR() {
             sleep ${sleep_time}
         else
             msg "-----------------------------------------------------------------------"    
-            success "Ready use"
+            success "IBM Common Services CR is Succeeded, Ready to proceed"
             break
         fi
     done


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61627

1. Patching OperandConfig and CommonService is sufficient to ensure that mgmtIngress CR will be updated with `multipleInstancesEnabled: false` by ODLM when mgmtIngress CR exists.
2. Conditional patching resources with `multipleInstancesEnabled: false`.
   - It only happens when we are converting Bedrock instance from a cluster shared instance to a dedicated instance.
   - It would not enable `multipleInstancesEnabled: false` when Bedrock instance was already in dedicated mode before running `isolate.sh`

### Test
- Test on a Bedrock 3.x which is in cluster shared mode, and running `isolate.sh` to convert it to a dedicated mode.
  ```bash
  ./isolate.sh --original-cs-ns ibm-common-services --control-ns cs-control
  
  ...
  subscription.operators.coreos.com/operand-deployment-lifecycle-manager-app patched
  [INFO] Waiting for OLM to update Deployment operand-deployment-lifecycle-manager 
  [✔] Deployment operand-deployment-lifecycle-manager is updated
  
  ...
  
  [✔] Commonservice common-service created in ibm-common-services.
  # Updating commonservice common-service in namespace ibm-common-services for management ingress CR ...
  [INFO] ibm-management-ingress-operator already exists in CS CR .spec.services, updating it ...
  [✔] Commonservice common-service updated in ibm-common-services for management ingress CR.
  [INFO] Waiting for operandconfig common-service in namespace ibm-common-services to be created ...
  [INFO] RETRYING: Waiting for operandconfig common-service in namespace ibm-common-services to be created ... (20 left)
  [INFO] RETRYING: Waiting for operandconfig common-service in namespace ibm-common-services to be created ... (19 left)
  [✔] Operandconfig common-service created in ibm-common-services.
  # Updating operandconfig common-service in namespace ibm-common-services for management ingress CR ...
  [INFO] ibm-management-ingress-operator already exists in operandconfig CR .spec.services, updating it ...
  [✔] Operandconfig common-service updated in ibm-common-services for management ingress CR.
  [INFO] Waiting for IBM Common Services CR is Succeeded
  -----------------------------------------------------------------------
  [✔] IBM Common Services CR is Succeeded, Ready to proceed
  ```

- Test on a Bedrock 3.x which already in dedicated mode, and running `isolate.sh` does not make any difference
  ```bash
  
  ...
  [INFO] isolated mode already set to true in ODLM subscription...
  subscription.operators.coreos.com/operand-deployment-lifecycle-manager-app patched (no change)
  [INFO] Waiting for OLM to update Deployment operand-deployment-lifecycle-manager 
  [✔] Deployment operand-deployment-lifecycle-manager is updated
  
  ...
  [✗] Instance has been isolated previously, skipping patching commonservice and operandconfig for management ingress CR...
  [INFO] Waiting for IBM Common Services CR is Succeeded
  [INFO] RETRYING: Waiting for IBM Common Services CR is Succeeded (29 left)
  [INFO] RETRYING: Waiting for IBM Common Services CR is Succeeded (28 left)
  [INFO] RETRYING: Waiting for IBM Common Services CR is Succeeded (27 left)
  -----------------------------------------------------------------------
  [✔] IBM Common Services CR is Succeeded, Ready to proceed
  [✔] Common Service Operator restarted.
  ```
