### PR TITLE
delete LSR ConfigMap from Pak ns during isolation

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -386,6 +386,9 @@ function uninstall_singletons() {
             ${OC} patch -n "${MASTER_NS}" OperandBindInfo ibm-licensing-bindinfo --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
         fi
     fi
+    for ns in ${EXCLUDED_NS//,/ }; do
+        "${OC}" delete -n "${ns}" --ignore-not-found configmap ibm-license-service-reporter-bindinfo-ibm-license-service-reporter-zen
+    done
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-crossplane-operator-app
     "${OC}" delete -n "${MASTER_NS}" --ignore-not-found sub ibm-crossplane-provider-kubernetes-operator-app
     csv=$("${OC}" get -n "${MASTER_NS}" csv | (grep ibm-crossplane-operator || echo "fail") | awk '{print $1}')


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60889

When Bedrock v3 was originally installed in cluster shared mode, LSR will create an [OperandBindinfo named `ibm-license-service-reporter-bindinfo`](https://github.com/IBM/ibm-licensing-operator/blob/release-ltsr/controllers/resources/reporter/helper.go#L211C33-L211C33) to share [ConfigMap `ibm-license-service-reporter-zen`](https://github.com/IBM/ibm-licensing-operator/blob/release-ltsr/controllers/resources/reporter/secrets.go#L93C4-L93C4) from `ibm-common-services` to other Cloud Pak namespaces.

During the isolation, although Cloud Pak namespace was excluded from original Bedrock v3 instance, the copied ConfigMap `ibm-license-service-reporter-bindinfo-ibm-license-service-reporter-zen` was left in the Cloud Pak namespace, causing a UI issue.

The fix is to manually delete this ConfigMap from Cloud Pak namespace, and it will NOT be re-copied by ODLM v3 after isolation, because Cloud Pak namespace has been excluded from original ODLM v3 tenant scope.