### PR TITLE
update for licesning case with spec.sender set during self-isolation

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2023-12-07T04:57:51Z"
+    createdAt: "2024-01-19T05:32:50Z"
     description: The IBM Common Service Operator is used to deploy IBM Common Services
     nss.operator.ibm.com/managed-operators: cloud-native-postgresql,ibm-bts-operator
     olm.skipRange: ">=3.3.0 <3.19.20"
@@ -234,6 +234,12 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
             - apiGroups:
                 - admissionregistration.k8s.io
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -69,6 +69,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+- apiGroups:
   - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1965,7 +1965,6 @@ func (b *Bootstrap) BackupCRtoCm(crNs, cmName, cmKey, targetNs string, resource 
 					backupCr.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterURL"] = "https://READ_(ibm.biz/lsr_sender_config)"
 				}
 				if backupCr.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterSecretToken"] != nil {
-					klog.Infof("")
 					backupCr.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterSecretToken"] = "ibm-license-service-reporter-token"
 				}
 			}

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1910,6 +1910,7 @@ func (b *Bootstrap) BackupCRtoCm(crNs, cmName, cmKey, targetNs string, resource 
 	exist, err := b.ResourceExists(dc, APIGroupVersion, resource.Kind)
 	if err != nil {
 		klog.Errorf("Failed to check resource with kind: %s, apiGroupVersion: %s", resource.Kind, APIGroupVersion)
+		return err
 	}
 	if !exist {
 		return nil
@@ -1937,38 +1938,6 @@ func (b *Bootstrap) BackupCRtoCm(crNs, cmName, cmKey, targetNs string, resource 
 			return err
 		}
 		crNs = ""
-	}
-
-	if resource.Kind == "IBMLicensing" {
-
-		klog.Infof("Creating LSR secret")
-		// Create an empty secret 'ibm-license-service-reporter-token' in targetNs to ensure that LS instance pod will start
-		lsrTokenSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ibm-license-service-reporter-token",
-				Namespace: targetNs,
-			},
-		}
-		if err := b.Client.Create(context.Background(), lsrTokenSecret); err != nil {
-			if errors.IsAlreadyExists(err) {
-				klog.Infof("LSR secret %s/%s already exists", targetNs, "ibm-license-service-reporter-token")
-			} else {
-				return err
-			}
-		}
-
-		if backupCr.Object["spec"] != nil {
-			if backupCr.Object["spec"].(map[string]interface{})["sender"] != nil {
-				// If LS connected to LicSvcReporter, set a template for sender configuration with url pointing to the IBM LSR docs
-				if backupCr.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterURL"] != nil {
-					klog.Infof("updating LSR sender configuration")
-					backupCr.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterURL"] = "https://READ_(ibm.biz/lsr_sender_config)"
-				}
-				if backupCr.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterSecretToken"] != nil {
-					backupCr.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterSecretToken"] = "ibm-license-service-reporter-token"
-				}
-			}
-		}
 	}
 
 	backupCr.SetResourceVersion("")
@@ -2066,6 +2035,77 @@ func (b *Bootstrap) RestoreCmtoCR(cmName, cnNs, objKey string) error {
 	return nil
 }
 
