### PR TITLE
Handle Keycloak upgrade to refresh cs-keycloak-tls-secret

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -493,17 +493,13 @@ spec:
               echo "Truststore file built, starting Keycloak ..."
               "/opt/keycloak/bin/kc.sh" "$@" --spi-truststore-file-file=${TRUSTSTORE_DIR}/keycloak-truststore.jks --spi-truststore-file-password=changeit --spi-truststore-file-hostname-verification-policy=WILDCARD
       - apiVersion: v1
+        annotations:
+          service.beta.openshift.io/serving-cert-secret-name: cpfs-opcon-cs-keycloak-tls-secret
+        labels:
+          app: keycloak
+          app.kubernetes.io/instance: cs-keycloak
+          app.kubernetes.io/managed-by: keycloak-operator
         data:
-          metadata:
-            annotations:
-              service.beta.openshift.io/serving-cert-secret-name: cpfs-opcon-cs-keycloak-tls-secret
-            labels:
-              app: keycloak
-              app.kubernetes.io/instance: cs-keycloak
-              app.kubernetes.io/managed-by: keycloak-operator
-              operator.ibm.com/opreq-control: 'true'
-            name: cpfs-opcon-cs-keycloak-service
-            namespace: {{ .ServicesNs }}
           spec:
             internalTrafficPolicy: Cluster
             ipFamilies:
@@ -524,6 +520,8 @@ spec:
         kind: Service
         name: cpfs-opcon-cs-keycloak-service
       - apiVersion: v1
+        labels:
+          operator.ibm.com/opreq-control: 'true'
         data:
           stringData:
             ca.crt:


### PR DESCRIPTION
When CS upgrade from 4.3 to 4.4, the owner of `cs-keycloak-tls-secret` was changed.
The owner of secret was `cs-keycloak-tls-certificate` in CS 4.3, and it changed to ODLM managing the secret in 4.4.

But ODLM will only manage/update a resource with label `operator.ibm.com/opreq-control: 'true'`.
As a result, `cs-keycloak-tls-secret` was not updated by ODLM to correctly reflect OCP serving cert in upgrade scenario, because it is missing such label in CS 4.3.

In order to solve this issue, two changes are made.
- Explicitly specify the label `operator.ibm.com/opreq-control: 'true'` in OperandConfig template for `cs-keycloak-tls-secret`, so ODLM will claim the owner of secret.
- Update ODLM logic, once label `operator.ibm.com/opreq-control: 'true'` is specified for certain resource in OperandConfig, and `force: true` is set, ODLM will update this resource definitely. See PR https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1010


------------------------------------------------------------------------------------
Also, Additional changes how to specify label and annotations for Service `cpfs-opcon-cs-keycloak-service`.
[`.data` field was not doing a deep merge yet with existing resources in the cluster](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61283), it means that existing resource's `.metadata` field will be totally overwritten by what is specified in OperandConfig
```
- apiVersion: v1
  data:
    metadata:       <------ existing resource's entire metadata field will be overwritten by content in template
      annotations:
        service.beta.openshift.io/serving-cert-secret-name: cpfs-opcon-cs-keycloak-tls-secret
      labels:
        app: keycloak
        app.kubernetes.io/instance: cs-keycloak
        app.kubernetes.io/managed-by: keycloak-operator
        operator.ibm.com/opreq-control: 'true'
      name: cpfs-opcon-cs-keycloak-service
      namespace: {{ .ServicesNs }}
    spec:
      internalTrafficPolicy: Cluster
      ipFamilies:
        - IPv4
      xxxx: xxxxx
  force: true
  kind: Service
  name: cpfs-opcon-cs-keycloak-service
```
