### PR TITLE
Disable the installation of MongoDB starting from 4.6.

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1245,6 +1245,7 @@ spec:
   - name: ibm-im-mongodb-operator
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
+    installMode: no-op
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
   - channel: v3


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62327

MongoDB operator and services are not longer requested by IM to install since release 4.6, we have marked it as `no-op` operator.