### PR TITLE
[4.7] Remove cert-manger CR and AuditLogging CR

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1452,9 +1452,6 @@ spec:
       commonWebUI: {}
       switcheritem: {}
       navconfiguration: {}
-  - name: ibm-cert-manager-operator
-    spec:
-      certManager: {}
   - name: ibm-management-ingress-operator
     spec:
       managementIngress: {}
@@ -1465,7 +1462,6 @@ spec:
       nginxIngress: {}
   - name: ibm-auditlogging-operator
     spec:
-      auditLogging: {}
       operandBindInfo: {}
       operandRequest: {}
   - name: ibm-platform-api-operator


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62528
This is to revert the fix made in release 4.6: https://github.com/IBM/ibm-common-service-operator/pull/1857
Original issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61103

We are going to remove `CertManager` CR and `AuditLogging` CR from OperandConfig, and ODLM will no longer be responsible for deleting them.