### PR TITLE
Label the CommonService CRD so it can be selected for backup

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -298,6 +298,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:metadata:labels="foundationservices.cloudpak.ibm.com=crd"
 // +operator-sdk:gen-csv:customresourcedefinitions.displayName="CommonService"
 
 // CommonService is the Schema for the commonservices API. This API is used to

--- a/bundle/manifests/operator.ibm.com_commonservices.yaml
+++ b/bundle/manifests/operator.ibm.com_commonservices.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/instance: ibm-common-service-operator
     app.kubernetes.io/managed-by: ibm-common-service-operator
     app.kubernetes.io/name: ibm-common-service-operator
+    foundationservices.cloudpak.ibm.com: crd
   name: commonservices.operator.ibm.com
 spec:
   group: operator.ibm.com

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -4,6 +4,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+    foundationservices.cloudpak.ibm.com: crd
   name: commonservices.operator.ibm.com
 spec:
   group: operator.ibm.com


### PR DESCRIPTION
**What this PR does / why we need it**:

To backup common services with velero we ask the user to add a label to the backup the CommonService CRD. This user added label will be reset after every operator upgrade, so lets add a label to the CRD ourselves that the user can select.

See doc here: https://www.ibm.com/docs/en/cloud-paks/foundational-services/4.4?topic=fsbr-cloud-pak-foundational-services-backup-restore-clusters-single-instance-foundational-services

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action