### PR TITLE
Automatically clean up NSS CRs and operator in Simple TP or All ns mode

### DIFF
--- a/api/v3/finalizer.go
+++ b/api/v3/finalizer.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package v3
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// RemoveFinalizer removes the finalizer from the object's ObjectMeta.
+func RemoveFinalizer(objectMeta *metav1.ObjectMeta, deletingFinalizer string) bool {
+	outFinalizers := make([]string, 0)
+	var changed bool
+	for _, finalizer := range objectMeta.Finalizers {
+		if finalizer == deletingFinalizer {
+			changed = true
+			continue
+		}
+		outFinalizers = append(outFinalizers, finalizer)
+	}
+
+	objectMeta.Finalizers = outFinalizers
+	return changed
+}

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-01-10T21:50:05Z"
+    createdAt: "2024-02-08T22:44:51Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -410,6 +410,16 @@ spec:
                       secretName: webhook-server-cert
       permissions:
         - rules:
+            - apiGroups:
+                - operator.ibm.com
+              resources:
+                - namespacescopes
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - watch
             - apiGroups:
                 - cert-manager.io
               resources:

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-02-08T22:44:51Z"
+    createdAt: "2024-02-11T07:01:56Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -420,6 +420,7 @@ spec:
                 - get
                 - list
                 - watch
+                - patch
             - apiGroups:
                 - cert-manager.io
               resources:

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-02-11T07:01:56Z"
+    createdAt: "2024-02-13T22:52:36Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -410,6 +410,13 @@ spec:
                       secretName: webhook-server-cert
       permissions:
         - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - delete
+                - patch
             - apiGroups:
                 - operator.ibm.com
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,16 @@ metadata:
   name: ibm-common-service-operator
 rules:
 - apiGroups:
+  - operator.ibm.com
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - watch
+  resources:
+  - namespacescopes
+- apiGroups:
   - cert-manager.io
   resources:
   - certificates

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,13 @@ metadata:
   name: ibm-common-service-operator
 rules:
 - apiGroups:
+  - ""
+  verbs:
+  - delete
+  - patch
+  resources:
+  - configmaps
+- apiGroups:
   - operator.ibm.com
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -80,6 +80,7 @@ rules:
   - get
   - list
   - watch
+  - patch
   resources:
   - namespacescopes
 - apiGroups:

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -49,9 +49,9 @@ import (
 	util "github.com/IBM/ibm-common-service-operator/controllers/common"
 	"github.com/IBM/ibm-common-service-operator/controllers/constant"
 	"github.com/IBM/ibm-common-service-operator/controllers/deploy"
+	nssv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
 
-	nssv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
 	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/apis/cert-manager/v1"
 )
 

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1274,6 +1274,7 @@ func (b *Bootstrap) CleanNamespaceScopeResources() error {
 							klog.Errorf("Failed to patch finalizers to delete the NamespaceScope CR %s: %v", nssCR.Name, err)
 							return err
 						}
