### PR TITLE
add rerun oidc job command

### DIFF
--- a/velero/schedule/common-service-db/cs-db-br-script-cm.yaml
+++ b/velero/schedule/common-service-db/cs-db-br-script-cm.yaml
@@ -1,4 +1,3 @@
-#TODO replace any instance of keycloak with relevant common service db change
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,7 +10,7 @@ data:
     #!/usr/bin/env bash
 
     # Licensed Materials - Property of IBM
-    # Copyright IBM Corporation 2023. All Rights Reserved
+    # Copyright IBM Corporation 2024. All Rights Reserved
     # US Government Users Restricted Rights -
     # Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
     #
@@ -78,6 +77,10 @@ data:
         info "Beginning restore of zen database..."
         oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_restore -U postgres --dbname zen --format=c --clean --exit-on-error -v /run/cs-db_backup/cs-db_zen_backup.dump
         oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" -c "\dn" -c "\du"
+
+        info "Rerunning OIDC registration job..."
+        oc -n $CSDB_NAMESPACE get job oidc-client-registration -o json |yq 'del(.spec.selector)' |yq 'del(.spec.template.metadata.labels)'| oc -n $CSDB_NAMESPACE replace --force -f -
+        oc -n $CSDB_NAMESPACE get pods | grep oidc-client-registration
 
     }
 


### PR DESCRIPTION
Mostly same changes as https://github.com/IBM/ibm-common-service-operator/pull/1946. Need to rerun oidc registration job after restore is completed and it is much better to add this step to the script than to add to documentation.