### PR TITLE
Update the Makefile so it can be run from anywhere

### DIFF
--- a/hack/keycloak-themes/Makefile
+++ b/hack/keycloak-themes/Makefile
@@ -1,8 +1,10 @@
-KEYCLOAK_THEME_DIR ?= hack/keycloak-themes
+KEYCLOAK_THEME_DIR ?= $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 JAR_THEME_FILE ?= cloudpak-theme.jar
 
 default: cloudpak-theme.jar
 
+.PHONY: cloudpak-theme.jar
 cloudpak-theme.jar:
 	@echo "Building the keycloak jar theme..."
-	@(cd $(KEYCLOAK_THEME_DIR) && zip -r ./$(JAR_THEME_FILE) META-INF theme)
+	rm ./$(JAR_THEME_FILE)
+	(cd $(KEYCLOAK_THEME_DIR) && zip -r ./$(JAR_THEME_FILE) META-INF theme)


### PR DESCRIPTION
The makefile was hard coded to only work if run from the root of the repo, this makes it runnable from anywhere, so you can just run `make` from the theme directory and get the jar.

Also removed the @ so the build log shows the command more clearly.