### PR TITLE
Enable storageClass configuration for EDB wal

### DIFF
--- a/controllers/constant/storageclass.go
+++ b/controllers/constant/storageclass.go
@@ -45,6 +45,8 @@ const StorageClassTemplate = `
         spec:
           storage:
             storageClass: placeholder
+          walStorage:
+            storageClass: placeholder
       kind: Cluster
       name: keycloak-edb-cluster
 `


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62016

Support storageClass configuration `.spec.walStorage.storageClass` for EDB Cluster CR named `keycloak-edb-cluster`

```yaml
...
walStorage:
  resizeInUseVolumes: true
  size: 1Gi
  storageClass: rook-ceph-block
maxSyncReplicas: 0
switchoverDelay: 3600
storage:
  resizeInUseVolumes: true
  size: 1Gi
  storageClass: rook-ceph-block
description: EDB Database with IBM License Key
```