+						klog.Infof("Rmoved finalizers to delete the NamespaceScope CR %s", nssCR.Name)
 					}
 				}
 			}

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1219,21 +1219,21 @@ func (b *Bootstrap) CleanNamespaceScopeResources() error {
 		// Delete v3 Namespace Scope operator
 		klog.Infof("Uninstall v3 Namespace Scope operator in servicesNamespace %s when the topology is Simple or All Namespaces Mode", b.CSData.ServicesNs)
 		sub := &olmv1alpha1.Subscription{}
-		if err := b.Client.Get(ctx, types.NamespacedName{Name: constant.NsSubName, Namespace: b.CSData.ServicesNs}, sub); err != nil {
-			if errors.IsNotFound(err) {
-				klog.Infof("The %s subscription is not found in the %s namespace, skip cleaning up", constant.NsSubName, b.CSData.ServicesNs)
-			} else {
-				klog.Errorf("Failed to get %s subscription: %v", constant.NsSubName, err)
-				return err
-			}
-		} else {
+		if err := b.Client.Get(ctx, types.NamespacedName{Name: constant.NsSubName, Namespace: b.CSData.ServicesNs}, sub); err == nil {
 			if strings.HasPrefix(sub.Spec.Channel, "v4.") {
 				klog.Infof("The %s subscription is in the v4.x channel, skip cleaning up", constant.NsSubName)
 				return nil
-			} else if err := b.DeleteOperator(constant.NsSubName, b.CSData.ServicesNs); err != nil {
+			}
+			if err := b.DeleteOperator(constant.NsSubName, b.CSData.ServicesNs); err != nil {
 				klog.Errorf("Failed to uninstall v3 Namespace Scope operator in servicesNamespace %s", b.CSData.ServicesNs)
 				return err
 			}
+		} else {
+			if !errors.IsNotFound(err) {
+				klog.Errorf("Failed to get %s subscription: %v", constant.NsSubName, err)
+				return err
+			}
+			klog.Infof("The %s subscription is not found in the %s namespace, skip cleaning up", constant.NsSubName, b.CSData.ServicesNs)
 		}
 
 		// Patch and remove the ownerReference in the namespace-scope configmap if it exist

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -287,15 +287,6 @@ func GetNSSCMSynchronization() bool {
 	return false
 }
 
-func GetItemByName(slice []interface{}, name string) interface{} {
-	for _, item := range slice {
-		if item.(map[string]interface{})["name"].(string) == name {
-			return item
-		}
-	}
-	return nil
-}
-
 // Contains returns whether the sub-string is contained
 func Contains(list []string, s string) bool {
 	for _, v := range list {

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -732,32 +732,34 @@ func GetRequestNs(r client.Reader) (requestNs []string) {
 }
 
 // GetNssCmNs gets namespaces from namespace-scope ConfigMap
-func GetNssCmNs(r client.Reader, cpfsNamespace string) (nssCmNs []string) {
-	nssConfigMap := GetCmOfNss(r, cpfsNamespace)
+func GetNssCmNs(r client.Reader, cpfsNamespace string) ([]string, error) {
+	nssConfigMap, err := GetCmOfNss(r, cpfsNamespace)
+	if err != nil {
+		return nil, err
+	} else {
+		nssNsMems, ok := nssConfigMap.Data["namespaces"]
+		if !ok {
+			klog.Infof("There is no namespace in configmap %v/%v", cpfsNamespace, constant.NamespaceScopeConfigmapName)
+			return nil, nil
+		}
+		nssCmNs := strings.Split(nssNsMems, ",")
 
-	nssNsMems, ok := nssConfigMap.Data["namespaces"]
-	if !ok {
-		klog.Infof("There is no namespace in configmap %v/%v", cpfsNamespace, constant.NamespaceScopeConfigmapName)
-		return
+		return nssCmNs, nil
 	}
-	nssCmNs = strings.Split(nssNsMems, ",")
-
-	return nssCmNs
 }
 
 // GetCmOfNss gets ConfigMap of Namespace-scope
-func GetCmOfNss(r client.Reader, operatorNs string) *corev1.ConfigMap {
+func GetCmOfNss(r client.Reader, operatorNs string) (*corev1.ConfigMap, error) {
 	cmName := constant.NamespaceScopeConfigmapName
 	cmNs := operatorNs
 	nssConfigmap := &corev1.ConfigMap{}
 
 	for {
-		if err := utilwait.PollImmediateInfinite(time.Second*10, func() (done bool, err error) {
+		if err := utilwait.PollImmediate(time.Second*10, time.Second*60, func() (done bool, err error) {
 			err = r.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: cmNs}, nssConfigmap)
 			if err != nil {
 				if errors.IsNotFound(err) {
 					klog.Infof("waiting for configmap %v/%v", operatorNs, constant.NamespaceScopeConfigmapName)
-					return false, nil
 				}
 				return false, err
 			}
@@ -765,12 +767,12 @@ func GetCmOfNss(r client.Reader, operatorNs string) *corev1.ConfigMap {
 		}); err == nil {
 			break
 		} else {
-			klog.Errorf("Failed to get configmap %v/%v: %v, retry in 10 seconds", operatorNs, constant.NamespaceScopeConfigmapName, err)
-			time.Sleep(10 * time.Second)
+			klog.Errorf("Failed to get configmap %v/%v: %v", operatorNs, constant.NamespaceScopeConfigmapName, err)
+			return nil, err
 		}
 	}
 
-	return nssConfigmap
+	return nssConfigmap, nil
 }
 
 func GetResourcesDynamically(ctx context.Context, dynamic dynamic.Interface, group string, version string, resource string) (

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -287,6 +287,15 @@ func GetNSSCMSynchronization() bool {
 	return false
 }
 
+func GetItemByName(slice []interface{}, name string) interface{} {
+	for _, item := range slice {
+		if item.(map[string]interface{})["name"].(string) == name {
+			return item
+		}
+	}
+	return nil
+}
+
 // Contains returns whether the sub-string is contained
 func Contains(list []string, s string) bool {
 	for _, v := range list {

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -727,16 +727,15 @@ func GetNssCmNs(r client.Reader, cpfsNamespace string) ([]string, error) {
 	nssConfigMap, err := GetCmOfNss(r, cpfsNamespace)
 	if err != nil {
 		return nil, err
-	} else {
-		nssNsMems, ok := nssConfigMap.Data["namespaces"]
-		if !ok {
-			klog.Infof("There is no namespace in configmap %v/%v", cpfsNamespace, constant.NamespaceScopeConfigmapName)
-			return nil, nil
-		}
-		nssCmNs := strings.Split(nssNsMems, ",")
-
-		return nssCmNs, nil
 	}
+	nssNsMems, ok := nssConfigMap.Data["namespaces"]
+	if !ok {
+		klog.Infof("There is no namespace in configmap %v/%v", cpfsNamespace, constant.NamespaceScopeConfigmapName)
+		return nil, nil
+	}
+	nssCmNs := strings.Split(nssNsMems, ",")
+
+	return nssCmNs, nil
 }
 
 // GetCmOfNss gets ConfigMap of Namespace-scope

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -216,12 +216,6 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		return ctrl.Result{}, err
 	}
 
-	// Clean v3 Namespace Scope Operator and CRs in the servicesNamespace
-	if err := r.Bootstrap.CleanNamespaceScopeResources(); err != nil {
-		klog.Errorf("Failed to clean NamespaceScope resources: %v", err)
-		return ctrl.Result{}, err
-	}
-
 	// Init common service bootstrap resource
 	// Including namespace-scope configmap
 	// Deploy OperandConfig and OperandRegistry

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -421,11 +421,12 @@ func (r *CommonServiceReconciler) mappingToCsRequestForOperandRegistry() handler
 			// It's not an OperandRegistry, ignore
 			return nil
 		}
-
-		if shouldReconcile(operandRegistry) {
-			// Enqueue a reconciliation request for the corresponding CommonService
-			return []reconcile.Request{
-				{NamespacedName: types.NamespacedName{Name: operandRegistry.Name, Namespace: operandRegistry.Namespace}},
+		if operandRegistry.Name == constant.MasterCR && operandRegistry.Namespace == r.Bootstrap.CSData.ServicesNs {
+			if shouldReconcile(operandRegistry) {
+				// Enqueue a reconciliation request for the corresponding CommonService
+				return []reconcile.Request{
+					{NamespacedName: types.NamespacedName{Name: constant.MasterCR, Namespace: r.Bootstrap.CSData.OperatorNs}},
+				}
 			}
 		}
 		return nil

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -216,6 +216,12 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		return ctrl.Result{}, err
 	}
 
+	// Clean v3 Namespace Scope Operator and CRs in the servicesNamespace
+	if err := r.Bootstrap.CleanNamespaceScopeResources(); err != nil {
+		klog.Errorf("Failed to clean NamespaceScope resources: %v", err)
+		return ctrl.Result{}, err
+	}
+
 	// Init common service bootstrap resource
 	// Including namespace-scope configmap
 	// Deploy OperandConfig and OperandRegistry

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -90,6 +90,8 @@ const (
 	CsClonedFromLabel = "operator.ibm.com/common-services.cloned-from"
 	// IBMCPPCONFIG is the name of ibm-cpp-config ConfigMap
 	IBMCPPCONFIG = "ibm-cpp-config"
+	// NssCRFinalizer is the name for the finalizer to allow for deletion
+	NssCRFinalizer = "finalizer.nss.operator.ibm.com"
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/controllers/recocile_pause.go
+++ b/controllers/recocile_pause.go
@@ -30,7 +30,7 @@ const (
 
 func (r *CommonServiceReconciler) reconcilePauseRequest(instance *apiv3.CommonService) bool {
 
-	klog.Info("Request Stage: ReconcilePauseRequest")
+	//klog.Info("Request Stage: ReconcilePauseRequest")
 
 	// if the given CommnService CR has not been existing
 	if instance == nil {
@@ -47,7 +47,7 @@ func (r *CommonServiceReconciler) reconcilePauseRequest(instance *apiv3.CommonSe
 }
 
 func (r *CommonServiceReconciler) pauseRequestExists(instance *apiv3.CommonService) bool {
-	klog.Info("Request Stage: Checking annotations for pause request")
+	klog.Info("Checking annotations for pause request")
 
 	// if there is pause or self-pause request annotation in the CommonService CR, pause request takes precedence over self-pause request
 	var pauseRequestFound bool


### PR DESCRIPTION
ticket: https://github.ibm.com/ibmprivatecloud/roadmap/issues/61040

### Context 
After upgrading from CS v3 to CS v4, the v3 Namespace Scope operator and CRs will be expected to be cleaned up by the common service operator automatically in Simple Topology or AllNamespace mode as they are no longer needed.

### NameSpace Scope clean up Workflow
1. CS operator upgrades to v4.
2. Check if all Bedrock v3 core services are no longer requested by CloudPak by inspecting the v4 OperandRegistry.
3. Check the deployment topology, whether it is a Simple Topology or in All Namespace Mode.
4. Delete v3 NSS operator in the servicesNamespace firstly if they still remain to prevent adding the ownerReferences back to `namespace-scope` configMap
5. Remove the ownerReferences in `namespace-scope` configMap in case it is deleted with `common-service` NamespaceScope CR and crashes cs operator pod
6. Lastly, delete all the remaining NamespaceScope CRs

### CS reconciliation
1. The CS operator will check if there are still `no-op` operators requested in the OperandRegistry. If there are none, it will trigger the reconciliation to clean up all NSS resources. If there are still some operators, it will skip the reconciliation.

### How to test
Test image: quay.io/yuchen_shen/cs_operator:nss_cleanup

- Simple TP
   1. Install a v3 CPFS in a single-shared cluster in one namespace `ibm-common-services`, or in a dedicated cluster in a custom namespace.
   3. Upgrade from v3 to v4 and configure the operator and service namespace in the CS CR.
   4. Apply the test image in the v4 CS CSV.
   5. Check that all NSS CRs and NSS operators in the service namespace are cleaned up automatically.

- All Namespaces
   1. Install a v3 CPFS and perform the upgrade.
   2. Apply the test image.
   3. Check if NSS relations are all gone.

- Advanced TP
   1. Install a v3 CPFS and upgrade to Advanced TP.
   2. Apply the test image.
   3. Ensure that NSS relations remain in the cluster.

