### PR TITLE
Pick up EDB 1.22, update channel and Operand images for cs postgresql and keycloak

### DIFF
--- a/controllers/constant/cloudNativePostgresql.go
+++ b/controllers/constant/cloudNativePostgresql.go
@@ -28,7 +28,7 @@ metadata:
     version: {{ .Version }}
 data:
   ibm-postgresql-15-operand-image: icr.io/cpopen/edb/postgresql:15.4@sha256:7ae65a0e9f172a6882b29a629d2f727aa9b6114c82eb116df5a934bf2797c17c
-  ibm-postgresql-14-operand-image: icr.io/cpopen/edb/postgresql:14.9@sha256:90136074adcbafb5033668b07fe1efea9addf0168fa83b0c8a6984536fc22264
+  ibm-postgresql-14-operand-image: icr.io/cpopen/edb/postgresql:14.10@sha256:368ede710ca9da45090907e265d70869bc44b0103f81e6980c0c35cdeba3d068
   ibm-postgresql-13-operand-image: icr.io/cpopen/edb/postgresql:13.12@sha256:7f8188c114ea8d1a2f706e7e7672e3462a50f96e7eec4da137e9996c4e40b674
   ibm-postgresql-12-operand-image: icr.io/cpopen/edb/postgresql:12.16@sha256:ff99a217198e58f89f847ddeea1ddc153593123f93b88fb0ece39d3c1f59cb6e
   edb-postgres-license-provider-image: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -256,7 +256,7 @@ spec:
     namespace: "{{ .ServicesNs }}"
     packageName: rhbk-operator
     scope: public
-  - channel: stable
+  - channel: stable-v1.22
     installPlanApproval: {{ .ApprovalMode }}
     name: edb-keycloak
     namespace: "{{ .CPFSNs }}"
@@ -279,7 +279,7 @@ metadata:
     excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
 spec:
   operators:
-  - channel: stable
+  - channel: stable-v1.22
     installPlanApproval: {{ .ApprovalMode }}
     name: common-service-postgresql
     namespace: "{{ .CPFSNs }}"
@@ -843,7 +843,7 @@ spec:
               templatingValueFrom:
                 default:
                   required: true
-                  defaultValue: icr.io/cpopen/edb/postgresql:14.9@sha256:90136074adcbafb5033668b07fe1efea9addf0168fa83b0c8a6984536fc22264
+                  defaultValue: icr.io/cpopen/edb/postgresql:14.10@sha256:368ede710ca9da45090907e265d70869bc44b0103f81e6980c0c35cdeba3d068
                   configMapKeyRef:
                     name: cloud-native-postgresql-image-list
                     key: ibm-postgresql-14-operand-image
@@ -969,6 +969,15 @@ spec:
                   - GRANT ALL PRIVILEGES ON DATABASE zen TO zen_user
             affinity:
               topologyKey: topology.kubernetes.io/zone
+            imageName:
+              templatingValueFrom:
+                default:
+                  required: true
+                  defaultValue: icr.io/cpopen/edb/postgresql:14.10@sha256:368ede710ca9da45090907e265d70869bc44b0103f81e6980c0c35cdeba3d068
+                  configMapKeyRef:
+                    name: cloud-native-postgresql-image-list
+                    key: ibm-postgresql-14-operand-image
+                    namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key
             instances: 1


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62138

Picked up EDB 1.22 version for sharable/embedded `common-serice-postgresql` EDB adopted by IM, and dedicated `edb-keycloak` EDB.

### Update content
1. Create a separate channel `stable-v1.22` for testing purpose
2. Pick up Operand image `14.10-4.22` and update in `cloud-native-postgresql-image-list` ConfigMap
3. Apply the new operand image in both `common-serice-postgresql` and `edb-keycloak` EDB Cluster CR


