### PR TITLE
quote array value for annotations

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -842,7 +842,7 @@ spec:
               size: 1Gi
         force: true
         annotations:
-          k8s.enterprisedb.io/addons: ["velero"]
+          k8s.enterprisedb.io/addons: '["velero"]'
           k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled
         labels:
           foundationservices.cloudpak.ibm.com: keycloak


### PR DESCRIPTION
To unblock the error on rendering OperandConfig, json could not unmarshal array `["velero"]` into annotation value `string`, need to quote the array `'["velero"]'`

```
E0329 04:25:33.828268 1 init.go:710] failed to concatenate OperandConfig: failed to fetch data of OprandConfig hugepages/common-service: error unmarshaling JSON: json: cannot unmarshal array into Go struct field ConfigResource.spec.services.resources.annotations of type string
E0329 04:25:33.835020 1 commonservice_controller.go:227] Fail to reconcile hugepages/common-service: failed to fetch data of OprandConfig hugepages/common-service: error unmarshaling JSON: json: cannot unmarshal array into Go struct field ConfigResource.spec.services.resources.annotations of type string
2024-03-29T04:25:33.835Z ERROR controller.commonservice Reconciler error {"reconciler group": "operator.ibm.com", "reconciler kind": "CommonService", "name": "common-service", "namespace": "hugepages", "error": "failed to fetch data of OprandConfig hugepages/common-service: error unmarshaling JSON: json: cannot unmarshal array into Go struct field ConfigResource.spec.services.resources.annotations of type string"}
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.10.0/pkg/internal/controller/controller.go:227
```