### PR TITLE
Label the CommonService CR so it can be selected for backup

### DIFF
--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -125,6 +125,8 @@ kind: CommonService
 metadata:
   annotations:
     version: "-1"
+  labels:
+    foundationservices.cloudpak.ibm.com: commonservice
   name: common-service
   namespace: "{{ .OperatorNs }}"
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

To backup common services with velero we ask the user to add a label to the backup the CommonService CR. This PR adds a default label to new CRs that the user can select more easily.

See doc here: https://www.ibm.com/docs/en/cloud-paks/foundational-services/4.4?topic=fsbr-cloud-pak-foundational-services-backup-restore-clusters-single-instance-foundational-services

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action