### PR TITLE
reference cpfs version in Keycloak pod template

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -645,6 +645,16 @@ spec:
               enabled: false
             unsupported:
               podTemplate:
+                metadata:
+                  annotations:
+                    cpfsVersion:
+                      templatingValueFrom:
+                        objectRef:
+                          apiVersion: v1
+                          kind: ConfigMap
+                          name: cs-keycloak-theme
+                          path: .metadata.annotations.version
+                        required: true
                 spec:
                   containers:
                     - command:


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62819

Keycloak CR's pod will have a reference on `annotations.version` from `cs-keycloak-theme` ConfigMap.
When the `cs-keycloak-theme` ConfigMa is updated in a new release(new theme update), Keycloak pod will be patched with a new annotation `cpfsVersion: 4.6.0`. As a result, the pod will be restarted to pick up the new theme styling.

### Test
- Keycloak CR will be updated with latest pod template
   <img width="661" alt="Screenshot 2024-04-09 at 2 21 45 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/c3231f07-6ca2-44dd-af74-f37bfd702ff4">
- Keycloak pod will be updated with new annotation
  <img width="684" alt="Screenshot 2024-04-09 at 2 22 23 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/99bbbe99-16d0-40c6-8010-7c98a33400b2">
