### PR TITLE
[CD] add version suffix entry for EDB 1.22

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1519,6 +1519,13 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
+  - channel: stable-v1.22
+    name: cloud-native-postgresql-v1.22
+    namespace: "{{ .CPFSNs }}"
+    packageName: cloud-native-postgresql
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    operatorConfig: cloud-native-postgresql-operator-config
   - channel: alpha
     name: ibm-user-data-services-operator
     namespace: "{{ .CPFSNs }}"


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63488

Enable the ability for ODLM to install EDB operator v1.22 from `stable-v1.22` channel