### PR TITLE
[4.6.4] Add EDB License secret into Cluster CR description

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1157,6 +1157,15 @@ spec:
             inheritedMetadata:
               labels:
                 foundationservices.cloudpak.ibm.com: cs-db
+            description:
+              templatingValueFrom:
+                objectRef:
+                  apiVersion: v1
+                  kind: Secret
+                  name: postgresql-operator-controller-manager-config
+                  path: .metadata.annotations.ibm-license-key-applied
+                  namespace: {{ .OperatorNs }}
+                required: true
             bootstrap:
               initdb:
                 database: cloudpak


### PR DESCRIPTION
**What this PR does / why we need it**:
Only create EDB Cluster CR after License Secret is injected for operator, to avoid operator pod restart during the CR reconciliation, see more details in https://github.com/IBM/ibm-common-service-operator/pull/1728

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64053
