### PR TITLE
Always return true for rm command

### DIFF
--- a/hack/keycloak-themes/Makefile
+++ b/hack/keycloak-themes/Makefile
@@ -6,5 +6,5 @@ default: cloudpak-theme.jar
 .PHONY: cloudpak-theme.jar
 cloudpak-theme.jar:
 	@echo "Building the keycloak jar theme..."
-	rm $(KEYCLOAK_THEME_DIR)/$(JAR_THEME_FILE)
+	rm $(KEYCLOAK_THEME_DIR)/$(JAR_THEME_FILE) || true
 	(cd $(KEYCLOAK_THEME_DIR) && zip -r ./$(JAR_THEME_FILE) META-INF theme)


### PR DESCRIPTION
```
Building the keycloak jar theme...
rm /home/prow/go/src/github.com/IBM/ibm-common-service-operator/hack/keycloak-themes/cloudpak-theme.jar
rm: cannot remove '/home/prow/go/src/github.com/IBM/ibm-common-service-operator/hack/keycloak-themes/cloudpak-theme.jar': No such file or directory
hack/keycloak-themes/Makefile:8: recipe for target 'cloudpak-theme.jar' failed
make: *** [cloudpak-theme.jar] Error 1
```