### PR TITLE
increase waiting time for operator upgrade and installation

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -275,7 +275,7 @@ function wait_for_csv() {
     local namespace=$1
     local package_name=$2
     local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${package_name}.${namespace}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}'"
-    local retries=60
+    local retries=180
     local sleep_time=10
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for operator ${package_name} CSV in namespace ${namespace} to be bound to Subscription"
@@ -483,8 +483,8 @@ function wait_for_operator_upgrade() {
     local install_mode=$4
     local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${package_name}.${namespace}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w $channel"
 
-    local retries=20
-    local sleep_time=30
+    local retries=120
+    local sleep_time=20
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for operator ${package_name} to be upgraded"
     local success_message="Operator ${package_name} is upgraded to latest version in channel ${channel}"


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64017

```
[INFO] RETRYING: Waiting for operator ibm-cert-manager-operator CSV in namespace ibm-cert-manager to be bound to Subscription (3 left)
[INFO] RETRYING: Waiting for operator ibm-cert-manager-operator CSV in namespace ibm-cert-manager to be bound to Subscription (2 left)
[INFO] RETRYING: Waiting for operator ibm-cert-manager-operator CSV in namespace ibm-cert-manager to be bound to Subscription (1 left)
[✘] Error in /home/cert-kubernetes/scripts/cpfs/installer_scripts/cp3pt0-deployment/common/utils.sh at line 126 in function wait_for_condition: Timeout after 10 minutes waiting for ibm-cert-manager-operator CSV in namespace ibm-cert-manager to be bound to Subscription
```

```
[INFO] RETRYING: Waiting for operator ibm-common-service-operator to be upgraded (2 left)
[INFO] RETRYING: Waiting for operator ibm-common-service-operator to be upgraded (1 left)
[✘] Error in /root/operator/cert-kubernetes/scripts/cpfs/installer_scripts/cp3pt0-deployment/common/utils.sh at line 126 in function wait_for_condition: Timeout after 10 minutes waiting for operator ibm-common-service-operator to be upgraded
```