### PR TITLE
specify dump location with emptyDir volume

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -371,14 +371,6 @@ spec:
       containers:
       - name: cs-mongodb-backup
         image: $ibm_mongodb_image
-        securityContext:
-          capabilities:
-            drop:
-              - ALL
-          privileged: false
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
         resources:
           limits:
             cpu: 500m

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -353,7 +353,7 @@ function dumpmongo() {
   if [[ "$currentns" -ne "$FROM_NAMESPACE" ]]; then
     error "Cannot switch to $FROM_NAMESPACE"
   fi
-  
+
   ibm_mongodb_image=$(${OC} get pod icp-mongodb-0 -n $FROM_NAMESPACE -o=jsonpath='{range .spec.containers[0]}{.image}{end}')
 
   if [[ $z_or_power_ENV == "false" ]]; then

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -383,6 +383,8 @@ spec:
           name: tmp-mongodb
         - mountPath: "/dump"
           name: mongodump
+        - mountPath: "/dump/dump"
+          name: dump
         - mountPath: "/cred/mongo-certs"
           name: icp-mongodb-client-cert
         - mountPath: "/cred/cluster-ca"
@@ -403,6 +405,8 @@ spec:
         persistentVolumeClaim:
           claimName: cs-mongodump
       - name: tmp-mongodb
+        emptyDir: {}
+      - name: dump
         emptyDir: {}
       - name: icp-mongodb-client-cert
         secret:
@@ -485,6 +489,8 @@ spec:
           name: tmp-mongodb
         - mountPath: "/dump"
           name: mongodump
+        - mountPath: "/dump/dump"
+          name: dump
         - mountPath: "/cred/mongo-certs"
           name: icp-mongodb-client-cert
         - mountPath: "/cred/cluster-ca"
@@ -505,6 +511,8 @@ spec:
         persistentVolumeClaim:
           claimName: cs-mongodump
       - name: tmp-mongodb
+        emptyDir: {}
+      - name: dump
         emptyDir: {}
       - name: icp-mongodb-client-cert
         secret:
@@ -652,6 +660,8 @@ spec:
         volumeMounts:
         - mountPath: "/dump"
           name: mongodump
+        - mountPath: "/dump/dump"
+          name: dump
         - mountPath: "/work-dir"
           name: tmp-mongodb
         - mountPath: "/cred/mongo-certs"
@@ -674,6 +684,8 @@ spec:
         persistentVolumeClaim:
           claimName: cs-mongodump
       - name: tmp-mongodb
+        emptyDir: {}
+      - name: dump
         emptyDir: {}
       - name: icp-mongodb-client-cert
         secret:
@@ -711,6 +723,8 @@ spec:
         volumeMounts:
         - mountPath: "/dump"
           name: mongodump
+        - mountPath: "/dump/dump"
+          name: dump
         - mountPath: "/work-dir"
           name: tmp-mongodb
         - mountPath: "/cred/mongo-certs"
@@ -733,6 +747,8 @@ spec:
         persistentVolumeClaim:
           claimName: cs-mongodump
       - name: tmp-mongodb
+        emptyDir: {}
+      - name: dump
         emptyDir: {}
       - name: icp-mongodb-client-cert
         secret:


### PR DESCRIPTION
CP4BA ran into issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63644 where they were seeing a failure with the mongodb-backup job created by the preload_data.sh script:
```
# oc logs mongodb-backup-fw6vv -n ibm-common-services
2024-05-28T19:05:09.097+0000	Failed: error dumping metadata: error creating directory for metadata file /dump/dump/platform-db: mkdir /dump/dump: permission denied
```
This failure was preventing successful upgrade. I went onto the cluster and added an emptyDir volume to each instance of a mongo restore or backup job and mounted it to the location where we try to write the mongodump out to "/dump/dump". After making this change on the cluster where the problem was seen, I saw the job and the preload_data.sh script complete successfully.
