### PR TITLE
grant new zen operator permission to nss operator

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -2101,3 +2101,13 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskrun/status
+  - taskrun
+  - taskruns/status
+  - taskruns
+  verbs:
+  - get
+  - list


### PR DESCRIPTION
fix permission issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61841

error msg in nss operator pod:
```
E0111 20:09:00.408154       1 namespacescope_controller.go:619] Failed to create role cp1-ns/ibm-zen-operator-4a84785ac0b629: roles.rbac.authorization.k8s.io "ibm-zen-operator-4a84785ac0b629" is forbidden: user "system:serviceaccount:cs-operators:ibm-namespace-scope-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:cs-operators" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["tekton.dev"], Resources:["taskrun"], Verbs:["get" "list"]}
{APIGroups:["tekton.dev"], Resources:["taskrun/status"], Verbs:["get" "list"]}
{APIGroups:["tekton.dev"], Resources:["taskruns"], Verbs:["get" "list"]}
{APIGroups:["tekton.dev"], Resources:["taskruns/status"], Verbs:["get" "list"]}
```