### PR TITLE
[323] Upgrade db2u operator channel to v5

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -428,7 +428,7 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: v3.2
+  - channel: v5.0
     name: ibm-db2u-operator
     namespace: "{{ .MasterNs }}"
     packageName: db2u-operator


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61733