### PR TITLE
update mongorestore command for multiple hosts

### DIFF
--- a/velero/restore/mongoDB/mongo-restore.sh
+++ b/velero/restore/mongoDB/mongo-restore.sh
@@ -35,7 +35,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: icr.io/cpopen/cpfs/ibm-mongodb@sha256:16a5587c212963d9b4c323762d89df7d9357decba59369102e10e4bd2ef4ccd2
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host rs0/icp-mongodb-0.icp-mongodb.$CS_NAMESPACE.svc.cluster.local,icp-mongodb-1.icp-mongodb.$CS_NAMESPACE.svc.cluster.local,icp-mongodb-2.icp-mongodb.$CS_NAMESPACE.svc.cluster.local --port $MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m

--- a/velero/restore/mongoDB/mongodbrestore.yaml
+++ b/velero/restore/mongoDB/mongodbrestore.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: icr.io/cpopen/cpfs/ibm-mongodb@sha256:16a5587c212963d9b4c323762d89df7d9357decba59369102e10e4bd2ef4ccd2
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host rs0/icp-mongodb-0.icp-mongodb.<mongo namespace>.svc.cluster.local,icp-mongodb-1.icp-mongodb.<mongo namespace>.svc.cluster.local,icp-mongodb-2.icp-mongodb.<mongo namespace>.svc.cluster.local --port $MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
         volumeMounts:
         - mountPath: "/dump"
           name: mongodump

--- a/velero/schedule/mongodb-backup-deployment.yaml
+++ b/velero/schedule/mongodb-backup-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       annotations:
         backup.velero.io/backup-volumes: mongodump
         pre.hook.backup.velero.io/command: '["bash", "-c", "rm -rf /dump/dump/*; cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongodump --oplog --out /dump/dump --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem"]'
-        post.hook.restore.velero.io/command: '["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]'
+        post.hook.restore.velero.io/command: '["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host rs0/icp-mongodb-0.icp-mongodb.<mongo namespace>.svc.cluster.local,icp-mongodb-1.icp-mongodb.<mongo namespace>.svc.cluster.local,icp-mongodb-2.icp-mongodb.<mongo namespace>.svc.cluster.local --port $MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]'
       name: mongodb-backup
       namespace: <mongo namespace>
       labels:


### PR DESCRIPTION
the previous host parameter would pick one of the three possible endpoints and would fail on restore if the endpoint selected was not the primary. Adding all possible hosts guarantees the primary is selected for write operations (mongorestore). This change is not required for backup (mongodump) because it is a read only operation.