### PR TITLE
create/update NSS CR before updating NSS operator

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -144,6 +144,9 @@ function main() {
         # Create namespace-scope ConfigMap in services namespace
         create_nss_configmap "$SERVICES_NS" "$SERVICES_NS"
     else
+        # Create/Update NamespaceScope CR common-service
+        update_nss_kind "$OPERATOR_NS" "$NS_LIST"
+
         # Update ibm-namespace-scope-operator channel
         is_sub_exist ibm-namespace-scope-operator-restricted $OPERATOR_NS
         if [ $? -eq 0 ]; then
@@ -159,9 +162,6 @@ function main() {
         for ns in ${NS_LIST//,/ }; do
             ${BASE_DIR}/common/authorize-namespace.sh $ns -to $OPERATOR_NS
         done
-
-        # Update NamespaceScope CR common-service
-        update_nss_kind "$OPERATOR_NS" "$NS_LIST"
 
         accept_license "namespacescope" "$OPERATOR_NS" "common-service"
     fi


### PR DESCRIPTION
fix for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61531

The fix is used to recreate/update the `common-service` NamespaceScope CR promptly after cleaning NSS resources to prevent obtaining an incorrect number of namespace members caused by the failure of the NSS operator upgrade the next time the script runs.
