### PR TITLE
change mongo node grabbing to be more consistent

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -156,7 +156,7 @@ function prereq() {
         error "Namespace $TO_NAMESPACE does not exist (or oc command line is not logged in)"
         exit 1
     fi
-    mongo_node=$(${OC} get pods -n $FROM_NAMESPACE -o wide | grep icp-mongodb-0 | awk '{print $7}')
+    mongo_node=$(${OC} get pods icp-mongodb-0 -n $FROM_NAMESPACE -o=jsonpath='{.spec.nodeName}')
     architecture=$(${OC} describe node $mongo_node | grep "Architecture:" | awk '{print $2}')
     if [[ $architecture == "s390x" ]] || [[ $architecture == "ppc64le" ]]; then
       z_or_power_ENV="true"


### PR DESCRIPTION
Copy and paste from the issue:

problem comes from this line in the preload script https://github.com/IBM/ibm-common-service-operator/blob/scripts-adopter/preload_data.sh#L159. It looks like the script finding the mongo node is pointing to the wrong column and then passes that value into the next line which is why we see `Error from server (NotFound): nodes "4d4h" not found`. I don't have mongo deployed but I tried the command with common-service-db:

>  $ oc get pods -o wide | grep common-service-db-1 | awk '{print $7}'
    worker0.luztest2.cp.fyre.ibm.com

But when I run the same command on the cluster from the issue it gives a different value:

>  $ oc get pods -o wide | grep mongodb-0 | awk '{print $7}'
    7d2h

New command:
> $ oc get pods icp-mongodb-0 -o=jsonpath='{.spec.nodeName}'
   worker0.cp4ba-performance.cp.fyre.ibm.com