### PR TITLE
Enable StorageClass configuration for common-service-db

### DIFF
--- a/controllers/constant/storageclass.go
+++ b/controllers/constant/storageclass.go
@@ -49,4 +49,13 @@ const StorageClassTemplate = `
             storageClass: placeholder
       kind: Cluster
       name: keycloak-edb-cluster
+- name: common-service-postgresql
+  resources:
+    - apiVersion: postgresql.k8s.enterprisedb.io/v1
+      data:
+        spec:
+          storage:
+            storageClass: placeholder
+      kind: Cluster
+      name: common-service-db
 `


### PR DESCRIPTION
Issue:https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62395

### Context
Added a storageClass template for `common-service-db`, so that when the user configures the storageClass in the CommonService CR, the custom storageClass will be added to the `common-service-db` resource in OperandConfig and synchronized in the Cluster CR.

### How to test
test image: quay.io/yuchen_shen/cs_operator:csdb_sc
1. Request `common-service-postgresql` without configure storageClass in CommonService CR, there will be no storageClass section for `common-service-db` in Cluster CR
2. Apply the test image, configure a storageClass in CS CR
3. Delete `common-service` OpCon and `common-service-db` Cluster CR and restart ODLM pod
4. Observe the custom sc will be added in OperandConfig and existing `common-service-db` Cluster CR

example:
```
storage:
    resizeInUseVolumes: true
    size: 1Gi
    storageClass: <storage-class-name>
```