### PR TITLE
[WIP] IM database rollback script init

### DIFF
--- a/velero/restore/im-database-rollback.sh
+++ b/velero/restore/im-database-rollback.sh
@@ -51,7 +51,7 @@ function main() {
 
     # pre requests
     prereq
-    deletemongocopy
+    
     # if mongo exist in the cluster skip following two steps
     mongoStatus=$(${OC} get po icp-mongodb-0 --no-headers --ignore-not-found -n $NAMESPACE | awk '{print $3}')
     if [[ -z "$mongoStatus" ]] || [[ "$mongoStatus" != "Running" ]]; then
@@ -225,7 +225,7 @@ function loadmongo() {
 
     info "Running Restore"
     # delete mongo-backup pod just in case it has error
-    MONGO_DATA_POD=$(${OC} get po -l velero.io/restore-name=restore-mongo-data --no-headers --ignore-not-found -n $NAMESPACE | awk '{print $1}')
+    MONGO_DATA_POD=$(${OC} get po -l foundationservices.cloudpak.ibm.com=mongo-data --no-headers --ignore-not-found -n $NAMESPACE | awk '{print $1}')
     echo $MONGO_DATA_POD
     wait_for_pod_delete $NAMESPACE $MONGO_DATA_POD
 


### PR DESCRIPTION
For ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62205
init IM database rollback script base on preload-data script
script logic:

Pre-request: 
1. IM and EDB exist in the cluster
2. IM in cs 4.6 or later version
3. mongo-data already restored in the cluster

script steps:
1. check pre-requests
2. deploy dummy mongo
3. load mongo data
4. cleanup data in EDB
5. trigger data migration
6. cleanup dummy mongo
