### PR TITLE
annotate Keycloak pod with theme version instead of CPFS version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,7 @@ bundle-manifests: clis
 	$(YQ) eval -i '.spec.webhookdefinitions[0].deploymentName = "ibm-common-service-operator" | .spec.webhookdefinitions[1].deploymentName = "ibm-common-service-operator"' ${CSV_PATH}
 	$(YQ) eval-all -i '.spec.relatedImages = load("config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml").spec.relatedImages' bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
 
-generate-all: yq kustomize operator-sdk generate manifests ## Generate bundle manifests, metadata and package manifests
+generate-all: yq kustomize operator-sdk generate manifests cloudpak-theme-version ## Generate bundle manifests, metadata and package manifests
 	$(OPERATOR_SDK) generate kustomize manifests -q
 	- make bundle-manifests CHANNELS=v4.6 DEFAULT_CHANNEL=v4.6
 

--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -32,18 +32,19 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 type CSData struct {
-	Channel            string
-	Version            string
-	CPFSNs             string
-	ServicesNs         string
-	OperatorNs         string
-	CatalogSourceName  string
-	CatalogSourceNs    string
-	IsolatedModeEnable string
-	ApprovalMode       string
-	OnPremMultiEnable  string
-	WatchNamespaces    string
-	CloudPakThemes     string
+	Channel               string
+	Version               string
+	CPFSNs                string
+	ServicesNs            string
+	OperatorNs            string
+	CatalogSourceName     string
+	CatalogSourceNs       string
+	IsolatedModeEnable    string
+	ApprovalMode          string
+	OnPremMultiEnable     string
+	WatchNamespaces       string
+	CloudPakThemes        string
+	CloudPakThemesVersion string
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -21,8 +21,9 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
+    cloudPakThemesVersion: styles460.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-04-03T14:59:21Z"
+    createdAt: "2024-04-11T02:45:28Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
+    cloudPakThemesVersion: styles460.css
     containerImage: icr.io/cpopen/common-service-operator:latest
     createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -144,6 +144,11 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 	if r, ok := annotations["operatorVersion"]; ok {
 		bs.CSData.Version = r
 	}
+
+	if r, ok := annotations["cloudPakThemesVersion"]; ok {
+		bs.CSData.CloudPakThemesVersion = r
+	}
+
 	klog.Infof("Single Deployment Status: %v, MultiInstance Deployment status: %v, SaaS Depolyment Status: %v", !bs.MultiInstancesEnable, bs.MultiInstancesEnable, bs.SaasEnable)
 	return
 }

--- a/controllers/constant/keycloakThemes.go
+++ b/controllers/constant/keycloakThemes.go
@@ -28,6 +28,7 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
+    themesVersion: {{ .CloudPakThemesVersion }}
 binaryData:
   cloudpak-theme.jar: {{ .CloudPakThemes }}
 `

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -647,13 +647,13 @@ spec:
               podTemplate:
                 metadata:
                   annotations:
-                    cpfsVersion:
+                    cloudpakThemesVersion:
                       templatingValueFrom:
                         objectRef:
                           apiVersion: v1
                           kind: ConfigMap
                           name: cs-keycloak-theme
-                          path: .metadata.annotations.version
+                          path: .metadata.annotations.themesVersion
                         required: true
                 spec:
                   containers:

--- a/hack/keycloak-themes/Makefile
+++ b/hack/keycloak-themes/Makefile
@@ -8,3 +8,10 @@ cloudpak-theme.jar:
 	@echo "Building the keycloak jar theme..."
 	rm $(KEYCLOAK_THEME_DIR)/$(JAR_THEME_FILE) || true
 	(cd $(KEYCLOAK_THEME_DIR) && zip -r ./$(JAR_THEME_FILE) META-INF theme)
+
+cloudpak-theme-version:
+	$(eval THEME_VERSION := $(shell ls $(KEYCLOAK_THEME_DIR)/theme/cloudpak/login/resources/css/ | grep .css))
+	@echo "Updating the keycloak jar theme version to $(THEME_VERSION)"
+	$(YQ) eval -i '.spec.template.metadata.annotations.cloudPakThemesVersion = "$(THEME_VERSION)"' $(KEYCLOAK_THEME_DIR)/../../testdata/deploy/deploy.yaml
+	$(YQ) eval -i '.metadata.annotations.cloudPakThemesVersion = "$(THEME_VERSION)"' $(KEYCLOAK_THEME_DIR)/../../config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml 
+	$(YQ) eval -i '.metadata.annotations.cloudPakThemesVersion = "$(THEME_VERSION)"' $(KEYCLOAK_THEME_DIR)/../../bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml

--- a/testdata/deploy/deploy.yaml
+++ b/testdata/deploy/deploy.yaml
@@ -17,44 +17,45 @@ spec:
         description: The IBM Common Service Operator is used to deploy IBM Common Services
         operatorChannel: v4.6
         operatorVersion: 4.6.0
+        cloudPakThemesVersion: styles460.css
     spec:
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - ppc64le
+                      - s390x
       containers:
-      - command:
-        - /manager
-        env:
-        - name: OPERATOR_NAME
-          value: ibm-common-service-operator
-        image: siji/operator:cs
-        imagePullPolicy: IfNotPresent
-        name: ibm-common-service-operator
-        resources:
-          limits:
-            cpu: 500m
-            memory: 512Mi
-          requests:
-            cpu: 100m
-            memory: 200Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        - command:
+            - /manager
+          env:
+            - name: OPERATOR_NAME
+              value: ibm-common-service-operator
+          image: siji/operator:cs
+          imagePullPolicy: IfNotPresent
+          name: ibm-common-service-operator
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62819#issuecomment-76863148

We annotate the Keycloak pod with the theme version. As long as the theme does not change, keycloak pod does not need to be restarted. It would be independent from CPFS upgrade.

### Test
- CS operator CSV will contain the theme version annotation
   <img width="940" alt="Screenshot 2024-04-10 at 10 51 10 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/50c0dec1-5929-4128-95f6-e1c11d34dc2b">

- `cs-keycloak-theme` ConfigMap will contain the theme version annotation.
  <img width="871" alt="Screenshot 2024-04-10 at 10 51 32 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/6dc203c0-2813-4120-9dc6-8f0f3b6fc820">

- Keycloak server pod will contain the theme version annotation.
  <img width="637" alt="Screenshot 2024-04-10 at 10 51 58 PM" src="https://github.com/IBM/ibm-common-service-operator/assets/29827416/2d13ce7e-613b-4ab3-9883-f896e2cc772f">
