### PR TITLE
fix lint error for KeyCloak CR

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -585,9 +585,11 @@ spec:
                         limits:
                           cpu: 1000m
                           memory: 1Gi
+                          ephemeral-storage: 512Mi
                         requests:
                           cpu: 1000m
                           memory: 1Gi
+                          ephemeral-storage: 256Mi
                       volumeMounts:
                         - mountPath: /mnt/truststore
                           name: truststore-volume
@@ -614,6 +616,17 @@ spec:
                           - key: cloudpak-theme.jar
                             path: cloudpak-theme.jar
                         name: cs-keycloak-theme
+                  affinity:
+                    nodeAffinity:
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        nodeSelectorTerms:
+                        - matchExpressions:
+                          - key: kubernetes.io/arch
+                            operator: In
+                            values:
+                            - amd64
+                            - ppc64le
+                            - s390x
         force: true
         kind: Keycloak
         name: cs-keycloak


### PR DESCRIPTION
Fix for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61198
test image: quay.io/yuchen_shen/cs_operator:keycloak_lint

- Add ephemeral storage limit and request in `Keycloak` CR
- Add nodeAffinity for Keycloak pod.