### PR TITLE
remove roks check in preload_data

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -527,15 +527,9 @@ function swapmongopvc() {
   ${OC} patch pv $VOL --type=merge -p '{"spec": {"claimRef":null}}'
   ${OC} patch pv $VOL --type json -p '[{ "op": "remove", "path": "/spec/claimRef" }]' #this line is proving problematic
 
-  roks=$(${OC} cluster-info | grep 'containers.cloud.ibm.com')
-  if [[ -z $roks ]]; then
-    stgclass=$(${OC} get pvc mongodbdir-icp-mongodb-0 -n $FROM_NAMESPACE -o=jsonpath='{.spec.storageClassName}')
-    if [[ -z $stgclass ]]; then
-      error "Cannnot get storage class name from PVC mongodbdir-icp-mongodb-0 in $FROM_NAMESPACE"
-    fi
-  else
-    debug1 "Preload run on ROKS, not setting storageclass name"
-    stgclass=""
+  stgclass=$(${OC} get pvc mongodbdir-icp-mongodb-0 -n $FROM_NAMESPACE -o=jsonpath='{.spec.storageClassName}')
+  if [[ -z $stgclass ]]; then
+    error "Cannnot get storage class name from PVC mongodbdir-icp-mongodb-0 in $FROM_NAMESPACE"
   fi
 
   cat <<EOF >$TEMPFILE


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62238

We implemented a check for ROKs last year (https://github.com/IBM/ibm-common-service-operator/pull/1237) due to some issues with cs-mongodump pvc binding to the right pv on ROKs specifically. According to the issue linked at the top, aiops is seeing intermittent failures on their QA tests due to pvcs being created with empty storage classes at ~60% occurence (rough estimate). I found that we do not make this same comparison for the original pvc we create in the `createdumppvc` function so I have removed it.

AIops QA team will test and verify this resolves their issue on ROKs.