### PR TITLE
updated opcon so Keycloak uses OCP certs

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -8,6 +8,11 @@ metadata:
           "apiVersion": "operator.ibm.com/v3",
           "kind": "CommonService",
           "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-common-service-operator",
+              "app.kubernetes.io/managed-by": "ibm-common-service-operator",
+              "app.kubernetes.io/name": "ibm-common-service-operator"
+            },
             "name": "example-commonservice"
           },
           "spec": {
@@ -17,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-01-04T22:59:50Z"
+    createdAt: "2024-01-10T21:50:05Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -45,9 +50,9 @@ spec:
         kind: CommonService
         name: commonservices.operator.ibm.com
         specDescriptors:
-          - displayName: License
+          - description: License information for this instance. You must accept the license.
+            displayName: License
             path: license
-            description: License information for this instance. You must accept the license.
           - description: Read and accept the license that is applicable to your installation. For more information, see https://ibm.biz/icpfs39license
             displayName: Accept
             path: license.accept
@@ -71,78 +76,76 @@ spec:
             displayName: Size
             path: size
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:select:starterset
-            - urn:alm:descriptor:com.tectonic.ui:select:starter
-            - urn:alm:descriptor:com.tectonic.ui:select:small
-            - urn:alm:descriptor:com.tectonic.ui:select:medium
-            - urn:alm:descriptor:com.tectonic.ui:select:large
-            - urn:alm:descriptor:com.tectonic.ui:select:production
+              - urn:alm:descriptor:com.tectonic.ui:select:starterset
+              - urn:alm:descriptor:com.tectonic.ui:select:starter
+              - urn:alm:descriptor:com.tectonic.ui:select:small
+              - urn:alm:descriptor:com.tectonic.ui:select:medium
+              - urn:alm:descriptor:com.tectonic.ui:select:large
+              - urn:alm:descriptor:com.tectonic.ui:select:production
           - displayName: Operator namespace
             path: operatorNamespace
             x-descriptors:
-            - urn:alm:descriptor:io.kubernetes:Namespace
+              - urn:alm:descriptor:io.kubernetes:Namespace
           - displayName: Services namespace
             path: servicesNamespace
             x-descriptors:
-            - urn:alm:descriptor:io.kubernetes:Namespace
-          # ----------- Advanced Section -----------
+              - urn:alm:descriptor:io.kubernetes:Namespace
           - displayName: Storage class
             path: storageClass
             x-descriptors:
-            - urn:alm:descriptor:io.kubernetes:StorageClass
-            - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:io.kubernetes:StorageClass
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: FIPS mode
             path: fipsEnabled
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-            - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - description: The profile controller for IBM Cloud Pak foundational services
             displayName: ProfileController
             path: profileController
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:select:default
-            - urn:alm:descriptor:com.tectonic.ui:select:commonservice
-            - urn:alm:descriptor:com.tectonic.ui:select:turbonomic
-            - urn:alm:descriptor:com.tectonic.ui:select:vpa
-            - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:select:default
+              - urn:alm:descriptor:com.tectonic.ui:select:commonservice
+              - urn:alm:descriptor:com.tectonic.ui:select:turbonomic
+              - urn:alm:descriptor:com.tectonic.ui:select:vpa
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: Identity management custom hostname
             path: routeHost
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: Identity management custom certificates
             path: BYOCACertificate
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
-            - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: Identity management default admin username
             path: defaultAdminUser
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: Custom OLM catalog name
             path: catalogName
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: Custom OLM catalog namespace
             path: catalogNamespace
             x-descriptors:
-            - urn:alm:descriptor:io.kubernetes:Namespace
-            - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:io.kubernetes:Namespace
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - displayName: OLM Install Plan approval mode
             path: installPlanApproval
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:select:Automatic
-            - urn:alm:descriptor:com.tectonic.ui:select:Manual
-            - urn:alm:descriptor:com.tectonic.ui:advanced
-          # ----------- Hidden Section -----------
+              - urn:alm:descriptor:com.tectonic.ui:select:Automatic
+              - urn:alm:descriptor:com.tectonic.ui:select:Manual
+              - urn:alm:descriptor:com.tectonic.ui:advanced
           - path: manualManagement
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
+              - urn:alm:descriptor:com.tectonic.ui:hidden
           - path: features
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
+              - urn:alm:descriptor:com.tectonic.ui:hidden
           - path: services
             x-descriptors:
-            - urn:alm:descriptor:com.tectonic.ui:hidden
+              - urn:alm:descriptor:com.tectonic.ui:hidden
         statusDescriptors:
           - description: Installed Bedrock Operator Name
             displayName: Name

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,10 +14,19 @@ rules:
   resourceNames:
   - common-service-maps
 - verbs:
+  - delete
+  apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - cloud-native-postgresql-image-list
+- verbs:
   - create
   - get
   - list
   - watch
+  - update
   apiGroups:
   - ''
   resources:


### PR DESCRIPTION
Updated default OperandConfig so that Keycloak uses OCP service serving cert instead of generating Certificate from cert-manager
- prefixed intermediary resources like the Service and service cert secret name with `cpfs-opcon-`, open for feedback to change name
- Route and Secret containing certs both still have the same name as what was GA-ed, so backwards compatibility maintained

Also updated role.yaml to properly generate CSV

How to test:

Pre-reqs:

1. pull secret for EDB and EDB catalogsource

Steps:

1. Install cs-operator from GA
2. Edit the image in CSV to `quay.io/henry_h_li/common-service-operator-amd64:dev` or build your own image from this PR
3. Delete the default OperandConfig and wait for it to be re-created
4. Create OperandRequest for keycloak

```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  name: keycloak-test
  namespace: cp1
spec:
  requests:
    - operands:
        - name: keycloak-operator
      registry: common-service
      registryNamespace: ibm-common-services
```