### PR TITLE
add velero annotation and cpfs lbr labels by default to cs db cluster cr

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1004,10 +1004,19 @@ spec:
           productID: 068a62892a1e4db39641342e592daa25
           productMetric: FREE
           productName: IBM Cloud Platform Common Services
+          k8s.enterprisedb.io/addons: '["velero"]'
+          k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled
+        labels:
+          foundationservices.cloudpak.ibm.com: cs-db
         force: true
         data:
           spec:
-            bootstrap:
+            inheritedMetadata:
+              annotations:
+                backup.velero.io/backup-volumes: pgdata,pg-wal
+	      labels:
+                foundationservices.cloudpak.ibm.com: cs-db
+	    bootstrap:
               initdb:
                 database: cloudpak
                 owner: cpadmin


### PR DESCRIPTION
Pending results from this issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63296.

Linked issue is to verify that our defaults are overwritten by CPD's commonservice CR since we have conflicting backup annotations. So far, it looks like it does properly overwrite but waiting on final verification after running a CPD BR.