### PR TITLE
replace xargs with tr and sed

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -465,9 +465,9 @@ EOF
             done
             existing_ns="${tmp_ns_list}"
         fi
-        new_ns_list=$(echo ${existing_ns} ${TETHERED_NS//,/ } ${SERVICES_NS} | xargs -n1 | sort -u | xargs)
+        new_ns_list=$(echo ${existing_ns} ${TETHERED_NS//,/ } ${SERVICES_NS} | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')
     else
-        new_ns_list=$(echo ${TETHERED_NS//,/ } ${SERVICES_NS} | xargs -n1 | sort -u | xargs)
+        new_ns_list=$(echo ${TETHERED_NS//,/ } ${SERVICES_NS} | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')
     fi
     debug1 "List of namespaces for common-service NSS ${new_ns_list}"
 


### PR DESCRIPTION
Replace `xargs` with `tr` and `sed` command due to License issue on including `xargs` binary in `cpfs-utils` image and shipped as IBM software.

The following command has the identical functionality
```bash
new_ns_list=$(echo ${existing_ns} ${TETHERED_NS//,/ } ${SERVICES_NS} | xargs -n1 | sort -u | xargs)
new_ns_list=$(echo ${existing_ns} ${TETHERED_NS//,/ } ${SERVICES_NS} | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')
```

### Test
#### Test with following configurations with `setup_tenant.sh`
```console
./cp3pt0-deployment/setup_tenant.sh \
--operator-namespace networkpolicy-control \
--services-namespace networkpolicy-data \
--tethered-namespaces networkpolicy-cpd-add,networkpolicy-cpd-add-2 \
--excluded-namespaces networkpolicy-cpd,networkpolicy-not-there  \
--license-accept \
-c v4.7
```

The final version of NSS CR is expected
```yaml
apiVersion: operator.ibm.com/v1
kind: NamespaceScope
metadata:
  name: common-service
  namespace: networkpolicy-control
spec:
  csvInjector:
    enable: true
  license:
    accept: true
  namespaceMembers:
    - networkpolicy-control
    - networkpolicy-cpd-add
    - networkpolicy-cpd-add-2
    - networkpolicy-data
  restartLabels:
    intent: projected
```

### Reference
#### The script to prove they are identical
```bash
#!/bin/bash

existing_ns="existing1 existing2"
TETHERED_NS="tethered1,tethered2"
SERVICES_NS="services1"

new_ns_list=$(echo ${existing_ns} ${TETHERED_NS//,/ } ${SERVICES_NS} | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/ $//')
echo "new_ns_list: ${new_ns_list}"

new_ns_list_with_xargs=$(echo ${existing_ns} ${TETHERED_NS//,/ } ${SERVICES_NS} | xargs -n1 | sort -u | xargs)
echo "new_ns_list_with_xargs: ${new_ns_list_with_xargs}"

if [ "${new_ns_list}" == "${new_ns_list_with_xargs}" ]; then
    echo "The two results are the same."
else
    echo "The two results are different."
    diff <(echo "${new_ns_list}") <(echo "${new_ns_list_with_xargs}")
fi
```

#### Return result
```
new_ns_list: existing1 existing2 services1 tethered1 tethered2
new_ns_list_with_xargs: existing1 existing2 services1 tethered1 tethered2
The two results are the same.
```