### PR TITLE
Add user management bindinfo

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -754,6 +754,7 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
 		constant.PlatformUIOpCon,
 		constant.KeyCloakOpCon,
 		constant.CommonServicePGOpCon,
+		constant.UserMgmtOpCon,
 	}
 
 	baseCon = constant.CSV4OpCon

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1065,6 +1065,43 @@ spec:
 )
 
 const (
+	UserMgmtOpCon = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+spec:
+  services:
+  - name: ibm-user-management-operator
+    resources:
+      - apiVersion: operator.ibm.com/v1alpha1
+        data:
+          spec:
+            bindings:
+              public-account-iam-config-dev:
+                configmap: account-iam-env-configmap-dev
+              public-bootstrap-creds:
+                secret: user-mgmt-bootstrap
+              public-ibmcloudca-secret:
+                secret: ibmcloud-cluster-ca-secret
+              public-mcsp-integration-details:
+                secret: mcsp-im-integration-details
+            description: Binding information that should be accessible to User Management adopters
+            operand: ibm-user-management-operator
+            registry: common-service
+            registryNamespace: {{ .ServicesNs }}
+        force: true
+        kind: OperandBindInfo
+        name: ibm-user-mgmt-bindinfo
+  `
+)
+
+const (
 	CommonServicePGOpCon = `
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandConfig


### PR DESCRIPTION
I have added the necessary bindinfo for user management operator in a way mirroring keycloak. I am still trying to get the operand config to populate the operandbindinfo into the operandconfig as well as automatically create the operandbindinfo when ibm-user-management-operator is requested.

Currently, the secret `mcsp-im-integration-details` is called `mcsp-im-integration-api-key` but it's my understanding that IM is changing the name of the secret to be more generic so this may need to be updated if they do not end up calling it `mcsp-im-integration-details`. 