### PR TITLE
Update CRD to be forward compatible

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -51,6 +51,7 @@ type ExtensionWithMarker struct {
 	runtime.RawExtension `json:",inline"`
 }
 
+// +kubebuilder:pruning:PreserveUnknownFields
 type ServiceConfig struct {
 	Name               string                         `json:"name"`
 	Spec               map[string]ExtensionWithMarker `json:"spec,omitempty"`
@@ -110,7 +111,7 @@ type CommonServiceSpec struct {
 	// +optional
 	// HugePages describes the hugepages settings for foundational services
 	// +kubebuilder:pruning:PreserveUnknownFields
-	HugePages HugePages `json:"hugepages,omitempty"`
+	HugePages *HugePages `json:"hugepages,omitempty"`
 	// OperatorConfigs is a list of configurations to be applied to operators via CSV updates
 	// +kubebuilder:pruning:PreserveUnknownFields
 	OperatorConfigs []OperatorConfig `json:"operatorConfigs,omitempty"`

--- a/api/v3/zz_generated.deepcopy.go
+++ b/api/v3/zz_generated.deepcopy.go
@@ -180,7 +180,11 @@ func (in *CommonServiceSpec) DeepCopyInto(out *CommonServiceSpec) {
 			(*out)[key] = val
 		}
 	}
-	in.HugePages.DeepCopyInto(&out.HugePages)
+	if in.HugePages != nil {
+		in, out := &in.HugePages, &out.HugePages
+		*out = new(HugePages)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.OperatorConfigs != nil {
 		in, out := &in.OperatorConfigs, &out.OperatorConfigs
 		*out = make([]OperatorConfig, len(*in))

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ibm-common-service-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=v4.6
 LABEL operators.operatorframework.io.bundle.channel.default.v1=v4.6
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.29.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.31.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-04-02T03:07:28Z"
+    createdAt: "2024-04-03T14:59:21Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -30,7 +30,7 @@ metadata:
     operatorChannel: v4.6
     operatorVersion: 4.6.0
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.29.0
+    operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/ibm-common-service-operator
     support: IBM

--- a/bundle/manifests/operator.ibm.com_commonservices.yaml
+++ b/bundle/manifests/operator.ibm.com_commonservices.yaml
@@ -192,6 +192,7 @@ spec:
                   required:
                   - name
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 type: array
               servicesNamespace:
                 description: |-

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: ibm-common-service-operator
   operators.operatorframework.io.bundle.channels.v1: v4.6
   operators.operatorframework.io.bundle.channel.default.v1: v4.6
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.29.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.31.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -188,6 +188,7 @@ spec:
                   required:
                   - name
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 type: array
               servicesNamespace:
                 description: |-

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deckarep/golang-set v1.7.1 // indirect
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-logr/logr v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
+github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
 github.com/deislabs/oras v0.8.1/go.mod h1:Mx0rMSbBNaNfY9hjpccEnxkOqJL6KGjtxNHPLC4G4As=
 github.com/denisenkom/go-mssqldb v0.0.0-20190515213511-eb9f6a1743f3/go.mod h1:zAg7JM8CkOJ43xKXIj7eRO9kmWm/TW578qo+oDO6tuM=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=


### PR DESCRIPTION
Add preserve unknown field for CS CR field .`spec.services[*]`

```yaml
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
spec:
  license:
    accept: false
  operatorNamespace: cs-condition
  servicesNamespace: cs-condition
  size: starterset
  services:
     - name: ibm-im-operator
       resources:
          - xxxx
       spec:
            xxxx
       ...  # Any arbitrary field
```