### PR TITLE
Add cert-manger and AudiLogging CRs back to OperandConfig

### DIFF
--- a/common/scripts/lint-csv.sh
+++ b/common/scripts/lint-csv.sh
@@ -40,7 +40,7 @@ echo "Lint alm-examples"
 $YQ eval '.metadata.annotations.alm-examples' $CSV_PATH  | $JQ . >/dev/null || STATUS=1
 
 # Lint yamls, only CS Operator needs this part
-for section in csV3OperandConfig csV3SaasOperandConfig csV3OperandRegistry csV3SaasOperandRegistry csOperatorSubscription csSecretshareOperator csWebhookOperator csWebhookOperatorEnableOpreqWebhook nsRestrictedSubscription nsSubscription odlmClusterSubscription odlmNamespacedSubscription; do
+for section in csV4OperandConfig csV4SaasOperandConfig csV4OperandRegistry csV4SaasOperandRegistry csOperatorSubscription csSecretshareOperator csWebhookOperator csWebhookOperatorEnableOpreqWebhook nsRestrictedSubscription nsSubscription odlmClusterSubscription odlmNamespacedSubscription; do
     echo "Lint $section"
     $YQ eval '.metadata.annotations.$section' $CSV_PATH  | $YQ - >/dev/null || STATUS=1
 done

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -664,7 +664,7 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 
 	var baseReg string
 	registries := []string{
-		constant.CSV3OpReg,
+		constant.CSV4OpReg,
 		constant.MongoDBOpReg,
 		constant.IMOpReg,
 		constant.IdpConfigUIOpReg,
@@ -673,9 +673,9 @@ func (b *Bootstrap) InstallOrUpdateOpreg(forceUpdateODLMCRs bool, installPlanApp
 		constant.CommonServicePGOpReg,
 	}
 	if b.SaasEnable {
-		baseReg = constant.CSV2SaasOpReg
+		baseReg = constant.CSV3SaasOpReg
 	} else {
-		baseReg = constant.CSV2OpReg
+		baseReg = constant.CSV3OpReg
 	}
 
 	concatenatedReg, err := constant.ConcatenateRegistries(baseReg, registries, b.CSData)
@@ -703,7 +703,7 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
 		constant.CommonServicePGOpCon,
 	}
 
-	baseCon = constant.CSV3OpCon
+	baseCon = constant.CSV4OpCon
 
 	concatenatedCon, err := constant.ConcatenateConfigs(baseCon, configs, b.CSData)
 	if err != nil {

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -27,10 +27,10 @@ import (
 )
 
 var (
-	CSV3OperandRegistry     string
-	CSV3SaasOperandRegistry string
-	CSV3OperandConfig       string
-	CSV3SaasOperandConfig   string
+	CSV4OperandRegistry     string
+	CSV4SaasOperandRegistry string
+	CSV4OperandConfig       string
+	CSV4SaasOperandConfig   string
 )
 
 const (
@@ -1118,7 +1118,7 @@ spec:
 )
 
 const (
-	CSV2OpReg = `
+	CSV3OpReg = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
@@ -1223,7 +1223,7 @@ spec:
     installMode: no-op
 `
 
-	CSV3OpReg = `
+	CSV4OpReg = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
@@ -1305,7 +1305,7 @@ spec:
 )
 
 const (
-	CSV2SaasOpReg = `
+	CSV3SaasOpReg = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
@@ -1369,7 +1369,7 @@ spec:
   `
 )
 
-const CSV3OpCon = `
+const CSV4OpCon = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig
 metadata:
@@ -1428,6 +1428,9 @@ spec:
       commonWebUI: {}
       switcheritem: {}
       navconfiguration: {}
+  - name: ibm-cert-manager-operator
+    spec:
+      certManager: {}
   - name: ibm-management-ingress-operator
     spec:
       managementIngress: {}
@@ -1438,6 +1441,7 @@ spec:
       nginxIngress: {}
   - name: ibm-auditlogging-operator
     spec:
+      auditLogging: {}
       operandBindInfo: {}
       operandRequest: {}
   - name: ibm-platform-api-operator


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61103#issuecomment-74347408

Add CRs back to OperandConfig
- Cert Manager CR `certManager`
- AuditLogging CR `auditLogging`