### PR TITLE
Improve the error msg for private catalogsource validating

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -638,8 +638,7 @@ function validate_operator_catalogsource(){
     if [[ $return_value -eq 0 ]]; then
         success "CatalogSource $source from $source_ns CatalogSourceNamespace is available for $pm in $operator_ns namespace"
     elif [[ $return_value -eq 1 ]]; then
-        warning "CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace"
-        error "Multiple CatalogSource are available for $pm in $operator_ns namespace, please specify the correct CatalogSource name and namespace"
+        error "The expected CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace. Also there are multiple CatalogSources for $pm available in the cluster, please create the expected CatalogSource, or specify the correct CatalogSource name and namespace and re-run the script again."
     elif [[ $return_value -eq 2 ]]; then
         warning "CatalogSource $source from $source_ns CatalogSourceNamespace is not available for $pm in $operator_ns namespace"
         

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -570,6 +570,7 @@ function pre_req() {
 
     # Using private catalog
     if [[ $ENABLE_PRIVATE_CATALOG -eq 1 ]]; then
+        warning "Flag --enable-private-catalog is enabled, please make sure the CatalogSource is deployed in the same namespace as operator"
         CM_SOURCE_NS="${CERT_MANAGER_NAMESPACE}"
         LIS_SOURCE_NS="${LICENSING_NAMESPACE}"
         LSR_SOURCE_NS="${LSR_NAMESPACE}"


### PR DESCRIPTION
**What this PR does / why we need it**:
When running the `setup_singleton.sh` with `-- enable-private-catalog` flag set, the error message of CatalogSource validation has been updated 

Improvement：

- When the `--enable-private-catalog` flag is set, there is a warning message that prompts the namespaces of singleton operators should be in the same namespace as the singleton CatalogSource.
- If the specific CatalogSource in its namespace is not found in the cluster, then the script will try to get an available global CatalogSource and will error out if there is more than one CatalogSource available in the entire cluster.

**Which issue(s) this PR fixes**:
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63998#issuecomment-83385625