### PR TITLE
Update service endpoint for EDB

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1078,7 +1078,7 @@ spec:
                   apiVersion: v1
                   kind: Service
                   name: common-service-db-r
-                  path: https://+.metadata.name+.+.metadata.namespace+.+svc
+                  path: .metadata.name+.+.metadata.namespace+.+svc
                 required: true
             DATABASE_RW_ENDPOINT:
               templatingValueFrom:
@@ -1086,7 +1086,7 @@ spec:
                   apiVersion: v1
                   kind: Service
                   name: common-service-db-rw
-                  path: https://+.metadata.name+.+.metadata.namespace+.+svc
+                  path: .metadata.name+.+.metadata.namespace+.+svc
                 required: true
             DATABASE_NAME: zen
             DATABASE_USER: zen_user
@@ -1114,7 +1114,7 @@ spec:
                   apiVersion: v1
                   kind: Service
                   name: common-service-db-r
-                  path: https://+.metadata.name+.+.metadata.namespace+.+svc
+                  path: .metadata.name+.+.metadata.namespace+.+svc
                 required: true
             DATABASE_RW_ENDPOINT:
               templatingValueFrom:
@@ -1122,7 +1122,7 @@ spec:
                   apiVersion: v1
                   kind: Service
                   name: common-service-db-rw
-                  path: https://+.metadata.name+.+.metadata.namespace+.+svc
+                  path: .metadata.name+.+.metadata.namespace+.+svc
                 required: true
             DATABASE_NAME: im
             DATABASE_USER: im_user


### PR DESCRIPTION
EDB service does not provide port with name `https`
```
# psql "postgresql://im_user@https://common-service-db-rw.cp4i.svc:5432/im?sslmode=require&sslcert=/tmp/postgres/secrets/tls.crt&sslkey=/tmp/postgres/secrets/tls.key&application_name=demo-deloyment"
psql: error: could not translate host name "https" to address: Name or service not known
```

The endpoint works without `https`
```
# psql "postgresql://im_user@common-service-db-rw.cp4i.svc:5432/im?sslmode=require&sslcert=/tmp/postgres/secrets/tls.crt&sslkey=/tmp/postgres/secrets/tls.key&application_name=demo-deloyment"
psql (16.1 (Debian 16.1-1.pgdg120+1), server 15.4)
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

im=> 
```