### PR TITLE
fixed cert-manager crd check

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 		}
 
 		// check if cert-manager CRD does not exist, then skip cert-manager related controllers initialization
-		exist, err := bs.CheckCRD(constant.CertManagerAPIGroupVersionV1, "certificates")
+		exist, err := bs.CheckCRD(constant.CertManagerAPIGroupVersionV1, "Certificate")
 		if err != nil {
 			klog.Errorf("Failed to check if cert-manager CRD exists: %v", err)
 			os.Exit(1)


### PR DESCRIPTION
crd check had typo when passing the kind to check, was certificates instead of Certificate, which caused the check to always think that there was no cert-manager CRD on the cluster