### PR TITLE
downgrade zen channel back to v4.3

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -217,14 +217,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - name: ibm-platformui-operator-v4.4
-    namespace: "{{ .CPFSNs }}"
-    channel: v4.4
-    packageName: ibm-zen-operator
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -419,9 +411,6 @@ spec:
     spec:
       operandBindInfo: {}
   - name: ibm-platformui-operator-v4.3
-    spec:
-      operandBindInfo: {}
-  - name: ibm-platformui-operator-v4.4
     spec:
       operandBindInfo: {}
 `
@@ -1054,7 +1043,7 @@ spec:
     sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
-    channel: v4.4
+    channel: v4.3
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}


### PR DESCRIPTION
For Bedrock 4.4 January release, Zen 5.1.x will use the same `v4.3` channel as Zen `5.1.0` uses.

- Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61522
- Slack discussion: https://ibm-cloudplatform.slack.com/archives/G01KTNY2ZCL/p1704749857268399?thread_ts=1702932338.968739&cid=G01KTNY2ZCL