### PR TITLE
Resolve issue with WaitForFirstConsumer volumeBindingMode

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -517,14 +517,15 @@ function swapmongopvc() {
   fi
 
   ${OC} patch pv $VOL -p '{"spec": { "persistentVolumeReclaimPolicy" : "Retain" }}'
-  ${OC} patch pv $VOL --type=merge -p '{"spec": {"claimRef":null}}'
-  ${OC} patch pv $VOL --type json -p '[{ "op": "remove", "path": "/spec/claimRef" }]'
   
   ${OC} delete pvc cs-mongodump -n $FROM_NAMESPACE --ignore-not-found --timeout=10s
   if [ $? -ne 0 ]; then
       info "Failed to delete pvc cs-mongodump, patching its finalizer to null..."
       ${OC} patch pvc cs-mongodump -n $FROM_NAMESPACE --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
   fi
+
+  ${OC} patch pv $VOL --type=merge -p '{"spec": {"claimRef":null}}'
+  ${OC} patch pv $VOL --type json -p '[{ "op": "remove", "path": "/spec/claimRef" }]' #this line is proving problematic
 
   roks=$(${OC} cluster-info | grep 'containers.cloud.ibm.com')
   if [[ -z $roks ]]; then

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -292,7 +292,7 @@ EOF
 
   ${OC} apply -f $TEMPFILE
 
-  wait_trigger=$(${OC} get sc $NEW_STORAGE_CLASS -o yaml | grep volumeBindingMode: | awk '{print $2}')
+  wait_trigger=$(${OC} get sc $stgclass -o yaml | grep volumeBindingMode: | awk '{print $2}')
   if [[ $wait_trigger == "WaitForFirstConsumer" ]]; then
     info "StorageClass waits for pod to claim PVC, skipping wait for binding."
   else


### PR DESCRIPTION
A couple changes needed to be made to resolve the problem found in SERT issue 60021

- The previous variable used in the check was not set prior to being used, changed to use the existing `stgclass` variable instead
- There was no check on the restore side, only the backup. Copy and pasted the check on the backup side to also be on the restore side
- noticed an unrelated problem with claim ref repopulating before deleting the old pvc. Changed the claimref clearance to after the old pvc was deleted

Tested the script beginning to end by creating a new storageclass `rook-cephfs-test` which was a copy pasted `rook-cephfs` but changed the `volumeBindingMode` to `WaitForFirstConsumer` which should be representative of the problem experienced in the issue.

Waiting to see if SERT can produce an AWS cluster to have a more direct test.