### PR TITLE
Check scoped namespaces from nss ConfigMap instead of watch_namespace

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1185,14 +1185,14 @@ func (b *Bootstrap) CleanNamespaceScopeResources() error {
 	if err != nil {
 		klog.Errorf("Failed to get %s configmap: %v", constant.NamespaceScopeConfigmapName, err)
 		return err
-	} else if nssCmNs == nil && err == nil {
-		klog.Infof("The %s configmap is not found in the %s namespace, skip cleaning up", constant.NamespaceScopeConfigmapName, b.CSData.OperatorNs)
+	} else if nssCmNs == nil {
+		klog.Infof("The %s configmap is not found in the %s namespace, skip cleaning the NamespaceScope resources", constant.NamespaceScopeConfigmapName, b.CSData.OperatorNs)
 		return nil
 	}
 
 	// If the topology is (NOT ALL NS Mode) and (NOT Simple) , return
 	if b.CSData.WatchNamespaces != "" && len(nssCmNs) > 1 {
-		klog.Infof("The topology is not All Namespaces Mode or Simple Topology, skip cleaning up")
+		klog.Infof("The topology is not All Namespaces Mode or Simple Topology, skip cleaning the NamespaceScope resources")
 		return nil
 	}
 

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1180,8 +1180,19 @@ func (b *Bootstrap) DeployCertManagerCR() error {
 // NamespaceScope resources include common-service, nss-managedby-odlm, nss-odlm-scope, and odlm-scope-managedby-odlm
 func (b *Bootstrap) CleanNamespaceScopeResources() error {
 
+	// get namespace-scope ConfigMap in operatorNamespace
+	nssCmNs, err := util.GetNssCmNs(b.Reader, b.CSData.OperatorNs)
+	if err != nil {
+		klog.Errorf("Failed to get %s configmap: %v", constant.NamespaceScopeConfigmapName, err)
+		return err
+	} else if nssCmNs == nil && err == nil {
+		klog.Infof("The %s configmap is not found in the %s namespace, skip cleaning up", constant.NamespaceScopeConfigmapName, b.CSData.OperatorNs)
+		return nil
+	}
+
 	// If the topology is (NOT ALL NS Mode) and (NOT Simple) , return
-	if b.CSData.WatchNamespaces != "" && len(strings.Split(b.CSData.WatchNamespaces, ",")) > 1 {
+	if b.CSData.WatchNamespaces != "" && len(nssCmNs) > 1 {
+		klog.Infof("The topology is not All Namespaces Mode or Simple Topology, skip cleaning up")
 		return nil
 	}
 

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -747,21 +747,17 @@ func GetCmOfNss(r client.Reader, operatorNs string) (*corev1.ConfigMap, error) {
 	cmNs := operatorNs
 	nssConfigmap := &corev1.ConfigMap{}
 
-	for {
-		if err := utilwait.PollImmediate(time.Second*5, time.Second*30, func() (done bool, err error) {
-			err = r.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: cmNs}, nssConfigmap)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					klog.Infof("waiting for configmap %v/%v", operatorNs, constant.NamespaceScopeConfigmapName)
-				}
-				return false, err
+	if err := utilwait.PollImmediate(time.Second*5, time.Second*30, func() (done bool, err error) {
+		err = r.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: cmNs}, nssConfigmap)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				klog.Infof("waiting for configmap %v/%v", operatorNs, constant.NamespaceScopeConfigmapName)
 			}
-			return true, nil
-		}); err == nil {
-			break
-		} else {
-			return nil, err
+			return false, err
 		}
+		return true, nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return nssConfigmap, nil

--- a/controllers/webhooks/commonservice/validatingwebhook.go
+++ b/controllers/webhooks/commonservice/validatingwebhook.go
@@ -37,7 +37,7 @@ import (
 
 // +kubebuilder:webhook:path=/validate-operator-ibm-com-v3-commonservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=operator.ibm.com,resources=commonservices,verbs=create;update,versions=v3,name=vcommonservice.kb.io,admissionReviewVersions=v1
 
-// CommonServiceDefaulter points to correct ServiceNamespace
+// CommonServiceDefaulter points to correct ServicesNamespace
 type Defaulter struct {
 	Reader    client.Reader
 	Client    client.Client


### PR DESCRIPTION
Fix for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62427

If the Namespace Scope operator does not immediately patch `WATCH_NAMESPACE` in the cs-operator CSV, we will then check the number of scoped namespaces from the `namespace-scope` ConfigMap before proceeding to clean up the NSS operator and CRs.