### PR TITLE
Update ODLM CRs after ODLM has a minor version upgrade

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -28,6 +28,7 @@ import (
 
 	utilyaml "github.com/ghodss/yaml"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -231,6 +232,13 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 	klog.Info("Installing ODLM Operator")
 	if err := b.renderTemplate(constant.ODLMSubscription, b.CSData); err != nil {
 		return err
+	}
+
+	klog.Info("Waiting for ODLM Operator to be ready")
+	if isWaiting, err := b.waitOperatorCSV("ibm-odlm", b.CSData.CPFSNs); err != nil {
+		return err
+	} else if isWaiting {
+		forceUpdateODLMCRs = true
 	}
 
 	// wait ODLM OperandRegistry and OperandConfig CRD
@@ -1837,4 +1845,70 @@ func (b *Bootstrap) UpdateResourceWithLabel(resources *unstructured.Unstructured
 		}
 	}
 	return nil
+}
+
+func (b *Bootstrap) waitOperatorCSV(packageManifest, operatorNs string) (bool, error) {
+	var isWaiting bool
+	// Wait for the operator CSV to be installed
+	klog.Infof("Waiting for the operator CSV with packageManifest %s in namespace %s to be installed", packageManifest, operatorNs)
+	if err := utilwait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+		installed, err := b.checkOperatorCSV(packageManifest, operatorNs)
+		if err != nil {
+			return false, err
+		} else if !installed {
+			klog.Infof("The operator CSV with packageManifest %s in namespace %s is not installed yet", packageManifest, operatorNs)
+			isWaiting = true
+		}
+		return installed, nil
+	}); err != nil {
+		return isWaiting, fmt.Errorf("failed to wait for the operator CSV to be installed: %v", err)
+	}
+	return isWaiting, nil
+}
+
+func (b *Bootstrap) checkOperatorCSV(packageManifest, operatorNs string) (bool, error) {
+	// List the subscription by packageManifest and operatorNs
+	// The subscription contain label "operators.coreos.com/<packageManifest>.<operatorNs>: ''"
+	subList := &olmv1alpha1.SubscriptionList{}
+	if err := b.Client.List(context.TODO(), subList, &client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{
+			"operators.coreos.com/" + packageManifest + "." + operatorNs: "",
+		}),
+		Namespace: operatorNs,
+	}); err != nil {
+		klog.Errorf("Failed to list Subscription by packageManifest %s and operatorNs %s: %v", packageManifest, operatorNs, err)
+		return false, err
+	}
+
+	// Check if multiple subscriptions exist
+	if len(subList.Items) > 1 {
+		return false, fmt.Errorf("multiple subscriptions found by packageManifest %s and operatorNs %s", packageManifest, operatorNs)
+	} else if len(subList.Items) == 0 {
+		return false, fmt.Errorf("no subscription found by packageManifest %s and operatorNs %s", packageManifest, operatorNs)
+	}
+
+	// Get the channel in the subscription .spec.channel, and check if it is semver
+	channel := subList.Items[0].Spec.Channel
+	if !semver.IsValid(channel) {
+		klog.Warningf("channel %s is not a semver for operator with packageManifest %s and operatorNs %s", channel, packageManifest, operatorNs)
+		return false, nil
+	}
+
+	// Get the CSV from subscription .status.installedCSV
+	installedCSV := subList.Items[0].Status.InstalledCSV
+	var installedVersion string
+	if installedCSV != "" {
+		// installedVersion is the version after the first dot in installedCSV
+		// For example, version is v4.3.1 for operand-deployment-lifecycle-manager.v4.3.1
+		installedVersion = installedCSV[strings.IndexByte(installedCSV, '.')+1:]
+	}
+
+	// 0 if channel == installedVersion - v4.3 == v4.3.0
+	// -1 if channel < installedVersion - v4.3 < v4.3.1
+	// +1 if channel > installedVersion - v4.3 > v4.2.0
+	if semver.Compare(channel, installedVersion) > 0 {
+		return false, nil
+	}
+
+	return true, nil
 }

