### PR TITLE
Remove default size profile and instance from OperandConfig template

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -641,7 +641,6 @@ spec:
               tlsSecret: cs-keycloak-tls-secret
             ingress:
               enabled: false
-            instances: 1
             unsupported:
               podTemplate:
                 spec:
@@ -649,15 +648,6 @@ spec:
                     - command:
                         - /bin/sh
                         - /mnt/startup/cs-keycloak-entrypoint.sh
-                      resources:
-                        limits:
-                          cpu: 1000m
-                          memory: 1Gi
-                          ephemeral-storage: 512Mi
-                        requests:
-                          cpu: 1000m
-                          memory: 1Gi
-                          ephemeral-storage: 256Mi
                       volumeMounts:
                         - mountPath: /mnt/truststore
                           name: truststore-volume
@@ -835,14 +825,6 @@ spec:
                     key: edb-keycloak-operand-image
             imagePullSecrets:
               - name: ibm-entitlement-key
-            instances: 1
-            resources:
-              limits:
-                cpu: 200m
-                memory: 512Mi
-              requests:
-                cpu: 200m
-                memory: 512Mi
             logLevel: info
             primaryUpdateStrategy: unsupervised
             primaryUpdateMethod: switchover
@@ -1023,7 +1005,6 @@ spec:
                     namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key
-            instances: 1
             replicationSlots:
               highAvailability:
                 enabled: true
@@ -1032,13 +1013,6 @@ spec:
               replicationTLSSecret: common-service-db-replica-tls-secret
               serverCASecret: cs-ca-certificate-secret
               serverTLSSecret: common-service-db-tls-secret
-            resources:
-              limits:
-                cpu: 200m
-                memory: 512Mi
-              requests:
-                cpu: 200m
-                memory: 512Mi
             primaryUpdateStrategy: unsupervised
             startDelay: 120
             stopDelay: 90

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -866,7 +866,9 @@ const Large = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -866,7 +866,9 @@ const Large = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -866,7 +866,9 @@ const Large = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -866,7 +866,9 @@ const Medium = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -866,7 +866,9 @@ const Medium = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -866,7 +866,9 @@ const Medium = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -866,7 +866,9 @@ const Small = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
-                      memory: 1Gi
+                      memory: 1Gi 
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -866,7 +866,9 @@ const Small = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -866,7 +866,9 @@ const Small = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -866,7 +866,9 @@ const StarterSet = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -866,7 +866,9 @@ const StarterSet = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -868,7 +868,9 @@ const StarterSet = `
                     limits:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 512Mi
                     requests:
                       cpu: 1000m
                       memory: 1Gi
+                      ephemeral-storage: 256Mi
 `


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/61284

After [implementing](https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1019) the ODLM's capability to deep merge Kubernetes resources logic, we could remove the default size profile and instance in OperandConfig template. Therefore, we should observe a consistent change in the number of instances during common-service reconciliation, rather than fluctuating between 3, 1, and 3.

Before removing the hardcoded size and instance:
1. When deploying KeyCloak for the first time, the instance created in KeyCloak CR would be `1`.
2. Then if the user configures a large size in CS CR, the instance will change to `3`.
3. If it is upgraded to a new version, we will observe the instance changing back to `1`, as CS applies the default value of 1 from OperandConfig during reconciliation.
4. Finally, it will ultimately change to `3`, as the size is configured as large in the CS CR

After removing:
1. The instance would always remain `3` without alteration, as long as the user configures it to a large size.
