### PR TITLE
Remove problematic code to reduce error

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -547,7 +547,6 @@ function swapmongopvc() {
   fi
 
   ${OC} patch pv $VOL --type=merge -p '{"spec": {"claimRef":null}}'
-  ${OC} patch pv $VOL --type json -p '[{ "op": "remove", "path": "/spec/claimRef" }]' #this line is proving problematic
 
   roks=$(${OC} cluster-info | grep 'containers.cloud.ibm.com')
   if [[ -z $roks ]]; then


### PR DESCRIPTION
As we introduce `error trapping in the $FUNCNAME`, we need to remove the problematic code to reduce errors that could lead to script termination