### PR TITLE
Update events permission in nss managed role

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -679,25 +679,8 @@ rules:
       - ibmevents.ibm.com
     resources:
       - kafkatopics
-  - verbs:
-      - get
-      - list
-      - watch
-      - create
-      - patch
-      - update
-    apiGroups:
-      - ibmevents.ibm.com
-    resources:
-      - kafkausers
-  - verbs:
-      - get
-      - patch
-      - update
-    apiGroups:
-      - ibmevents.ibm.com
-    resources:
       - kafkatopics/status
+      - kafkausers
       - kafkausers/status
   - verbs:
       - create
@@ -748,33 +731,27 @@ rules:
       - list
       - watch
       - create
+      - delete
       - patch
       - update
     apiGroups:
       - ibmevents.ibm.com
     resources:
       - kafkas
-      - kafkanodepools
-      - kafkaconnects
-      - kafkaconnectors
-      - kafkamirrormakers
-      - kafkabridges
-      - kafkamirrormaker2s
-      - kafkarebalances
-  - verbs:
-      - get
-      - patch
-      - update
-    apiGroups:
-      - ibmevents.ibm.com
-    resources:
       - kafkas/status
+      - kafkanodepools
       - kafkanodepools/status
+      - kafkaconnects
       - kafkaconnects/status
+      - kafkaconnectors
       - kafkaconnectors/status
+      - kafkamirrormakers
       - kafkamirrormakers/status
+      - kafkabridges
       - kafkabridges/status
+      - kafkamirrormaker2s
       - kafkamirrormaker2s/status
+      - kafkarebalances
       - kafkarebalances/status
   - verbs:
       - get


### PR DESCRIPTION
**What this PR does / why we need it**:
Copy the events-related permissions collected from the 4.4 release into the 4.6 NSS managed role YAML to fix the permission issue hit in the upgrade path.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64035#issuecomment-84268980

**Special notes for your reviewer**:
`nss-maanged-bedrock-core-role.yaml` is the template role that needs to be applied after each upgrade done by the script.