+// UpdateLicensingCR will update the licensing CR set a tenokate fir sebder configuration and create secret
+func (b *Bootstrap) UpdateLicensingCR(targetNs string, lsCR *Resource) error {
+	// check if crd exist
+	dc := discovery.NewDiscoveryClientForConfigOrDie(b.Config)
+	APIGroupVersion := lsCR.Group + "/" + lsCR.Version
+	exist, err := b.ResourceExists(dc, APIGroupVersion, lsCR.Kind)
+	if err != nil {
+		klog.Errorf("Failed to check resource with kind: %s, apiGroupVersion: %s", lsCR.Kind, APIGroupVersion)
+		return err
+	}
+	if !exist {
+		return nil
+	}
+	// get ibmlicenseservice instance
+	ls := &unstructured.Unstructured{}
+	ls.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   lsCR.Group,
+		Version: lsCR.Version,
+		Kind:    lsCR.Kind,
+	})
+	if err := b.Client.Get(context.TODO(), types.NamespacedName{
+		Name: lsCR.Name,
+	}, ls); err != nil {
+		if errors.IsNotFound(err) {
+			klog.Infof("LS instance %s is not found", lsCR.Name)
+			return nil
+		}
+		klog.Errorf("Failed to get LS instance %s: %v", lsCR.Name, err)
+		return err
+	}
+
+	klog.Infof("Creating LSR secret ibm-license-service-reporter-token in namespace %s", targetNs)
+	// Create an empty secret 'ibm-license-service-reporter-token' in targetNs to ensure that LS instance pod will start
+	lsrTokenSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ibm-license-service-reporter-token",
+			Namespace: targetNs,
+		},
+		Data: map[string][]byte{
+			"token": []byte(""),
+		},
+	}
+
+	if err := b.Client.Create(context.Background(), lsrTokenSecret); err != nil {
+		if errors.IsAlreadyExists(err) {
+			klog.Infof("LSR secret %s/%s already exists", targetNs, "ibm-license-service-reporter-token")
+		} else {
+			return err
+		}
+	}
+	// If spec.sender is configured in LS lsCR, set a template for sender configuration with url pointing to the IBM LSR docs
+	if ls.Object["spec"] != nil {
+		if ls.Object["spec"].(map[string]interface{})["sender"] != nil {
+			// If LS connected to LicSvcReporter, set a template for sender configuration with url pointing to the IBM LSR docs
+			if ls.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterURL"] != nil {
+				klog.Infof("updating LSR sender configuration")
+				ls.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterURL"] = "https://READ_(ibm.biz/lsr_sender_config)"
+			}
+			if ls.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterSecretToken"] != nil {
+				ls.Object["spec"].(map[string]interface{})["sender"].(map[string]interface{})["reporterSecretToken"] = "ibm-license-service-reporter-token"
+			}
+			// update LS instance
+			if err := b.Client.Update(context.Background(), ls); err != nil {
+				klog.Errorf("Failed to update LS instance %s: %v", lsCR.Name, err)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // IsolateLSR will isolate the LSR instance from the given namespace
 func (b *Bootstrap) IsolateLSR(masterNs string, lsrCR *Resource) error {
 
@@ -2074,6 +2114,7 @@ func (b *Bootstrap) IsolateLSR(masterNs string, lsrCR *Resource) error {
 	exist, err := b.ResourceExists(dc, APIGroupVersion, lsrCR.Kind)
 	if err != nil {
 		klog.Errorf("Failed to check resource with kind: %s, apiGroupVersion: %s", lsrCR.Kind, APIGroupVersion)
+		return err
 	}
 	if !exist {
 		return nil

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -86,6 +86,7 @@ var ctx = context.Background()
 //+kubebuilder:rbac:groups=operator.ibm.com,resources=certmanagers,verbs=get;list;watch;delete
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create
 
 //+kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=commonservices,verbs=create
 //+kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=operandregistries;operandconfigs,verbs=create;get;list;watch;update;patch;delete

--- a/controllers/scopewatcher_controller.go
+++ b/controllers/scopewatcher_controller.go
@@ -357,6 +357,14 @@ func (r *CommonServiceReconciler) ScopeReconcile(ctx context.Context, req ctrl.R
 			klog.Errorf("Failed to get Deployment %s in %s: %v", constant.LicensingSub, r.Bootstrap.CSData.MasterNs, err)
 			return ctrl.Result{}, err
 		}
+
+		klog.Infof("Upding Licensing CR with setting a template for sender configuration and creating a secret")
+		for _, cr := range licensingCR {
+			if err := r.Bootstrap.UpdateLicensingCR(r.Bootstrap.CSData.ControlNs, cr); err != nil {
+				klog.Errorf("Failed to update Licensing CR in %s: %v", r.Bootstrap.CSData.ControlNs, err)
+				return ctrl.Result{}, err
+			}
+		}
 	} else {
 		klog.Infof("%s deployment is found in %s, skipping restore Licensing CR", constant.LicensingSub, r.Bootstrap.CSData.MasterNs)
 	}


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61587

### Content
Upgrade scenarios:

- LS + LSR in the same cluster

Updates for the licensing case during self-isolation:

- If spec.sender  is configured in LS instance, set a template for sender configuration with url pointing to the IBM LSR docs
- And create an empty secret ibm-license-service-reporter-token in LS_new_namespace to ensure that LS instance pod will start

### How to test

1. install v3 operator in ibm-common-services ns and shared with two cloudpaks: cp4i, cp4ba
2. request `ibm-licensing-operator` in cp4i namespace and enable LSR according to[Deploying License Service Reporter]( https://www.ibm.com/docs/en/cloud-paks/foundational-services/3.23?topic=reporter-deploying-license-service)
3. in spec.sender in `IBMLicensing` instance
    ```
    spec:
      sender:
        reporterSecretToken: ibm-licensing-reporter-token
        reporterURL: 'https://ibm-license-service-reporter:8080'
    ```
      
4. change test image: quay.io/yuchen_shen/cs_operator:lsr_sender
5. switch cs operator channel to v4.4 in cp4i ns
6. observe the changes in `IBMLicensing` instance
    ```
    spec:
      sender:
        reporterSecretToken: ibm-license-service-reporter-token
        reporterURL: https://READ_(ibm.biz/lsr_sender_config)
    ```