### PR TITLE
Update preview dir path to support multi non-root user

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -45,7 +45,7 @@ BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 LOG_FILE="migrate_tenant_log_$(date +'%Y%m%d%H%M%S').log"
 
 # preview mode directory
-PREVIEW_DIR="/tmp/preview"
+PREVIEW_DIR="/tmp/migrate-tenant-$(date +'%Y%m%d%H%M%S')-preview"
 
 # counter to keep track of installation steps
 STEP=0

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -49,7 +49,7 @@ BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 LOG_FILE="setup_singleton_log_$(date +'%Y%m%d%H%M%S').log"
 
 # preview mode directory
-PREVIEW_DIR="/tmp/preview"
+PREVIEW_DIR="/tmp/setup-singleton-$(date +'%Y%m%d%H%M%S')-preview"
 
 # counter to keep track of installation steps
 STEP=0

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -46,7 +46,7 @@ LOG_FILE="setup_tenant_log_$(date +'%Y%m%d%H%M%S').log"
 STEP=0
 
 # preview mode directory
-PREVIEW_DIR="/tmp/preview"
+PREVIEW_DIR="/tmp/setup-tenant-$(date +'%Y%m%d%H%M%S')-preview"
 
 # ---------- Main functions ----------
 

--- a/isolate.sh
+++ b/isolate.sh
@@ -45,7 +45,7 @@ BASE_DIR=$(cd $(dirname "$0")/$(dirname "$(readlink $0)") && pwd -P)
 LOG_FILE="isolate_log_$(date +'%Y%m%d%H%M%S').log"
 
 # preview mode directory
-PREVIEW_DIR="/tmp/preview"
+PREVIEW_DIR="/tmp/isolate-$(date +'%Y%m%d%H%M%S')-preview"
 
 # ---------- Main functions ----------
 


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61784

Each execution of script will re-direct the preview file into different directory. So it will support different non-root users to run the same script under on same Linux based client.

After executing `setup_singleton.sh` multiple times, this is the files and directories under `/tmp` folder
```
> ls -r /tmp/*-preview

/tmp/setup-singleton-20240110105758-preview:
operatorgroup.yaml

/tmp/setup-singleton-20240110105549-preview:
operatorgroup.yaml issuer.yaml        certificate.yaml

/tmp/isolate-20240110100317-preview:
```
