### PR TITLE
[4.5] Pick up EDB 1.18.10

### DIFF
--- a/controllers/constant/cloudNativePostgresql.go
+++ b/controllers/constant/cloudNativePostgresql.go
@@ -27,9 +27,10 @@ metadata:
   annotations:
     version: {{ .Version }}
 data:
-  ibm-postgresql-15-operand-image: icr.io/cpopen/edb/postgresql:15.4@sha256:7ae65a0e9f172a6882b29a629d2f727aa9b6114c82eb116df5a934bf2797c17c
-  ibm-postgresql-14-operand-image: icr.io/cpopen/edb/postgresql:14.9@sha256:90136074adcbafb5033668b07fe1efea9addf0168fa83b0c8a6984536fc22264
-  ibm-postgresql-13-operand-image: icr.io/cpopen/edb/postgresql:13.12@sha256:7f8188c114ea8d1a2f706e7e7672e3462a50f96e7eec4da137e9996c4e40b674
-  ibm-postgresql-12-operand-image: icr.io/cpopen/edb/postgresql:12.16@sha256:ff99a217198e58f89f847ddeea1ddc153593123f93b88fb0ece39d3c1f59cb6e
-  edb-postgres-license-provider-image: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
+  ibm-postgresql-16-operand-image: icr.io/cpopen/edb/postgresql:16.2@sha256:dfd176f664352298c481b40197ecb08678705e876cee44bc8a6d4d5998ee84e9
+  ibm-postgresql-15-operand-image: icr.io/cpopen/edb/postgresql:15.6@sha256:e43e67652b6b5c2faf3d59f9108a7d2ba7b7b1029f6d14915ec68ef362bab616
+  ibm-postgresql-14-operand-image: icr.io/cpopen/edb/postgresql:14.11@sha256:ba747b4a9666d66383e52009cd66b572c8fc22620a6e608f62e1552f9e979b5e
+  ibm-postgresql-13-operand-image: icr.io/cpopen/edb/postgresql:13.14@sha256:2cb7e3e7447bc16cb12c09ae84fe7a2a1f16ab6ed43cbf92313d45fc1628c17a
+  ibm-postgresql-12-operand-image: icr.io/cpopen/edb/postgresql:12.18@sha256:5d743d6e5d2f840ff79efcb8b5aed26bc573f12e5f9a2776db71c21bb445925f
+  edb-postgres-license-provider-image: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:c9660f09a003178b13830fc260519c8d2e054ee8312e3cd1273d88d8d1acb759
 `

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -819,7 +819,6 @@ spec:
                     templatingValueFrom:
                       default:
                         required: true
-                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
                         configMapKeyRef:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
@@ -851,7 +850,6 @@ spec:
                     templatingValueFrom:
                       default:
                         required: true
-                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
                         configMapKeyRef:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
@@ -933,7 +931,6 @@ spec:
               templatingValueFrom:
                 default:
                   required: true
-                  defaultValue: icr.io/cpopen/edb/postgresql:14.9@sha256:90136074adcbafb5033668b07fe1efea9addf0168fa83b0c8a6984536fc22264
                   configMapKeyRef:
                     name: cloud-native-postgresql-image-list
                     key: ibm-postgresql-14-operand-image
@@ -1400,7 +1397,6 @@ spec:
                     templatingValueFrom:
                       default:
                         required: true
-                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
                         configMapKeyRef:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
@@ -1432,7 +1428,6 @@ spec:
                     templatingValueFrom:
                       default:
                         required: true
-                        defaultValue: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:05f30f2117ff6e0e853487f17785024f6bb226f3631425eaf1498b9d3b753345
                         configMapKeyRef:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62285#issuecomment-74522237

1. Pick images for EDB 1.18.10
2. Removing hardcoded image string from OperandConfig, image is always referenced from `cloud-native-postgresql-image-list` ConfigMap.