### PR TITLE
added cert label to keycloak cert secret

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -522,6 +522,7 @@ spec:
       - apiVersion: v1
         labels:
           operator.ibm.com/opreq-control: 'true'
+          operator.ibm.com/watched-by-cert-manager: ''
         data:
           stringData:
             ca.crt:


### PR DESCRIPTION
in order to leverage pod restart logic in cs-operator, the label is necessary