### PR TITLE
update velero post hook annotation

### DIFF
--- a/velero/schedule/keycloak/keycloak-backup-deployment.yaml
+++ b/velero/schedule/keycloak/keycloak-backup-deployment.yaml
@@ -13,7 +13,7 @@ spec:
         backup.velero.io/backup-volumes: keycloak-backup
         pre.hook.backup.velero.io/command: '["sh", "-c", "/keycloak/br_keycloak.sh backup <keycloak namespace>"]'
         pre.hook.backup.velero.io/timeout: 300s
-        post.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /keycloak/keycloak-backup/"]'
+        post.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /keycloak/keycloak-backup/database && rm -rf /keycloak/keycloak-backup/secrets"]'
         post.hook.restore.velero.io/command: '["sh", "-c", "/keycloak/br_keycloak.sh restore <keycloak namespace>"]'
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s

--- a/velero/schedule/schedule-common-services.yaml
+++ b/velero/schedule/schedule-common-services.yaml
@@ -4,7 +4,7 @@ metadata:
   name: commonservice-backup
   namespace: velero
 spec:
-  schedule: 45 * * * *
+  schedule: 45 13 * * *
   template:
     ttl: 48h0m0s
     defaultVolumesToRestic: true


### PR DESCRIPTION
remove database and secrets separately, otherwise it might cause permission issue because of `readonlyrootfilesystem`