### PR TITLE
add keycloak label to schedule

### DIFF
--- a/velero/schedule/schedule-common-services.yaml
+++ b/velero/schedule/schedule-common-services.yaml
@@ -41,4 +41,5 @@ spec:
         - lsr-data
         - cs-db-data
         - keycloak-data
+        - keycloak
         - singleton-subscription


### PR DESCRIPTION
We use a different label for the pgdump (keycloak-data) and cluster annotation (keycloak) BR approaches. We need to make sure both are covered in the schedule yaml file.