### PR TITLE
add velero plugin to im edb cluster config by default

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -990,8 +990,16 @@ spec:
         kind: Cluster
         name: common-service-db
         force: true
+        annotations:
+          k8s.enterprisedb.io/addons: ["velero"]
+          k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled
+        labels:
+          foundationservices.cloudpak.ibm.com: cs-db
         data:
           spec:
+            inheritedMetadata:
+              annotations:
+                backup.velero.io/backup-volumes: pgdata,pg-wal
             bootstrap:
               initdb:
                 database: cloudpak

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -991,7 +991,7 @@ spec:
         name: common-service-db
         force: true
         annotations:
-          k8s.enterprisedb.io/addons: ["velero"]
+          k8s.enterprisedb.io/addons: '["velero"]'
           k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled
         labels:
           foundationservices.cloudpak.ibm.com: cs-db


### PR DESCRIPTION
By default, we want to enable the velero backup addon for IM EDB cluster. This way, in all use cases except CP4D, IM EDB will follow the officially supported BR process for EDB. In the CP4D case where IM EDB will be sharing cluster config with zen, CP4D will overwrite the annotation with their own via the CommonService CR. This will remove the ability to backup IM via velero plugin so we will have a fork in the instructions to specify using the pgdump approach instead. I stuck with calling the velero label cs-db instead of cs-db-data as we already have in scripts to facilitate this use case based fork.

Discussion welcome.