### PR TITLE
EDB max connection configuration

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1052,8 +1052,6 @@ spec:
               resizeInUseVolumes: true
               size: 10Gi
             postgresql:
-              parameters:
-                max_connections: "600"  
               pg_hba:
                 - hostssl cloudpak cpadmin all cert
                 - hostssl im im_user all cert

--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -249,13 +249,14 @@ func mergeChangedMap(key string, defaultMap interface{}, changedMap interface{},
 				finalMap[key] = defaultMap
 			} else {
 				var comparableKeys = map[string]bool{
-					"replicas":     true,
-					"cpu":          true,
-					"memory":       true,
-					"profile":      true,
-					"fipsEnabled":  true,
-					"fips_enabled": true,
-					"instances":    true,
+					"replicas":        true,
+					"cpu":             true,
+					"memory":          true,
+					"profile":         true,
+					"fipsEnabled":     true,
+					"fips_enabled":    true,
+					"instances":       true,
+					"max_connections": true,
 				}
 				if _, ok := comparableKeys[key]; ok {
 					if directAssign {

--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -91,6 +91,9 @@ const ConfigurationRules = `
             ephemeral-storage: LARGEST_VALUE
             cpu: LARGEST_VALUE
             memory: LARGEST_VALUE    
+        postgresql:
+          parameters:
+            max_connections: LARGEST_VALUE     
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -85,6 +85,9 @@ const Large = `
             ephemeral-storage: 200Mi
             cpu: 225m
             memory: 600Mi
+        postgresql:
+          parameters:
+            max_connections: 1100
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -85,6 +85,9 @@ const Large = `
             ephemeral-storage: 500Mi
             cpu: 384m
             memory: 768Mi
+        postgresql:
+          parameters:
+            max_connections: 1100
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -85,6 +85,9 @@ const Large = `
             ephemeral-storage: 500Mi
             cpu: 384m
             memory: 768Mi
+        postgresql:
+          parameters:
+            max_connections: 1100
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -85,6 +85,9 @@ const Medium = `
             ephemeral-storage: 128Mi
             cpu: 150m
             memory: 384Mi
+        postgresql:
+          parameters:
+            max_connections: 750
 - name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -85,6 +85,9 @@ const Medium = `
             ephemeral-storage: 128Mi
             cpu: 150m
             memory: 384Mi
+        postgresql:
+          parameters:
+            max_connections: 750
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -850,6 +850,9 @@ const Medium = `
           requests:
             cpu: 500m
             memory: 1024Mi
+        postgresql:
+          parameters:
+            max_connections: 750
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -85,6 +85,9 @@ const Medium = `
             ephemeral-storage: 128Mi
             cpu: 150m
             memory: 384Mi
+        postgresql:
+          parameters:
+            max_connections: 750
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:
@@ -850,9 +853,6 @@ const Medium = `
           requests:
             cpu: 500m
             memory: 1024Mi
-        postgresql:
-          parameters:
-            max_connections: 750
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -850,6 +850,9 @@ const Small = `
           requests:
             cpu: 200m
             memory: 768Mi
+        postgresql:
+          parameters:
+            max_connections: 600
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -85,6 +85,9 @@ const Small = `
             ephemeral-storage: 128Mi
             cpu: 75m
             memory: 256Mi
+        postgresql:
+          parameters:
+            max_connections: 600
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:
@@ -850,9 +853,6 @@ const Small = `
           requests:
             cpu: 200m
             memory: 768Mi
-        postgresql:
-          parameters:
-            max_connections: 600
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -850,6 +850,9 @@ const Small = `
           requests:
             cpu: 200m
             memory: 768Mi
+        postgresql:
+          parameters:
+            max_connections: 600
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -85,6 +85,9 @@ const Small = `
             ephemeral-storage: 128Mi
             cpu: 75m
             memory: 256Mi
+        postgresql:
+          parameters:
+            max_connections: 600
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:
@@ -850,9 +853,6 @@ const Small = `
           requests:
             cpu: 200m
             memory: 768Mi
-        postgresql:
-          parameters:
-            max_connections: 600
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -850,6 +850,9 @@ const Small = `
           requests:
             cpu: 200m
             memory: 768Mi
+        postgresql:
+          parameters:
+            max_connections: 600
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -85,6 +85,9 @@ const Small = `
             ephemeral-storage: 128Mi
             cpu: 75m
             memory: 256Mi
+        postgresql:
+          parameters:
+            max_connections: 600
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:
@@ -850,9 +853,6 @@ const Small = `
           requests:
             cpu: 200m
             memory: 768Mi
-        postgresql:
-          parameters:
-            max_connections: 600
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -85,6 +85,9 @@ const StarterSet = `
             ephemeral-storage: 128Mi
             cpu: 75m
             memory: 256Mi
+        postgresql:
+          parameters:
+            max_connections: 400
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:
@@ -850,9 +853,6 @@ const StarterSet = `
           requests:
             cpu: 200m
             memory: 512Mi
-        postgresql:
-          parameters:
-            max_connections: 400
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -850,6 +850,9 @@ const StarterSet = `
           requests:
             cpu: 200m
             memory: 512Mi
+        postgresql:
+          parameters:
+            max_connections: 400
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -85,6 +85,9 @@ const StarterSet = `
             ephemeral-storage: 128Mi
             cpu: 75m
             memory: 256Mi
+        postgresql:
+          parameters:
+            max_connections: 400
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:
@@ -850,9 +853,6 @@ const StarterSet = `
           requests:
             cpu: 200m
             memory: 512Mi
-        postgresql:
-          parameters:
-            max_connections: 400
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -850,6 +850,9 @@ const StarterSet = `
           requests:
             cpu: 200m
             memory: 512Mi
+        postgresql:
+          parameters:
+            max_connections: 400
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -852,6 +852,9 @@ const StarterSet = `
           requests:
             cpu: 200m
             memory: 512Mi
+        postgresql:
+          parameters:
+            max_connections: 400
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -87,6 +87,9 @@ const StarterSet = `
             ephemeral-storage: 128Mi
             cpu: 75m
             memory: 256Mi
+        postgresql:
+          parameters:
+            max_connections: 400
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:
@@ -852,9 +855,6 @@ const StarterSet = `
           requests:
             cpu: 200m
             memory: 512Mi
-        postgresql:
-          parameters:
-            max_connections: 400
 - name: keycloak-operator
   resources:
   - apiVersion: k8s.keycloak.org/v2alpha1


### PR DESCRIPTION
Ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63175
Set default value for max connections of `common-service-db` cluster CR for different size profile