### PR TITLE
Add StatusMonitoredServices annotations to OperandRegistry

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -31,19 +31,21 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 type CSData struct {
-	Channel               string
-	Version               string
-	CPFSNs                string
-	ServicesNs            string
-	OperatorNs            string
-	CatalogSourceName     string
-	CatalogSourceNs       string
-	IsolatedModeEnable    string
-	ApprovalMode          string
-	OnPremMultiEnable     string
-	WatchNamespaces       string
-	CloudPakThemes        string
-	CloudPakThemesVersion string
+	Channel                 string
+	Version                 string
+	CPFSNs                  string
+	ServicesNs              string
+	OperatorNs              string
+	CatalogSourceName       string
+	CatalogSourceNs         string
+	IsolatedModeEnable      string
+	ApprovalMode            string
+	OnPremMultiEnable       string
+	WatchNamespaces         string
+	CloudPakThemes          string
+	CloudPakThemesVersion   string
+	ExcludedCatalog         string
+	StatusMonitoredServices string
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -112,14 +112,16 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		return
 	}
 	csData := apiv3.CSData{
-		CPFSNs:            cpfsNs,
-		ServicesNs:        servicesNs,
-		OperatorNs:        operatorNs,
-		CatalogSourceName: catalogSourceName,
-		CatalogSourceNs:   catalogSourceNs,
-		ApprovalMode:      approvalMode,
-		WatchNamespaces:   util.GetWatchNamespace(),
-		OnPremMultiEnable: strconv.FormatBool(util.CheckMultiInstances(mgr.GetAPIReader())),
+		CPFSNs:                  cpfsNs,
+		ServicesNs:              servicesNs,
+		OperatorNs:              operatorNs,
+		CatalogSourceName:       catalogSourceName,
+		CatalogSourceNs:         catalogSourceNs,
+		ApprovalMode:            approvalMode,
+		WatchNamespaces:         util.GetWatchNamespace(),
+		OnPremMultiEnable:       strconv.FormatBool(util.CheckMultiInstances(mgr.GetAPIReader())),
+		ExcludedCatalog:         constant.ExcludedCatalog,
+		StatusMonitoredServices: constant.StatusMonitoredServices,
 	}
 
 	bs = &Bootstrap{

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -34,6 +34,11 @@ var (
 )
 
 const (
+	ExcludedCatalog         = "certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog"
+	StatusMonitoredServices = "ibm-idp-config-ui-operator,ibm-mongodb-operator,ibm-im-operator"
+)
+
+const (
 	MongoDBOpReg = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
@@ -44,7 +49,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - name: ibm-im-mongodb-operator-v4.0
@@ -74,7 +80,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - name: ibm-im-operator-v4.0
@@ -125,7 +132,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - name: ibm-idp-config-ui-operator-v4.0
@@ -170,7 +178,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - name: ibm-platformui-operator-v4.0
@@ -217,7 +226,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - channel: stable-v22
@@ -247,7 +257,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - channel: stable
@@ -1281,7 +1292,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: "{{ .Version }}"
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - name: ibm-licensing-operator
@@ -1386,7 +1398,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - name: ibm-im-operator
@@ -1476,7 +1489,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: "true"
   annotations:
     version: {{ .Version }}
-    excluded-catalogsource: certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
   - name: ibm-licensing-operator


### PR DESCRIPTION
**What this PR does / why we need it**:

After refactoring the ODLM service status check, ODLM will get a list of services whose status is reported from OperandRegistry annotations.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63673

New OperandRegistry is created with following annotations
```yaml
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRegistry
metadata:
  annotations:
    excluded-catalogsource: 'certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog'
    status-monitored-services: 'ibm-idp-config-ui-operator,ibm-mongodb-operator,ibm-im-operator'
    version: 4.6.3
```