### PR TITLE
separate wal storage and increase storage volume

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1034,7 +1034,10 @@ spec:
             stopDelay: 90
             storage:
               resizeInUseVolumes: true
-              size: 1Gi
+              size: 10Gi
+            walStorage:
+              resizeInUseVolumes: true
+              size: 10Gi
             postgresql:
               parameters:
                 max_connections: "600"  

--- a/controllers/constant/storageclass.go
+++ b/controllers/constant/storageclass.go
@@ -56,6 +56,8 @@ const StorageClassTemplate = `
         spec:
           storage:
             storageClass: placeholder
+          walStorage:
+            storageClass: placeholder
       kind: Cluster
       name: common-service-db
 `


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62563

A new PVC is created for WAL storage, and the size for two PVCs are both 10Gi
<img width="1618" alt="Screenshot 2024-03-18 at 1 08 28 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/4bda2907-9411-4692-895a-c33cddf8d377">
