### PR TITLE
Check OperandRegistry when checking no-op operators

### DIFF
--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -62,11 +62,6 @@ const (
 	CRFailed       string = "Failed"
 )
 
-var (
-	OpregAPIGroupVersion = "operator.ibm.com/v1alpha1"
-	OpregKind            = "OperandRegistry"
-)
-
 func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
 	klog.Infof("Reconciling CommonService: %s", req.NamespacedName)
@@ -479,7 +474,7 @@ func (r *CommonServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 					return true
 				},
 			}))
-	if isOpregAPI, err := r.Bootstrap.CheckCRD(OpregAPIGroupVersion, OpregKind); err != nil {
+	if isOpregAPI, err := r.Bootstrap.CheckCRD(constant.OpregAPIGroupVersion, constant.OpregKind); err != nil {
 		klog.Errorf("Failed to check if OperandRegistry CRD exists: %v", err)
 		return err
 	} else if isOpregAPI {

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -96,6 +96,10 @@ const (
 	CsClonedFromLabel = "operator.ibm.com/common-services.cloned-from"
 	// IBMCPPCONFIG is the name of ibm-cpp-config ConfigMap
 	IBMCPPCONFIG = "ibm-cpp-config"
+	// OpregAPIGroupVersion is the api group version of OperandRegistry
+	OpregAPIGroupVersion = "operator.ibm.com/v1alpha1"
+	// OpregKind is the kind of OperandRegistry
+	OpregKind = "OperandRegistry"
 )
 
 // CsOg is OperatorGroup constent for the common service operator


### PR DESCRIPTION
Found an issue when doing a fresh install CPFS in simple topology.

CS operator is trying to check if OperandRegistry has any no-op operator requested before cleaning any NSS resources. However, OperandRegistry is not present yet in fresh installation.

```
E0221 03:26:42.996735       1 init.go:1191] Failed to get common-service OperandRegistry: no matches for kind "OperandRegistry" in version "operator.ibm.com/v1alpha1"
E0221 03:26:42.996810       1 init.go:164] Failed to clean NamespaceScope resources: no matches for kind "OperandRegistry" in version "operator.ibm.com/v1alpha1"
E0221 03:26:42.996836       1 commonservice_controller.go:229] Failed to initialize resources: no matches for kind "OperandRegistry" in version "operator.ibm.com/v1alpha1"
E0221 03:26:43.005957       1 commonservice_controller.go:233] Fail to reconcile ibm-common-services/common-service: no matches for kind "OperandRegistry" in version "operator.ibm.com/v1alpha1"
2024-02-21T03:26:43.006Z	ERROR	controller.commonservice	Reconciler error	{"reconciler group": "operator.ibm.com", "reconciler kind": "CommonService", "name": "common-service", "namespace": "ibm-common-services", "error": "no matches for kind \"OperandRegistry\" in version \"operator.ibm.com/v1alpha1\""}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:227
```

After the update, CS operator will check if OperandRegistry CRD exists or not. If it is not there, it will skip the `no-op` operator check, and continue NSS cleanup.
```
I0221 03:48:33.018747 1 init.go:1192] OperandRegistry CRD does not exist, skip checking no-op installMode
I0221 03:48:33.119799 1 init.go:1233] The ibm-namespace-scope-operator subscription is not found in the 4-5-test namespace, skip cleaning up
```