### PR TITLE
[4.6.2] Set max connection value as a string

### DIFF
--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -87,7 +87,7 @@ const Large = `
             memory: 600Mi
         postgresql:
           parameters:
-            max_connections: 1100
+            max_connections: "1100"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -87,7 +87,7 @@ const Large = `
             memory: 768Mi
         postgresql:
           parameters:
-            max_connections: 1100
+            max_connections: "1100"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -87,7 +87,7 @@ const Large = `
             memory: 768Mi
         postgresql:
           parameters:
-            max_connections: 1100
+            max_connections: "1100"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -87,7 +87,7 @@ const Medium = `
             memory: 384Mi
         postgresql:
           parameters:
-            max_connections: 750
+            max_connections: "750"
 - name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -87,7 +87,7 @@ const Medium = `
             memory: 384Mi
         postgresql:
           parameters:
-            max_connections: 750
+            max_connections: "750"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -87,7 +87,7 @@ const Medium = `
             memory: 384Mi
         postgresql:
           parameters:
-            max_connections: 750
+            max_connections: "750"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -87,7 +87,7 @@ const Small = `
             memory: 256Mi
         postgresql:
           parameters:
-            max_connections: 600
+            max_connections: "600"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -87,7 +87,7 @@ const Small = `
             memory: 256Mi
         postgresql:
           parameters:
-            max_connections: 600
+            max_connections: "600"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -87,7 +87,7 @@ const Small = `
             memory: 256Mi
         postgresql:
           parameters:
-            max_connections: 600
+            max_connections: "600"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -87,7 +87,7 @@ const StarterSet = `
             memory: 256Mi
         postgresql:
           parameters:
-            max_connections: 400
+            max_connections: "400"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -87,7 +87,7 @@ const StarterSet = `
             memory: 256Mi
         postgresql:
           parameters:
-            max_connections: 400
+            max_connections: "400"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -89,7 +89,7 @@ const StarterSet = `
             memory: 256Mi
         postgresql:
           parameters:
-            max_connections: 400
+            max_connections: "400"
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:


### PR DESCRIPTION
Fix issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63360
Cherry pick: https://github.com/IBM/ibm-common-service-operator/pull/1968
