### PR TITLE
revert cpfs utils image to 4.5 to match repo

### DIFF
--- a/velero/backup/zen/zen5_backup_job.yaml
+++ b/velero/backup/zen/zen5_backup_job.yaml
@@ -12,7 +12,7 @@ spec:
           - -c
           - ls
           - ./zen5/backup_zen5.sh <zenservice namespace>
-          image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0, etc based on CS version.
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.5.0 #4.1.0 if using CS 4.1, 4.2.0, etc based on CS version.
           imagePullPolicy: Always
           name: zen5-backup-job
           resources:

--- a/velero/restore/common-service-db/cs-db-restore-job.yaml
+++ b/velero/restore/common-service-db/cs-db-restore-job.yaml
@@ -11,7 +11,7 @@ spec:
           - sh
           - -c
           - /cs-db/br_cs-db.sh restore <cs-db namespace>
-          image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2 etc based on CS version.
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.5.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2 etc based on CS version.
           imagePullPolicy: Always
           name: cs-db-restore-job
           resources:

--- a/velero/restore/keycloak/keycloak-restore-job.yaml
+++ b/velero/restore/keycloak/keycloak-restore-job.yaml
@@ -11,7 +11,7 @@ spec:
           - sh
           - -c
           - /keycloak/br_keycloak.sh restore <keycloak namespace>
-          image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2 etc based on CS version.
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.5.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2 etc based on CS version.
           imagePullPolicy: Always
           name: keycloak-restore-job
           resources:

--- a/velero/restore/zen/zen-restore-job.yaml
+++ b/velero/restore/zen/zen-restore-job.yaml
@@ -11,7 +11,7 @@ spec:
           - sh
           - -c
           - /zen4/zen4-br.sh <zenservice namespace> false
-          image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0 etc based on CS version.
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.5.0 #4.1.0 if using CS 4.1, 4.2.0 etc based on CS version.
           imagePullPolicy: Always
           name: zen4-restore-job
           resources:

--- a/velero/restore/zen/zen5-restore-job.yaml
+++ b/velero/restore/zen/zen5-restore-job.yaml
@@ -11,7 +11,7 @@ spec:
           - sh
           - -c
           - /zen5/restore_zen5.sh <zenservice namespace> <zenservice name>
-          image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0 etc based on CS version.
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.5.0 #4.1.0 if using CS 4.1, 4.2.0 etc based on CS version.
           imagePullPolicy: Always
           name: zen5-restore-job
           resources:

--- a/velero/schedule/common-service-db/cs-db-backup-deployment.yaml
+++ b/velero/schedule/common-service-db/cs-db-backup-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           - sh
           - -c
           - sleep infinity
-          image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2, etc based on CS version.
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.5.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2, etc based on CS version.
           imagePullPolicy: IfNotPresent
           name: cs-db-br
           resources:

--- a/velero/schedule/keycloak/keycloak-backup-deployment.yaml
+++ b/velero/schedule/keycloak/keycloak-backup-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           - sh
           - -c
           - sleep infinity
-          image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2 etc based on CS version.
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.5.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2 etc based on CS version.
           imagePullPolicy: IfNotPresent
           name: keycloak-br
           resources:


### PR DESCRIPTION
the cpfs utils repo is still using 4.5 for the new image so need to revert the image values in the scripts repo