### PR TITLE
Cm catalog

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -638,8 +638,7 @@ function validate_operator_catalogsource(){
     if [[ $return_value -eq 0 ]]; then
         success "CatalogSource $source from $source_ns CatalogSourceNamespace is available for $pm in $operator_ns namespace"
     elif [[ $return_value -eq 1 ]]; then
-        warning "CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace"
-        error "Multiple CatalogSource are available for $pm in $operator_ns namespace, please specify the correct CatalogSource name and namespace"
+        error "CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace, there are multiple CatalogSources for $pm available in the cluster, please specify the correct CatalogSource name and namespace and try again"
     elif [[ $return_value -eq 2 ]]; then
         warning "CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace"
         

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -570,6 +570,7 @@ function pre_req() {
 
     # Using private catalog
     if [[ $ENABLE_PRIVATE_CATALOG -eq 1 ]]; then
+        warning "Private catalog is enabled, make sure the namespaces of singleton operators are in the same namespace as the CatalogSource"
         CM_SOURCE_NS="${CERT_MANAGER_NAMESPACE}"
         LIS_SOURCE_NS="${LICENSING_NAMESPACE}"
         LSR_SOURCE_NS="${LSR_NAMESPACE}"

--- a/velero/spectrum-fusion/recipes/4.7-example-recipe-single-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.7-example-recipe-single-ns.yaml
@@ -34,9 +34,43 @@ spec:
         - customresourcedefinitions.apiextensions.k8s.io
       name: cert-manager-crd
       type: resource
+    - includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-crd
+      type: resource
     - labelSelector: foundationservices.cloudpak.ibm.com=licensing
       name: licensing-resources
       type: resource
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: license-service-reporter-resources
+      type: resource
+    - backupRef: license-service-reporter-resources
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: lsr-pre-deploy
+      type: resource
+    - backupRef: license-service-reporter-resources
+      includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+      name: lsr-deployment
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-volume
+      type: volume
     - includedResourceTypes:
         - catalogsources.operators.coreos.com
       labelSelector: foundationservices.cloudpak.ibm.com=catalog
@@ -88,6 +122,11 @@ spec:
         - subscriptions.operators.coreos.com
       labelSelector: foundationservices.cloudpak.ibm.com=singleton-subscription
       name: singleton-subscriptions
+      type: resource
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-subscriptions
       type: resource
     - includeClusterResources: true
       includedResourceTypes:
@@ -264,6 +303,47 @@ spec:
         - condition: '{$.status.phase} == {"Running"}'
           name: podReady
           onError: fail
+          timeout: 600
+      name: license-service-reporter-check
+      labelSelector: app.kubernetes.io/name=ibm-license-service-reporter
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-deployment
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-data
+      namespace: <lsr namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace> backup"]
+          container: lsr-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/lsr/br_lsr.sh <lsr namespace> restore"]
+          container: lsr-backup-job
+          name: restore
+          timeout: 2000
+      selectResource: pod
+      type: exec
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
           timeout: 1200
       labelSelector: 'k8s.enterprisedb.io/cluster=zen-metastore-edb,role=primary'
       name: zen-metastore-edb-check
@@ -343,6 +423,9 @@ spec:
         - group: cs-db-volume
         - group: cs-db-br-resources
         - hook: cs-db-data/cs-db-backup-post
+        - hook: lsr-data/backup
+        - group: lsr-volume
+        - group: license-service-reporter-resources
         - hook: zen5-data/backup
         - group: zen-volume
         - group: zen
@@ -352,6 +435,7 @@ spec:
         - group: common-services-catalogs
         - group: common-services-operatorgroups
         - group: common-services-configmaps
+        - group: license-service-reporter-crd
         - group: commonservice-crd
         - group: commonservice-cr
         - group: cs-operator-permissions
@@ -359,6 +443,7 @@ spec:
         - group: singleton-subscriptions
         - group: cert-manager-resources
         - group: licensing-resources
+        - group: license-service-reporter-subscriptions
         - group: common-services-subscriptions
         - group: cert-manager-workload-resources
         - group: odlm-resources
@@ -374,12 +459,20 @@ spec:
         - group: common-services-configmaps
         - group: commonservice-crd
         - group: cert-manager-crd
+        - group: license-service-reporter-crd
         - group: singleton-subscriptions
         - group: commonservice-cr
         - hook: cert-manager-operator-check/podReady
         - hook: cert-manager-webhook-check/podReady
         - group: cert-manager-workload-resources
         - group: licensing-resources
+        - group: license-service-reporter-subscriptions
+        - hook: license-service-reporter-check/podReady
+        - group: lsr-pre-deploy
+        - group: lsr-volume
+        - group: lsr-deployment
+        - hook: lsr-deployment/podReady
+        - hook: lsr-data/restore
         - group: common-services-subscriptions
         - hook: odlm-check/podReady
         - group: odlm-resources

--- a/velero/spectrum-fusion/recipes/4.7-example-recipe-single-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.7-example-recipe-single-ns.yaml
@@ -68,6 +68,13 @@ spec:
         - deployments
       name: lsr-deployment
       type: resource
+  - includeClusterResources: true
+      includedResourceTypes:
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-instances
+      type: resource
     - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
       name: lsr-volume
       type: volume
@@ -425,6 +432,7 @@ spec:
         - hook: cs-db-data/cs-db-backup-post
         - hook: lsr-data/backup
         - group: lsr-volume
+        - group: license-service-reporter-instances
         - group: license-service-reporter-resources
         - hook: zen5-data/backup
         - group: zen-volume
@@ -468,6 +476,7 @@ spec:
         - group: licensing-resources
         - group: license-service-reporter-subscriptions
         - hook: license-service-reporter-check/podReady
+        - group: license-service-reporter-instances
         - group: lsr-pre-deploy
         - group: lsr-volume
         - group: lsr-deployment


### PR DESCRIPTION
**What this PR does / why we need it**:
When running the `setup_singleton.sh` with `-- enable-private-catalog` flag set, the error message of CatalogSource validation has been updated 

Enhancement：

- When the `--enable-private-catalog` flag is set, there is a warning message that prompts the namespaces of singleton operators should be in the same namespace as the singleton CatalogSource.
- If the specific CatalogSource in its namespace is not found in the cluster, then the script will try to get an available global CatalogSource and will error out if there is more than one CatalogSource available in the entire cluster.

**Which issue(s) this PR fixes**:
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63998#issuecomment-83385625
