### PR TITLE
Use jsonpath to check the status for mongodb pod

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -237,13 +237,13 @@ function pre_req_bpm() {
 
   info "Copying mongodb from namespace $FROM_NAMESPACE to namespace $TO_NAMESPACE"
  
-  runningmongo=$(${OC} get po icp-mongodb-0 --no-headers --ignore-not-found -n $FROM_NAMESPACE | awk '{print $3}')
+  runningmongo=$(${OC} get po icp-mongodb-0 --no-headers --ignore-not-found -n $FROM_NAMESPACE -o=jsonpath='{.status.phase}')
   if [[ -z "$runningmongo" ]] || [[ "$runningmongo" != "Running" ]]; then
     error "Mongodb is not running in Namespace $FROM_NAMESPACE"
     exit -1
   fi
 
-  runningmongo=$(${OC} get po icp-mongodb-0 --no-headers --ignore-not-found -n $TO_NAMESPACE | awk '{print $3}')
+  runningmongo=$(${OC} get po icp-mongodb-0 --no-headers --ignore-not-found -n $TO_NAMESPACE -o=jsonpath='{.status.phase}')
   if [[ ! -z "$runningmongo" ]]; then
     error "Mongodb is deployed in namespace $TO_NAMESPACE - this script depends on mongo being uninitialzed in the target namespace"
     exit -1
@@ -1855,7 +1855,7 @@ EOF
     info "Waiting for MongoDB copy to initialize"
     sleep 10
     ${OC} get po icp-mongodb-0 --no-headers
-    status=$(${OC} get po icp-mongodb-0 --no-headers | awk '{print $3}')
+    status=$(${OC} get po icp-mongodb-0 --no-headers -o=jsonpath='{.status.phase}')
   done
 
   success "Temporary Mongo copy deployed to namespace $TO_NAMESPACE"


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `jsonpath` to get the status of mongodb pod
**Which issue(s) this PR fixes**:
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64387

### Test
Execute script with a successful run
```console
./preload_data.sh --original-cs-ns ibm-common-services --services-ns services

All arguments passed into the script: --original-cs-ns ibm-common-services --services-ns services
[✔] oc command available
[✔] yq command available
[✔] oc command logged in as kube:admin
[INFO] Checking cert manager readiness.
issuer.cert-manager.io/test-issuer created
certificate.cert-manager.io/test-certificate created
certificate.cert-manager.io "test-certificate" deleted
issuer.cert-manager.io "test-issuer" deleted
[✔] Cert manager is ready, preload can proceed.
[INFO] Copying mongodb from namespace ibm-common-services to namespace services
# Cleaning up any previous copy operations...
-----------------------------------------------------------------------
[✔] Previous run cleaned up.
# Deploying a temporary mongodb in services
-----------------------------------------------------------------------
configmap/icp-mongodb-install created
configmap/icp-mongodb-init created
issuer.cert-manager.io/god-issuer created
configmap/ibm-cpp-config created
secret/icp-mongodb-admin created
certificate.cert-manager.io/icp-mongodb-client-cert created
configmap/icp-mongodb created
secret/icp-mongodb-keyfile created
secret/icp-mongodb-metrics created
serviceaccount/ibm-mongodb-operand created
service/mongodb created
service/icp-mongodb created
certificate.cert-manager.io/mongodb-root-ca-cert created
issuer.cert-manager.io/mongodb-root-ca-issuer created
configmap/namespace-scope created
Warning: would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "install" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers "install", "bootstrap", "icp-mongodb" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or containers "install", "bootstrap", "icp-mongodb" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers "install", "bootstrap", "icp-mongodb" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
statefulset.apps/icp-mongodb created
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     11s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     22s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     33s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     44s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     56s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     67s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     78s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     89s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Running   0     100s
[✔] Temporary Mongo copy deployed to namespace services
# Creating a PVC for the MongoDB dump
-----------------------------------------------------------------------
Now using project "ibm-common-services" on server "https://api.ocp4xforvl.cp.fyre.ibm.com:6443".
persistentvolumeclaim/cs-mongodump created
[✔] MongoDB PVC ready
# Backing up MongoDB in namespace ibm-common-services
-----------------------------------------------------------------------
[INFO] Running Backup
Warning: would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "cs-mongodb-backup" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "cs-mongodb-backup" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "cs-mongodb-backup" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "cs-mongodb-backup" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
job.batch/mongodb-backup created
mongodb-backup-69m4q                                    0/1     ContainerCreating   0             0s
[INFO] Waiting for job pod mongodb-backup to complete
[✔] Job mongodb-backup completed in namespace ibm-common-services

[INFO] Saving mongodb-backup logs in _mongodb-backup.log
[INFO] Deleting job mongodb-backup
job.batch "mongodb-backup" deleted
[✔] Backup Complete
# Moving restored mongodb volume to services
-----------------------------------------------------------------------
persistentvolume/pvc-f29db2e7-9ee3-4a13-874b-ddf0070722ef patched
persistentvolumeclaim "cs-mongodump" deleted
persistentvolume/pvc-f29db2e7-9ee3-4a13-874b-ddf0070722ef patched
persistentvolumeclaim/cs-mongodump created
[✔] Restored MongoDB volume moved to namespace services
# Restoring MongoDB to copy in namespace services
-----------------------------------------------------------------------
[INFO] Running Restore
Warning: would violate PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "icp-mongodb-restore" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "icp-mongodb-restore" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "icp-mongodb-restore" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "icp-mongodb-restore" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
job.batch/mongodb-restore created
[INFO] Waiting for job pod mongodb-restore to complete
[✔] Job mongodb-restore completed in namespace services

[INFO] Saving mongodb-restore logs in _mongodb-restore.log
[INFO] Deleting job mongodb-restore
job.batch "mongodb-restore" deleted
[✔] Restore Complete
# Deleting the stand up mongodb statefulset in services
-----------------------------------------------------------------------
statefulset.apps "icp-mongodb" deleted
service "icp-mongodb" deleted
issuer.cert-manager.io "god-issuer" deleted
configmap "ibm-cpp-config" deleted
certificate.cert-manager.io "icp-mongodb-client-cert" deleted
configmap "icp-mongodb" deleted
configmap "icp-mongodb-init" deleted
configmap "icp-mongodb-install" deleted
secret "icp-mongodb-keyfile" deleted
secret "icp-mongodb-metrics" deleted
serviceaccount "ibm-mongodb-operand" deleted
service "mongodb" deleted
certificate.cert-manager.io "mongodb-root-ca-cert" deleted
issuer.cert-manager.io "mongodb-root-ca-issuer" deleted
configmap "namespace-scope" deleted
persistentvolume/pvc-f29db2e7-9ee3-4a13-874b-ddf0070722ef patched
persistentvolumeclaim "cs-mongodump" deleted
persistentvolume "pvc-f29db2e7-9ee3-4a13-874b-ddf0070722ef" deleted
[✔] MongoDB restored to new namespace services
configmap/mongodb-preload-endpoint created
#  Copying secret platform-auth-idp-credentials from ibm-common-services to services 
secret/platform-auth-idp-credentials created
[✔] secret platform-auth-idp-credentials copied over to services.
#  Copying secret platform-auth-ldaps-ca-cert from ibm-common-services to services 
secret/platform-auth-ldaps-ca-cert created
[✔] secret platform-auth-ldaps-ca-cert copied over to services.
#  Copying secret platform-oidc-credentials from ibm-common-services to services 
secret/platform-oidc-credentials created
[✔] secret platform-oidc-credentials copied over to services.
#  Copying secret oauth-client-secret from ibm-common-services to services 
Warning: resource secrets/oauth-client-secret is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by oc apply. oc apply should only be used on resources created declaratively by either oc create --save-config or oc apply. The missing annotation will be patched automatically.
secret/oauth-client-secret configured
[✔] secret oauth-client-secret copied over to services.
#  Copying configmap ibm-cpp-config from ibm-common-services to services 
configmap/ibm-cpp-config created
[✔] configmap ibm-cpp-config copied over to services.
#  Copying configmap common-web-ui-config from ibm-common-services to services 
configmap/common-web-ui-config created
[✔] configmap common-web-ui-config copied over to services.
#  Copying configmap platform-auth-idp from ibm-common-services to services 
configmap/platform-auth-idp created
[✔] configmap platform-auth-idp copied over to services.
#  Copying commonservice common-service from ibm-common-services to services 
commonservice.operator.ibm.com/preload-common-service-from-ibm-common-services created
[✔] commonservice preload-common-service-from-ibm-common-services copied over to services.
#  Copying secret icp-mongodb-client-cert from ibm-common-services to services 
Warning: resource secrets/icp-mongodb-client-cert is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by oc apply. oc apply should only be used on resources created declaratively by either oc create --save-config or oc apply. The missing annotation will be patched automatically.
secret/icp-mongodb-client-cert configured
[✔] secret icp-mongodb-client-cert copied over to services.
#  Copying secret mongodb-root-ca-cert from ibm-common-services to services 
Warning: resource secrets/mongodb-root-ca-cert is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by oc apply. oc apply should only be used on resources created declaratively by either oc create --save-config or oc apply. The missing annotation will be patched automatically.
secret/mongodb-root-ca-cert configured
[✔] secret mongodb-root-ca-cert copied over to services.
#  Copying secret icp-mongodb-admin from ibm-common-services to services 
secret/icp-mongodb-admin configured
[✔] secret icp-mongodb-admin copied over to services.
```