### PR TITLE
Fix zen extension cleanup logic

### DIFF
--- a/velero/schedule/zen5-backup-deployment.yaml
+++ b/velero/schedule/zen5-backup-deployment.yaml
@@ -16,9 +16,9 @@ spec:
         pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace; /zen5/backup_zen5.sh <zenservice namespace>"]'
         pre.hook.backup.velero.io/timeout: 300s
         post.hook.restore.velero.io/command: '["sh", "-c", "/zen5/restore_zen5.sh <zenservice namespace> <zenservice name>"]'
-        post.hook.restore.velero.io/wait-timeout: 300s
-        post.hook.restore.velero.io/exec-timeout: 300s
-        post.hook.restore.velero.io/timeout: 600s
+        post.hook.restore.velero.io/wait-timeout: 1000s
+        post.hook.restore.velero.io/exec-timeout: 1000s
+        post.hook.restore.velero.io/timeout: 1000s
       name: zen5-backup
       namespace: <zenservice namespace>
       labels:

--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -385,7 +385,7 @@ data:
                     warning "The list of extensions provided returned an empty ID list from the database. These extensions may not be present in this database."
                 else
                     info "List of extension IDs populated, continuing with deletion."
-                    id_list=${id_list//\//%F}
+                    id_list=${id_list//\//%2F}
                     info "id_list with / replaced: $id_list"
 
                     # Delete each extension using the ID

--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -385,6 +385,8 @@ data:
                     warning "The list of extensions provided returned an empty ID list from the database. These extensions may not be present in this database."
                 else
                     info "List of extension IDs populated, continuing with deletion."
+                    id_list=${id_list//\//%F}
+                    info "id_list with / replaced: $id_list"
 
                     # Delete each extension using the ID
                     # curl -H 'secret: <broker-secret>' -ks -X DELETE https://zen-core-api-svc:4444/v1/internal/extensions/{source_id}

--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -345,7 +345,7 @@ data:
             info "Broker Secret obtained in namespace $ZEN_NAMESPACE"
         fi
         if [[ $BACKUP == "true" ]]; then
-            extension_check=$(oc get zenextension -n $ZEN_NAMESPACE -o name || echo "empty")
+            extension_check=$(oc get zenextension -n $ZEN_NAMESPACE -o name | grep -v "common-web-ui-zen-extension\|zen-watchdog-frontdoor-extension" || echo "empty")
             if [[ $extension_check != "empty" ]]; then
                 extensions=""
                 for ext in $extension_check

--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -345,7 +345,7 @@ data:
             info "Broker Secret obtained in namespace $ZEN_NAMESPACE"
         fi
         if [[ $BACKUP == "true" ]]; then
-            extension_check=$(oc get zenextension -n $ZEN_NAMESPACE -o name | grep -v "common-web-ui-zen-extension\|zen-watchdog-frontdoor-extension" || echo "empty")
+            extension_check=$(oc get zenextension -n $ZEN_NAMESPACE -o name || echo "empty")
             if [[ $extension_check != "empty" ]]; then
                 extensions=""
                 for ext in $extension_check


### PR DESCRIPTION
For issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62738.

Increase the zen timeout to reduce the likelihood of timing out during a zen data restore.

Change the extension delete api request to be in line with what zen core api expects by replacing `/` with `%2F` after consulting with zen team.