### PR TITLE
BTS version suffix

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1460,6 +1460,18 @@ spec:
     packageName: ibm-bts-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+  - channel: v3.34
+    name: ibm-bts-operator-v3.34
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-bts-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+  - channel: v3.35
+    name: ibm-bts-operator-v3.35
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-bts-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
   - channel: v1.3
     name: ibm-automation-flink
     namespace: "{{ .CPFSNs }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding version suffix for bts operator in operandregistry

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63816

