### PR TITLE
Fix bug in theme - switch from cloud-pak to cloudpak name

### DIFF
--- a/hack/keycloak-themes/theme/cloudpak/account/theme.properties
+++ b/hack/keycloak-themes/theme/cloudpak/account/theme.properties
@@ -1,5 +1,5 @@
 parent=keycloak.v2
-import=common/cloud-pak
+import=common/cloudpak
 deprecatedMode=false
 
 developmentMode=false

--- a/hack/keycloak-themes/theme/cloudpak/admin/theme.properties
+++ b/hack/keycloak-themes/theme/cloudpak/admin/theme.properties
@@ -1,5 +1,5 @@
 parent=keycloak.v2
-import=common/cloud-pak
+import=common/cloudpak
 deprecatedMode=false
 
 developmentMode=false


### PR DESCRIPTION
Bugs from importing from my repo - I was using cloud-pak as the name and the right name is cloudpak.

This enables the theme to show up for admin/account consoles.