### PR TITLE
Enable customization for common-service-db Cluster CR

### DIFF
--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -74,6 +74,22 @@ const ConfigurationRules = `
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE
             ephemeral-storage: LARGEST_VALUE
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: LARGEST_VALUE
+        resources:
+          limits:
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE
+          requests:
+            ephemeral-storage: LARGEST_VALUE
+            cpu: LARGEST_VALUE
+            memory: LARGEST_VALUE    
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -68,6 +68,22 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 3000m
+            memory: 3Gi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 3Gi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -68,6 +68,22 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 3000m
+            memory: 3072Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 3072Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -68,6 +68,22 @@ const Large = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 3000m
+            memory: 3072Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 3072Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -68,6 +68,22 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 2Gi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 2Gi
 - name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -68,6 +68,22 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 2048Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 2048Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -68,6 +68,22 @@ const Medium = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 2048Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 2048Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -68,6 +68,22 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 640Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 640Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -68,6 +68,22 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 700Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 700Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -68,6 +68,22 @@ const Small = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 2
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 700Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 700Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -68,6 +68,22 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 1
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 640Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 640Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -68,6 +68,22 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 1
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 700Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 700Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -70,6 +70,22 @@ const StarterSet = `
           limits:
             cpu: 1000m
             memory: 350Mi
+- name: common-service-postgresql
+  resources:
+  - apiVersion: postgresql.k8s.enterprisedb.io/v1
+    kind: Cluster
+    name: common-service-db
+    data:
+      spec:
+        instances: 1
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 700Mi
+          requests:
+            ephemeral-storage: 256Mi
+            cpu: 500m
+            memory: 700Mi
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:


### PR DESCRIPTION
issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/62292

- Include size setting into the rules template
- Incorporate resource instance values to the T-shirt size
- Add CPU, memory limitation