### PR TITLE
increase wait time for cert and issuer

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -243,7 +243,7 @@ function wait_for_issuer() {
     local issuer=$1
     local namespace=$2
     local condition="${OC} -n ${namespace} get issuer.v1.cert-manager.io ${issuer} --ignore-not-found -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' | grep 'True'"
-    local retries=10
+    local retries=50
     local sleep_time=6
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for Issuer ${issuer} in namespace ${namespace} to be Ready"
@@ -257,7 +257,7 @@ function wait_for_certificate() {
     local certificate=$1
     local namespace=$2
     local condition="${OC} -n ${namespace} get certificate.v1.cert-manager.io ${certificate} --ignore-not-found -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' | grep 'True'"
-    local retries=10
+    local retries=50
     local sleep_time=6
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for Certificate ${certificate} in namespace ${namespace} to be Ready"


### PR DESCRIPTION
issue: https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/17638#issuecomment-74020451

Increase the wait time from 1 min to 5 min for certificate smoke test
```
[root@api.sre-upg-3m15w-ocs-480-airc-01.cp.fyre.ibm.com work]# tail -f setup-instance-topology-March1-t5.log
[INFO] RETRYING: Waiting for Certificate test-certificate in namespace operator-ns to be Ready (5 left)
[INFO] RETRYING: Waiting for Certificate test-certificate in namespace operator-ns to be Ready (4 left)
[INFO] RETRYING: Waiting for Certificate test-certificate in namespace operator-ns to be Ready (3 left)
[INFO] RETRYING: Waiting for Certificate test-certificate in namespace operator-ns to be Ready (2 left)
[INFO] RETRYING: Waiting for Certificate test-certificate in namespace operator-ns to be Ready (1 left)
[✘] Timeout after 1 minutes waiting for Certificate test-certificate in namespace operator-ns to be Ready
[ERROR] 2024-03-01T12:53:56.593518Z cmd.Run() failed with exit status 1
[ERROR] 2024-03-01T12:53:56.593690Z Command exception: The setup-instance-topology command failed (exit status 1). You may find output and logs in the /tmp/work/cpd-cli-workspace/olm-utils-workspace/work directory.
[ERROR] 2024-03-01T12:53:56.595478Z RunPluginCommand:Execution error:  exit status 1
```