### PR TITLE
Preload IM client credentials for admin

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -54,6 +54,8 @@ function main() {
     # copy im credentials
     copy_resource "secret" "platform-auth-idp-credentials"
     copy_resource "secret" "platform-auth-ldaps-ca-cert"
+    copy_resource "secret" "platform-oidc-credentials"
+    copy_resource "secret" "oauth-client-secret"
     copy_resource "configmap" "ibm-cpp-config"
     copy_resource "configmap" "common-web-ui-config"
     copy_resource "configmap" "platform-auth-idp"


### PR DESCRIPTION
The `platform-oidc-credentials` and `oauth-client-secret` Secrets both contain client registrations that are expected to persist through an isolated upgrade and migration from MongoDB to EDB. Not having these secrets established before the IAM Operator starts leads to split-brain problems between the Operator and the platform-auth-service Operand.