--- a/controllers/bootstrap/init_test.go
+++ b/controllers/bootstrap/init_test.go
@@ -1,0 +1,243 @@
+//
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func init() {
+	// Add the v1alpha1 version of the operators.coreos.com API to the scheme
+	_ = olmv1alpha1.AddToScheme(scheme.Scheme)
+}
+
+func TestCheckOperatorCSV(t *testing.T) {
+	// Create a fake client
+	fakeClient := fake.NewClientBuilder().Build()
+
+	// Create a Bootstrap instance
+	bootstrap := &Bootstrap{
+		Client: fakeClient,
+	}
+
+	// Define the packageManifest and operatorNs
+	packageManifest := "ibm-common-service-operator"
+	operatorNs := "cpfs-operator-ns"
+
+	// Create a SubscriptionList with a single item
+	subList := &olmv1alpha1.SubscriptionList{
+		Items: []olmv1alpha1.Subscription{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "subscription-1",
+					Namespace: operatorNs,
+					Labels: map[string]string{
+						"operators.coreos.com/" + packageManifest + "." + operatorNs: "",
+					},
+				},
+				Spec: &olmv1alpha1.SubscriptionSpec{
+					Channel: "v1.0",
+				},
+				Status: olmv1alpha1.SubscriptionStatus{
+					InstalledCSV: "ibm-common-service-operator.v1.0.0",
+				},
+			},
+		},
+	}
+
+	var err error
+	for _, item := range subList.Items {
+		err = fakeClient.Create(context.TODO(), &item)
+		assert.NoError(t, err)
+	}
+
+	// Test case 1: Single subscription found with valid semver
+	result, err := bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	assert.True(t, result)
+	assert.NoError(t, err)
+
+	// Test case 2: Multiple subscriptions found
+	err = fakeClient.Create(context.TODO(), &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "subscription-2",
+			Namespace: operatorNs,
+			Labels: map[string]string{
+				"operators.coreos.com/" + packageManifest + "." + operatorNs: "",
+			},
+		},
+		Spec: &olmv1alpha1.SubscriptionSpec{
+			Channel: "v2.0",
+		},
+		Status: olmv1alpha1.SubscriptionStatus{
+			InstalledCSV: "ibm-common-service-operator.v2.0.0",
+		},
+	})
+	assert.NoError(t, err)
+
+	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	assert.False(t, result)
+	assert.EqualError(t, err, fmt.Sprintf("multiple subscriptions found by packageManifest %s and operatorNs %s", packageManifest, operatorNs))
+
+	// Test case 3: No subscription found
+	err = fakeClient.DeleteAllOf(context.TODO(), &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "operators.coreos.com/v1alpha1",
+			"kind":       "Subscription",
+		},
+	}, &client.DeleteAllOfOptions{
+		ListOptions: client.ListOptions{
+			Namespace: operatorNs,
+		},
+	})
+	assert.NoError(t, err)
+
+	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	assert.False(t, result)
+	assert.EqualError(t, err, fmt.Sprintf("no subscription found by packageManifest %s and operatorNs %s", packageManifest, operatorNs))
+
+	// Test case 4: Invalid semver in channel
+	err = fakeClient.Create(context.TODO(), &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "subscription-3",
+			Namespace: operatorNs,
+			Labels: map[string]string{
+				"operators.coreos.com/" + packageManifest + "." + operatorNs: "",
+			},
+		},
+		Spec: &olmv1alpha1.SubscriptionSpec{
+			Channel: "invalid-semver",
+		},
+		Status: olmv1alpha1.SubscriptionStatus{
+			InstalledCSV: "ibm-common-service-operator.v1.0.0",
+		},
+	})
+	assert.NoError(t, err)
+
+	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	assert.False(t, result)
+	assert.NoError(t, err)
+
+	// Test case 5: Small semver in channel
+	// InstalledCSV: "ibm-common-service-operator.v1.0.0", Channel: "v0.1"
+	subscription := &olmv1alpha1.Subscription{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "subscription-3", Namespace: "cpfs-operator-ns"}, subscription)
+	assert.NoError(t, err)
+
+	subscription.Spec.Channel = "v0.1"
+	err = fakeClient.Update(context.TODO(), subscription)
+	assert.NoError(t, err)
+
+	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	assert.True(t, result)
+	assert.NoError(t, err)
+
+	// Test case 6: Large semver in channel
+	// InstalledCSV: "ibm-common-service-operator.v1.0.0", Channel: "v1.1"
+	subscription = &olmv1alpha1.Subscription{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "subscription-3", Namespace: "cpfs-operator-ns"}, subscription)
+	assert.NoError(t, err)
+
+	subscription.Spec.Channel = "v1.1"
+	err = fakeClient.Update(context.TODO(), subscription)
+	assert.NoError(t, err)
+
+	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	assert.False(t, result)
+	assert.NoError(t, err)
+
+	// Test case 7: same semver in channel and installedCSV
+	// InstalledCSV: "ibm-common-service-operator.v1.0.0", Channel: "v1.0"
+	subscription = &olmv1alpha1.Subscription{}
+	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "subscription-3", Namespace: "cpfs-operator-ns"}, subscription)
+	assert.NoError(t, err)
+
+	subscription.Spec.Channel = "v1.0"
+	err = fakeClient.Update(context.TODO(), subscription)
+	assert.NoError(t, err)
+
+	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	assert.True(t, result)
+	assert.NoError(t, err)
+
+}
+
+func TestWaitOperatorCSV(t *testing.T) {
+	// Create a fake client
+	fakeClient := fake.NewClientBuilder().Build()
+
+	// Create a Bootstrap instance
+	bootstrap := &Bootstrap{
+		Client: fakeClient,
+	}
+
+	// Define the packageManifest and operatorNs
+	packageManifest := "ibm-common-service-operator"
+	operatorNs := "cpfs-operator-ns"
+
+	// Test case 1: Operator CSV is not installed yet
+	err := fakeClient.Create(context.TODO(), &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "subscription-1",
+			Namespace: operatorNs,
+			Labels: map[string]string{
+				"operators.coreos.com/" + packageManifest + "." + operatorNs: "",
+			},
+		},
+		Spec: &olmv1alpha1.SubscriptionSpec{
+			Channel: "v1.2",
+		},
+		Status: olmv1alpha1.SubscriptionStatus{
+			InstalledCSV: "ibm-common-service-operator.v1.0.0",
+		},
+	})
+	assert.NoError(t, err)
+
+	// additional go routine to update the subscription status
+	go func() {
+		// sleep for 3 seconds to simulate the operator CSV installation
+		<-time.After(3 * time.Second)
+
+		subscription := &olmv1alpha1.Subscription{}
+		err := fakeClient.Get(context.TODO(), types.NamespacedName{Name: "subscription-1", Namespace: "cpfs-operator-ns"}, subscription)
+		assert.NoError(t, err)
+
+		subscription.Status.InstalledCSV = "ibm-common-service-operator.v1.2.0"
+		err = fakeClient.Update(context.TODO(), subscription)
+		assert.NoError(t, err)
+	}()
+
+	isWaiting, err := bootstrap.waitOperatorCSV(packageManifest, operatorNs)
+	assert.True(t, isWaiting)
+	assert.NoError(t, err)
+
+	// Test case 2: Operator CSV is already installed
+	isWaiting, err = bootstrap.waitOperatorCSV(packageManifest, operatorNs)
+	assert.False(t, isWaiting)
+	assert.NoError(t, err)
+}

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1142,9 +1142,9 @@ spec:
             inheritedMetadata:
               annotations:
                 backup.velero.io/backup-volumes: pgdata,pg-wal
