### PR TITLE
Pin the ODLM channel at v4.3 for CS 4.6+

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -368,7 +368,7 @@ function pre_req() {
     # When Common Service channel is less than v4.5, use maintained channel for ODLM channel
     local channel_numeric="${CHANNEL#v}"
     local odlm_channel_numeric="${ODLM_CHANNEL#v}"
-    if awk -v num="$channel_numeric" "BEGIN { exit !(num < 4.5) }"; then
+    if awk -v num="$channel_numeric" "BEGIN { exit !(num < 4.6) }"; then
         ODLM_CHANNEL="$MAINTAINED_CHANNEL"
     fi
 }


### PR DESCRIPTION
CS version `4.4.1` will become `4.5.0`, and `4.5.0` will then progress to `4.6.0`,so pin the channel of ODLM at version 4.3 for CS 4.6+

- The ODLM channel will be the same as the version of Common Service for 4.0 and 4.1 release
- The ODLM channel will be at `v4.2` for CPFS 4.2-4.5 release
- The ODLM channel will be pinned at version `v4.3` for each release starting from 4.6