### PR TITLE
Add common to the list of theme types so it works in jar format

### DIFF
--- a/hack/keycloak-themes/META-INF/keycloak-themes.json
+++ b/hack/keycloak-themes/META-INF/keycloak-themes.json
@@ -1,6 +1,6 @@
 {
     "themes": [{
         "name" : "cloudpak",
-        "types": [ "login", "account", "admin", "email" ]
+        "types": [ "login", "account", "admin", "email", "common" ]
     }]
 }


### PR DESCRIPTION
Follow on from #1739 which didn't work if the theme was in a jar file.