### PR TITLE
Allow cpfs pods to establish DNS connection

### DIFF
--- a/cp3-networkpolicy/egress/cert-manager/bedrock-egress-ibm-cert-manager-operator.yaml
+++ b/cp3-networkpolicy/egress/cert-manager/bedrock-egress-ibm-cert-manager-operator.yaml
@@ -17,6 +17,20 @@ spec:
             matchLabels:
               apiserver: 'true'
           namespaceSelector: {}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+      to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            dns.operator.openshift.io/daemonset-dns: default
   podSelector:
     matchLabels:
       name: "ibm-cert-manager-operator"

--- a/cp3-networkpolicy/egress/license-service-reporter/bedrock-egress-ibm-license-service-reporter-operator.yaml
+++ b/cp3-networkpolicy/egress/license-service-reporter/bedrock-egress-ibm-license-service-reporter-operator.yaml
@@ -17,6 +17,20 @@ spec:
             matchLabels:
               apiserver: 'true'
           namespaceSelector: {}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+      to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            dns.operator.openshift.io/daemonset-dns: default
   podSelector:
     matchLabels:
       name: "ibm-license-service-reporter-operator"

--- a/cp3-networkpolicy/egress/license-service/bedrock-egress-ibm-licensing-operator.yaml
+++ b/cp3-networkpolicy/egress/license-service/bedrock-egress-ibm-licensing-operator.yaml
@@ -22,3 +22,17 @@ spec:
             matchLabels:
               apiserver: 'true'
           namespaceSelector: {}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+      to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            dns.operator.openshift.io/daemonset-dns: default

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-cloud-native-postgresql.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-cloud-native-postgresql.yaml
@@ -26,5 +26,19 @@ spec:
             matchLabels:
               apiserver: 'true'
           namespaceSelector: {}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+      to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            dns.operator.openshift.io/daemonset-dns: default
   policyTypes:
     - Egress

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-egress-create-postgres-license-config.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-egress-create-postgres-license-config.yaml
@@ -20,5 +20,19 @@ spec:
             matchLabels:
               apiserver: 'true'
           namespaceSelector: {}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+      to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            dns.operator.openshift.io/daemonset-dns: default
   policyTypes:
     - Egress

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-bts-operator.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-bts-operator.yaml
@@ -17,6 +17,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
   podSelector:
     matchLabels:
       app.kubernetes.io/name: "ibm-bts-operator"

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-common-service-operator.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-common-service-operator.yaml
@@ -17,6 +17,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
   podSelector:
     matchLabels:
       name: "ibm-common-service-operator"

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-commonui-operator.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-commonui-operator.yaml
@@ -17,6 +17,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
   podSelector:
     matchLabels:
       name: "ibm-commonui-operator"

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-events-operator.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-events-operator.yaml
@@ -17,6 +17,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default  
   podSelector:
     matchLabels:
       name: "ibm-events-operator"

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-iam-operator.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-iam-operator.yaml
@@ -33,6 +33,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default  
   podSelector:
     matchLabels:
       name: "ibm-iam-operator"

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-mongodb-operator.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-mongodb-operator.yaml
@@ -17,6 +17,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default  
   podSelector:
     matchLabels:
       name: "ibm-mongodb-operator"

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-namespace-scope-operator.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-ibm-namespace-scope-operator.yaml
@@ -17,6 +17,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default  
   podSelector:
     matchLabels:
       name: "ibm-namespace-scope-operator"

--- a/cp3-networkpolicy/egress/operators/bedrock-egress-operand-deployment-lifecycle-manager.yaml
+++ b/cp3-networkpolicy/egress/operators/bedrock-egress-operand-deployment-lifecycle-manager.yaml
@@ -17,6 +17,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default  
   podSelector:
     matchLabels:
       name: "operand-deployment-lifecycle-manager"

--- a/cp3-networkpolicy/egress/operators/zen-egress-ibm-zen-operator.yaml
+++ b/cp3-networkpolicy/egress/operators/zen-egress-ibm-zen-operator.yaml
@@ -26,6 +26,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default  
   podSelector:
     matchLabels:
       name: "ibm-zen-operator"

--- a/cp3-networkpolicy/egress/operators/zen-egress-ibm-zen-setup-job.yaml
+++ b/cp3-networkpolicy/egress/operators/zen-egress-ibm-zen-setup-job.yaml
@@ -20,5 +20,19 @@ spec:
             matchLabels:
               apiserver: 'true'
           namespaceSelector: {}
+    - ports:
+      - port: 53
+        protocol: UDP
+      - port: 53
+        protocol: TCP
+      - port: 5353
+        protocol: UDP
+      - port: 5353
+        protocol: TCP
+      to:
+      - namespaceSelector: {}
+        podSelector:
+          matchLabels:
+            dns.operator.openshift.io/daemonset-dns: default  
   policyTypes:
     - Egress

--- a/cp3-networkpolicy/egress/services/bedrock-egress-rhbk-operator.yaml
+++ b/cp3-networkpolicy/egress/services/bedrock-egress-rhbk-operator.yaml
@@ -17,6 +17,20 @@ spec:
       podSelector:
         matchLabels:
           apiserver: "true"
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    - port: 5353
+      protocol: UDP
+    - port: 5353
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
   podSelector:
     matchLabels:
       name: "rhbk-operator"


### PR DESCRIPTION
**What this PR does / why we need it**:
This is used to establish DNS connection for CPFS pod only

**Which issue(s) this PR fixes**:
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63853