### PR TITLE
Workaround to overwrite BTS operandrequest

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1626,6 +1626,7 @@ spec:
         requests:
           - operands:
               - name: ibm-im-operator
+              - name: ibm-im-operator
             registry: common-service
   - name: ibm-zen-operator
     spec:


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63126

In v3 CPFS, there is an OperandRequest `ibm-bts-request` created along with BTS operator installation, to request the BTS dependencies on `ibm-cert-manager-operator` and `ibm-iam-operator`. The template of OperandRequest is defined in BTS operator CSV's `alm-example`
```yaml
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  name: ibm-bts-request
  namespace: ibm-common-services
spec:
  requests:
    - operands:
        - name: ibm-cert-manager-operator
        - name: ibm-iam-operator
      registry: common-service
```

in v3 -> v4 CPFS upgrade scenario, we [update OperandConfig to overwrite the existing `ibm-bts-request`](https://github.com/IBM/ibm-common-service-operator/blob/86d8cc5c158adc78d0dd28c2b2a36a4517e44256/controllers/constant/odlm.go#L1628).
```yaml
  - name: ibm-bts-operator
    spec:
      operandRequest:
        requests:
          - operands:
              - name: ibm-im-operator
            registry: common-service
```

However, the enhancement of json deep merge in ODLM, ODLM will only update the resources field existed in OperandConfig, and keep other fields in existing resource unchanged in the cluster. As a result, we will see ODLM updates OperandRequest `ibm-bts-request` partially.
```yaml
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  name: ibm-bts-request
  namespace: ibm-common-services
spec:
  requests:
    - operands:
        - name: ibm-im-operator      # replace original ibm-cert-manager-operator
        - name: ibm-iam-operator    # unchanged because there is no replacement in above OperandConfig template
      registry: common-service
```

### Solution
The temporary solution is to update OperandConfig template, to have a full replacement on OperandRequest `ibm-bts-request`, to unblock the upgrade from IAM v3 to IM v4.
```yaml
  - name: ibm-bts-operator
    spec:
      operandRequest:
        requests:
          - operands:
              - name: ibm-im-operator
              - name: ibm-im-operator
            registry: common-service
```

We will need a followup enhancement in ODLM, to overwrite any field whose structure is array/list. There should be no partial update for an array object.