### PR TITLE
add velero plugin based labels, clarify labels

### DIFF
--- a/velero/schedule/schedule-common-services.yaml
+++ b/velero/schedule/schedule-common-services.yaml
@@ -38,7 +38,7 @@ spec:
         - crd
         - lsr #non-data license service reporter resources
         - lsr-data #license service reporter data
-        - cs-db-data #pgdump
-        - cs-db #velero plugin
-        - keycloak-data #pgdump
-        - keycloak #velero plugin
+        - cs-db-data #pgdump approach to BR IM EDB data
+        - cs-db #velero plugin approach to BR IM EDB data
+        - keycloak-data #pgdump approach to BR keycloak data
+        - keycloak #velero plugin approach to BR keycloak data

--- a/velero/schedule/schedule-common-services.yaml
+++ b/velero/schedule/schedule-common-services.yaml
@@ -22,21 +22,23 @@ spec:
         - catalog
         - subscription
         - operand
-        - zen-data
+        - zen-data #zen 4 data
         - mongo-data
         - entitlementkey
         - commonservice
         - pull-secret
         - operatorgroup
-        - zen
+        - zen #non-data zen 4 resources
         - licensing
         - cert-manager
         - namespace
         - configmap
-        - zen5
-        - zen5-data
+        - zen5 #non-data zen 5 resources
+        - zen5-data #zen 5 data
         - crd
-        - lsr
-        - lsr-data
-        - cs-db-data
-        - keycloak-data
+        - lsr #non-data license service reporter resources
+        - lsr-data #license service reporter data
+        - cs-db-data #pgdump
+        - cs-db #velero plugin
+        - keycloak-data #pgdump
+        - keycloak #velero plugin


### PR DESCRIPTION
The velero plugin based BR is currently setup to use the labels `keycloak` and `cs-db` for velero to notice and process the keycloak and IM EDB clusters for backup. This is to differentiate between the velero plugin approach (facilitated and officially supported by the EDB operator) and the pgdump approach we implemented outside of the operator. The pgdump approach uses `keycloak-data` and `cs-db-data` for comparison. I have added comments to these four values as well as the similarly structured License Service Reporter and Zen values to provide clarity on their usage.