-	      labels:
+              labels:
                 foundationservices.cloudpak.ibm.com: cs-db
-	    bootstrap:
+            bootstrap:
               initdb:
                 database: cloudpak
                 owner: cpadmin

--- a/controllers/recocile_pause.go
+++ b/controllers/recocile_pause.go
@@ -34,7 +34,6 @@ func (r *CommonServiceReconciler) reconcilePauseRequest(instance *apiv3.CommonSe
 
 	// if the given CommnService CR has not been existing
 	if instance == nil {
-		klog.Warningf("CommonService CR %s/%s is not existing", instance.Name, instance.Namespace)
 		return false
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
+	golang.org/x/mod v0.8.0
 	golang.org/x/net v0.23.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -968,6 +968,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61732

CS operator will wait for ODLM minor version upgrade before proceeding to next step. e.g., ODLM `v4.2.3` -> `v4.3.0` with a channel switch `v4.2` to `v4.3`.
Also when CS operator detects an ODLM minor version upgrade, meaning there are potential CRD changes, CS operator will force ODLM CRs(OperandConfig and OperandRegistry) update, to ensure that CRs are applied to the cluster with latest ODLM CRD changes.

The file `controllers/bootstrap/init_test.go` includes the unit test for two new added functions.
The end to end test was done as well on the cluster with image build.