### PR TITLE
migrate licensing configmaps in self-isolation

### DIFF
--- a/controllers/scopewatcher_controller.go
+++ b/controllers/scopewatcher_controller.go
@@ -142,6 +142,7 @@ var (
 	}
 
 	licensingConfigMaps = []string{
+		"ibm-licensing-config",
 		"ibm-licensing-annotations",
 		"ibm-licensing-products",
 		"ibm-licensing-products-vpc-hour",


### PR DESCRIPTION
issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/61620

###  Context
If the IBM Licensing v4 operator is already installed in `cs-control` namespace before self-isolation, the CS operator should overwrite/update the ConfigMaps in the `cs-control` namespace with the ConfigMap data from `ibm-common-services` for those Licensing ConfigMaps that exist in `ibm-common-services`.

### How to test
1. Install v3 operator in `ibm-common-services` ns and shared with two cloudpaks: cp4i, aiops, and check there is `ibm-licensing-config` ConfigMaps in the same namespace
2. Create a control namespace called `cs-control`
3. Install a IBM licensing v4 in `cs-control`, and create an example licensing ConfigMaps `ibm-licensing-config` with different data 
4. Switch cs oeprator channel to v4.4 in `aiops` namespace to trigger self-isolation

### Observe
`ibm-licensing-config` cm will be migrated successfully without any error message.
From cs pod log:
```I0124 20:25:08.082546 1 util.go:1135] Migrate ConfigMap ibm-licensing-config from ibm-common-services to cs-control```
 
