### PR TITLE
add cpfs annotation info for EDB Cluster CR

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -846,6 +846,9 @@ spec:
         annotations:
           k8s.enterprisedb.io/addons: '["velero"]'
           k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled
+          productID: 068a62892a1e4db39641342e592daa25
+          productMetric: FREE
+          productName: IBM Cloud Platform Common Services
         labels:
           foundationservices.cloudpak.ibm.com: keycloak
         kind: Cluster
@@ -989,6 +992,10 @@ spec:
       - apiVersion: postgresql.k8s.enterprisedb.io/v1
         kind: Cluster
         name: common-service-db
+        annotations:
+          productID: 068a62892a1e4db39641342e592daa25
+          productMetric: FREE
+          productName: IBM Cloud Platform Common Services
         force: true
         data:
           spec:


### PR DESCRIPTION
Add following CPFS annotations for EDB Cluster CR created by CPFS. One Cluster CR for IM, and the other one for Keycloak.
```
productID: 068a62892a1e4db39641342e592daa25
productMetric: FREE
productName: IBM Cloud Platform Common Services
```

The pod managed by EDB Cluster CR contains the annotations as well

<img width="741" alt="Screenshot 2024-04-08 at 2 38 44 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/cd8a1bf4-6c2f-43cc-ad72-c7d75de59fcf">
