### PR TITLE
Reference EDB License Secret from OperatorNamespace

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -860,6 +860,7 @@ spec:
                   kind: Secret
                   name: postgresql-operator-controller-manager-config
                   path: .metadata.annotations.ibm-license-key-applied
+                  namespace: {{ .OperatorNs }}
                 required: true
             bootstrap:
               initdb:


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61807

When CommonService is deployed in All Namespace mode or separation of control and data, `postgresql-operator-controller-manager-config` secret will be in operator namespace. And EDB CR is in a different namespace which is services namespace.