### PR TITLE
Wait for cs pod ready before configuring CS CR

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -714,23 +714,32 @@ EOF
     echo ""
 
     while [ $retries -gt 0 ]; do
+        # Wait for the operator pod to be ready by 60s
+        cs_pod=$(${OC} get pods -n ${OPERATOR_NS} -o name  | grep "ibm-common-service-operator" | head -n 1)
+        ${OC} -n ${OPERATOR_NS} wait --for=condition=Ready $cs_pod --timeout=60s 2> /dev/null
 
-        cat "${PREVIEW_DIR}/commonservice.yaml" | ${OC_CMD} apply -f -
-
-        # Check if the patch was successful
         if [[ $? -eq 0 ]]; then
-            operator_ns_in_cr=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | "${YQ}" '.spec.operatorNamespace')
-            services_ns_in_cr=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | "${YQ}" '.spec.servicesNamespace')
-            if [[ "$operator_ns_in_cr" == "$OPERATOR_NS" ]] && [[ "$services_ns_in_cr" == "$SERVICES_NS" ]]; then
-                success "Successfully patched CommonService CR in ${OPERATOR_NS}"
-                break
+            cat "${PREVIEW_DIR}/commonservice.yaml" | ${OC_CMD} apply -f -
+
+            # Check if the patch was successful
+            if [[ $? -eq 0 ]]; then
+                operator_ns_in_cr=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | "${YQ}" '.spec.operatorNamespace')
+                services_ns_in_cr=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o yaml | "${YQ}" '.spec.servicesNamespace')
+                if [[ "$operator_ns_in_cr" == "$OPERATOR_NS" ]] && [[ "$services_ns_in_cr" == "$SERVICES_NS" ]]; then
+                    success "Successfully patched CommonService CR in ${OPERATOR_NS}"
+                    break
+                else
+                    warning "Expected OperatorNamespace is ${OPERATOR_NS}, but existing value is ${operator_ns_in_cr} in CommonService CR, retry it in ${delay} seconds..."
+                    warning "Expected ServicesNamespace is ${SERVICES_NS}, but existing value is ${services_ns_in_cr} in CommonService CR, retry it in ${delay} seconds..."
+                    retries=$((retries-1))
+                fi
             else
-                warning "Expected OperatorNamespace is ${OPERATOR_NS}, but existing value is ${operator_ns_in_cr} in CommonService CR, retry it in ${delay} seconds..."
-                warning "Expected ServicesNamespace is ${SERVICES_NS}, but existing value is ${services_ns_in_cr} in CommonService CR, retry it in ${delay} seconds..."
+                warning "Failed to patch CommonService CR in ${OPERATOR_NS}, retry it in ${delay} seconds..."
+                sleep ${delay}
                 retries=$((retries-1))
             fi
         else
-            warning "Failed to patch CommonService CR in ${OPERATOR_NS}, retry it in ${delay} seconds..."
+            warning "ibm-common-service-operator pod is not ready, retry it in ${delay} seconds..."
             sleep ${delay}
             retries=$((retries-1))
         fi

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -715,8 +715,7 @@ EOF
 
     while [ $retries -gt 0 ]; do
         # Wait for the operator pod to be ready by 60s
-        cs_pod=$(${OC} get pods -n ${OPERATOR_NS} -o name  | grep "ibm-common-service-operator" | head -n 1)
-        ${OC} -n ${OPERATOR_NS} wait --for=condition=Ready $cs_pod --timeout=60s 2> /dev/null
+        ${OC} -n ${OPERATOR_NS} wait --for=condition=Ready pod -l name=ibm-common-service-operator --timeout=60s 2> /dev/null
 
         if [[ $? -eq 0 ]]; then
             cat "${PREVIEW_DIR}/commonservice.yaml" | ${OC_CMD} apply -f -


### PR DESCRIPTION
Enhance the issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63437

Adding waiting condition for the `ibm-common-service` pod to contain the status condition of type "Ready" before applying the configured CommonService CR.
