### PR TITLE
Extend the time to wait for CS CR readiness

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -299,7 +299,7 @@ function wait_for_cscr_status(){
     local namespace=$1
     local name=$2
     local condition="${OC} -n ${namespace} get commonservice ${name} --no-headers --ignore-not-found -o jsonpath='{.status.phase}' | grep 'Succeeded'"
-    local retries=20
+    local retries=50
     local sleep_time=6
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for CommonService CR ${name} in ${namespace} to be ready"


### PR DESCRIPTION
Fix for issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/62501

In this release, we have temporarily extended the CS CR waiting time to address the issue. Additionally, we are planning to refactor the code and create new controllers to concurrently reconcile the CS CR, aiming to reduce waiting times in future releases.