### PR TITLE
specify data copied over in preload data script

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -644,7 +644,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:27017 --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m
@@ -704,7 +704,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --host rs0/icp-mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:27017 --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -644,7 +644,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m
@@ -704,7 +704,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -644,7 +644,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local,icp-mongodb-1.icp-mongodb.$TO_NAMESPACE.svc.cluster.local,icp-mongodb-2.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m
@@ -704,7 +704,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local,icp-mongodb-1.icp-mongodb.$TO_NAMESPACE.svc.cluster.local,icp-mongodb-2.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -644,7 +644,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:27017 --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m
@@ -704,7 +704,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:27017 --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -644,7 +644,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local,icp-mongodb-1.icp-mongodb.$TO_NAMESPACE.svc.cluster.local,icp-mongodb-2.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m
@@ -704,7 +704,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db rs0/icp-mongodb-0.icp-mongodb.$TO_NAMESPACE.svc.cluster.local,icp-mongodb-1.icp-mongodb.$TO_NAMESPACE.svc.cluster.local,icp-mongodb-2.icp-mongodb.$TO_NAMESPACE.svc.cluster.local --port \$MONGODB_SERVICE_PORT --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -644,7 +644,7 @@ spec:
       containers:
       - name: icp-mongodb-restore
         image: $ibm_mongodb_image
-        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --host rs0/icp-mongodb:27017 --username \$ADMIN_USER --password \$ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump"]
+        command: ["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
In older environments where metering data still exists, it is possible for the restore job to fail trying to restore metering data when it is not covered by the preload script. This failure happens because of how the preload data script works. This script creates a dummy mongo in the target namespace. By default, this mongo is stood up with the oauth db and the platform db. the ouath data is copied over via secrets and configmaps that are copied over from the original namespace to the target namespace so those values don't need to be restored. This leaves the plaftform db data. When mongo starts up, it automatically creates this db inside mongo. This does not happen by default for metering so there is no metering db.

What does this mean?
This means when we run the mongorestore command, oauth and platform db data can be written to the new mongo in the target namespace but metering cannot. Mongorestore does not create dbs that do not exist, it only writes to existing dbs. This results in a createIndexError during mongorestore causing the mongo-restore job (and then the preload data script as a whole) to fail. We only care about bringing over the platform db data (since this script is run specifically for 4.x upgrades and metering was deprecated before then).

How does this pr fix this problem?
This pr changes the mongorestore command to only restore the platform db and nothing else. It will only try to write data to the platform db which should not be problematic. The addition of the `--drop` flag will also prevent the duplicate key error messages. This is also the exact command we use for our [BR](https://github.com/IBM/ibm-common-service-operator/blob/scripts/velero/schedule/mongodb-backup-deployment.yaml#L17) and what we have advised CPD to use.