### PR TITLE
Updating cs-onprem-tenant-config.sh

### DIFF
--- a/cs-onprem-tenant-config.sh
+++ b/cs-onprem-tenant-config.sh
@@ -1,27 +1,8 @@
 #!/bin/bash
 configMapCustomHostname="cs-onprem-tenant-config"
 csNamespace=""
-custom_hostname=""
-topology=""
 map_to_common_service_namespace=""
-
-configmap_yaml=$(oc get configmap common-service-maps -n kube-public -ojsonpath='{.data.common-service-maps\.yaml}')
-temp_yaml_file=$(mktemp)
-echo "$configmap_yaml" > "$temp_yaml_file"
-count=$(cat $temp_yaml_file |grep -A2 'requested-from-namespace:' | sed -n '/^  - /p' |wc -l)
-if [ "$count" -eq 2 ]; then
-    # Fetch the value of the "map-to-common-service-namespace" property
-    map_to_common_service_namespace=$(cat $temp_yaml_file |grep 'map-to-common-service-namespace:' | awk '{print $3}')
-    topology="SOD"
-    csNamespace=$(cat $temp_yaml_file |grep -A2 'requested-from-namespace:' | sed -n '/^  - /p' |grep -v $map_to_common_service_namespace|awk '{print $2}')
-    #echo "The value of 'map-to-common-service-namespace' is: $map_to_common_service_namespace and control namespace is $csNamespace"
-else
-    map_to_common_service_namespace=$(cat $temp_yaml_file |grep 'map-to-common-service-namespace:' | awk '{print $3}')
-    topology="simple"
-    csNamespace=$map_to_common_service_namespace
-fi
-
-echo "This cluster is configured with $topology topology"
+custom_hostname=""
 wlp_client_id=$(oc get secret -n $map_to_common_service_namespace platform-oidc-credentials -o jsonpath='{.data.WLP_CLIENT_ID}'|base64 -d)
 wlp_client_secret=$(oc get secret -n $map_to_common_service_namespace platform-oidc-credentials -o jsonpath='{.data.WLP_CLIENT_SECRET}'|base64 -d)
 oauth2_client_registration_secret=$(oc get secret -n $map_to_common_service_namespace platform-oidc-credentials -o jsonpath='{.data.OAUTH2_CLIENT_REGISTRATION_SECRET}'|base64 -d)
@@ -44,7 +25,7 @@ checkIfSecretExist(){
   if [[ "$count" -eq 1 ]]; then
     checkCrtFilesExist
     echo "Deleting old custom-tls-secret if exists"
-    oc delete secret custom-tls-secret -n $map_to_common_service_namespace --ignore-not-found
+    oc delete secret $(oc get configmap -n $map_to_common_service_namespace cs-onprem-tenant-config -o jsonpath='{.data.custom_host_certificate_secret}') --ignore-not-found
     custom_secret=$(oc get configmap -n $map_to_common_service_namespace cs-onprem-tenant-config -o jsonpath='{.data.custom_host_certificate_secret}')
     echo "Creating custom-tls-secret"
     oc create secret generic $custom_secret -n $map_to_common_service_namespace --from-file=ca.crt=./ca.crt --from-file=tls.crt=./tls.crt --from-file=tls.key=./tls.key
@@ -100,7 +81,8 @@ echo "Deleting old job of iam-custom-hostname if exists"
 oc delete job iam-custom-hostname --ignore-not-found -n $csNamespace
 
 echo "Running custom hostname job"
-cat <<EOF | tee >(oc apply -f -) | cat >/dev/null
+tmpfile=$(mktemp)
+cat <<EOF > "$tmpfile"
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -141,62 +123,13 @@ spec:
       serviceAccountName: ibm-iam-operator
       restartPolicy: OnFailure
 EOF
-
-# Setting the label of the pod which needs to be deleted
-AUTH_SERVICE_LABEL="app=platform-auth-service"
-PROVIDER_LABEL="app=platform-identity-provider"
-ZEN_OPERATOR_LABEL="name=ibm-zen-operator"
-USERMGMT_LABEL="component=usermgmt"
+oc apply -f "$tmpfile"
+rm "$tmpfile"
 
 # Function to check if the job has completed
 check_job_completion() {
-  job_name=$1
-  namespace=$2
-  timeout=120
-  start_time=$(date +%s)
-
-  while true; do
-    # Get the job status
-    job_status=$(oc get jobs "$job_name" -n "$namespace" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
-
-    # Check if the job is completed
-    if [[ "$job_status" == "True" ]]; then
-      echo "Job $job_name has completed."
-      break
-    fi
-
-    current_time=$(date +%s)
-    elapsed_time=$((current_time - start_time))
-    if [[ $elapsed_time -ge $timeout ]]; then
-      echo "Job did not complete within the timeout period."
-      break
-    fi
-
-    echo "Waiting for job $job_name to complete..."
-    sleep 5
-  done
+  oc wait job iam-custom-hostname --for condition=complete --timeout=120s
 }
-
-
-
-: '
-# Restart the pod with the specified label
-oc delete  -n $map_to_common_service_namespace $(oc get pods -n $map_to_common_service_namespace -l "$AUTH_SERVICE_LABEL" -o name) 
-oc delete  -n $map_to_common_service_namespace $(oc get pods -n $map_to_common_service_namespace -l "$PROVIDER_LABEL" -o name) 
-pods=$(oc get pods -l "$ZEN_OPERATOR_LABEL" -o name)
-if [ -n "$pods" ]; then
-  oc delete $pods
-else
-  echo "No pods found with label $ZEN_OPERATOR_LABEL"
-fi
-
-pods=$(oc get pods -l "$USERMGMT_LABEL" -o name)
-if [ -n "$pods" ]; then
-  oc delete $pods
-else
-  echo "No pods found with label $USERMGMT_LABEL"
-fi
-'
 
 deployment_name="platform-auth-service"
 timeout_seconds=180  # assuming auth-service will come in 3 mins after restart


### PR DESCRIPTION
Changes went in:

1. Script to support **multiple topology**.

2. Fixed the hardcoded secret name `custom-tls-secret` issue while deleting the secret.

 Replaced command 
  -> oc delete secret custom-tls-secret -n $map_to_common_service_namespace --ignore-not-found 
       to
  -> oc delete secret $(oc get configmap -n $map_to_common_service_namespace cs-onprem-tenant-config -o 
       jsonpath='{.data.custom_host_certificate_secret}') --ignore-not-found

3. Removed the part of code where we are setting the labels of the pods and also the part where the pods are being restarted, since no need to restart the pods.

4. Fixed issue of running custom hostname job. 

5. Job completion function `check_job_completion()` changed to 
->  oc wait job iam-custom-hostname --for condition=complete --timeout=120s 

Addressing the below issues: 

- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61884.
- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61748.
- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62140.
