### PR TITLE
Cleanup preload

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -2063,9 +2063,9 @@ function success() {
 
 function error() {
     msg "\33[31m[✘] ${1}\33[0m"
-    info "The script can be re-run using one of the following commands:"
-    echo "./preload_data.sh $ARGUMENTS --cleanup && ./preload_data.sh $ARGUMENTS"
-    echo "./preload_data.sh $ARGUMENTS --rerun"
+    echo "The script can be re-run using one of the following commands:"
+    echo "For simple cleanup to prepare another run: ./preload_data.sh --cleanup $ARGUMENTS"
+    echo "For an immediate re-run of preload_data: ./preload_data.sh --rerun $ARGUMENTS"
     echo "Run ./preload_data.sh --help to see usage."
     exit 1
 }

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -30,6 +30,8 @@ TEMPFILE="_TMP.yaml"
 DEBUG=0
 z_or_power_ENV="false"
 RERUN="false"
+CLEANUP="false"
+ARGUMENTS=""
 
 # ---------- Command variables ----------
 
@@ -46,29 +48,35 @@ LOG_FILE="preload_data_log_$(date +'%Y%m%d%H%M%S').log"
 trap 'error "Error occurred in function $FUNCNAME at line $LINENO"' ERR
 
 function main() {
+    ARGUMENTS="$@"
     parse_arguments "$@"
     save_log "cp3pt0-deployment/logs" "preload_data_log" "$DEBUG"
     trap cleanup_log EXIT
     prereq
-    if [[ $RERUN == "true" ]]; then
-      info "Rerun specified..."
+    if [[ $CLEANUP == "false" ]]; then
+      if [[ $RERUN == "true" ]]; then
+        info "Rerun specified..."
+        deletemongocopy
+      fi
+      # run backup preload
+      backup_preload_mongo
+      # copy im credentials
+      copy_resource "secret" "platform-auth-idp-credentials"
+      copy_resource "secret" "platform-auth-ldaps-ca-cert"
+      copy_resource "secret" "platform-oidc-credentials"
+      copy_resource "secret" "oauth-client-secret"
+      copy_resource "configmap" "ibm-cpp-config"
+      copy_resource "configmap" "common-web-ui-config"
+      copy_resource "configmap" "platform-auth-idp"
+      copy_resource "commonservice" "common-service" "preload-common-service-from-$FROM_NAMESPACE"
+      copy_resource "secret" "icp-mongodb-client-cert"
+      copy_resource "secret" "mongodb-root-ca-cert"
+      copy_resource "secret" "icp-mongodb-admin"
+      # any extra config
+    else
+      info "Cleanup selected. Cleaning MongoDB in services namespace $TO_NAMESPACE"
       deletemongocopy
     fi
-    # run backup preload
-    backup_preload_mongo
-    # copy im credentials
-    copy_resource "secret" "platform-auth-idp-credentials"
-    copy_resource "secret" "platform-auth-ldaps-ca-cert"
-    copy_resource "secret" "platform-oidc-credentials"
-    copy_resource "secret" "oauth-client-secret"
-    copy_resource "configmap" "ibm-cpp-config"
-    copy_resource "configmap" "common-web-ui-config"
-    copy_resource "configmap" "platform-auth-idp"
-    copy_resource "commonservice" "common-service" "preload-common-service-from-$FROM_NAMESPACE"
-    copy_resource "secret" "icp-mongodb-client-cert"
-    copy_resource "secret" "mongodb-root-ca-cert"
-    copy_resource "secret" "icp-mongodb-admin"
-    # any extra config
 }
 
 function parse_arguments() {
@@ -95,6 +103,9 @@ function parse_arguments() {
             ;;
         --rerun)
             RERUN="true"
+            ;;
+        --cleanup)
+            CLEANUP="true"
             ;;
         -v | --debug)
             shift
@@ -125,6 +136,7 @@ function print_usage() {
     echo "   --original-cs-ns string                        Required. Namespace to migrate Cloud Pak 2 Foundational services data from."
     echo "   --services-ns string                           Required. Namespace to migrate Cloud Pak 2 Foundational services data too"
     echo "   --rerun                                        Optional. If specified, will cleanup the previous attempt's mongo copy installed in specified services namespace before executing script."
+    echo "   --cleanup                                      Optional. Overrides --rerun. If specified, will cleanup the previous attempt's mongo copy installed in specified services namespace without executing the rest of the script."
     echo "   -v, --debug integer                            Optional. Verbosity of logs. Default is 0. Set to 1 for debug logs"
     echo "   -h, --help                                     Print usage information"
     echo ""
@@ -2051,6 +2063,10 @@ function success() {
 
 function error() {
     msg "\33[31m[✘] ${1}\33[0m"
+    info "The script can be re-run using one of the following commands:"
+    echo "./preload_data.sh $ARGUMENTS --cleanup && ./preload_data.sh $ARGUMENTS"
+    echo "./preload_data.sh $ARGUMENTS --rerun"
+    echo "Run ./preload_data.sh --help to see usage."
     exit 1
 }
 


### PR DESCRIPTION
Add cleanup option for more script flexibility as well as update error message to reflect --rerun and --cleanup options

Testing:
```
[root@api.o1-772676.cp.fyre.ibm.com ibm-common-service-operator]# ./preload_data.sh --original-cs-ns ibm-common-services --services-ns combank1
All arguments passed into the script: --original-cs-ns ibm-common-services --services-ns combank1
[✔] oc command available
[✔] yq command available
[✔] oc command logged in as kube:admin
[INFO] Checking cert manager readiness.
issuer.cert-manager.io/test-issuer created
certificate.cert-manager.io/test-certificate created
certificate.cert-manager.io "test-certificate" deleted
issuer.cert-manager.io "test-issuer" deleted
[✔] Cert manager is ready, preload can proceed.
[INFO] Copying mongodb from namespace ibm-common-services to namespace combank1
[✘] Mongodb is deployed in namespace combank1 - this script depends on mongo being uninitialzed in the target namespace
[INFO] The script can be re-run using one of the following commands:
./preload_data.sh --original-cs-ns ibm-common-services --services-ns combank1 --cleanup && ./preload_data.sh --original-cs-ns ibm-common-services --services-ns combank1
./preload_data.sh --original-cs-ns ibm-common-services --services-ns combank1 --rerun
Run ./preload_data.sh --help to see usage.

[root@api.o1-772676.cp.fyre.ibm.com ibm-common-service-operator]# ./preload_data.sh --original-cs-ns ibm-common-services --services-ns combank1 --cleanup
All arguments passed into the script: --original-cs-ns ibm-common-services --services-ns combank1 --cleanup
[✔] oc command available
[✔] yq command available
[✔] oc command logged in as kube:admin
[INFO] Checking cert manager readiness.
issuer.cert-manager.io/test-issuer created
certificate.cert-manager.io/test-certificate created
certificate.cert-manager.io "test-certificate" deleted
issuer.cert-manager.io "test-issuer" deleted
[✔] Cert manager is ready, preload can proceed.
[INFO] Cleanup selected. Cleaning MongoDB in services namespace combank1
# Deleting the stand up mongodb statefulset in combank1
-----------------------------------------------------------------------
statefulset.apps "icp-mongodb" deleted
service "icp-mongodb" deleted
issuer.cert-manager.io "god-issuer" deleted
configmap "ibm-cpp-config" deleted
certificate.cert-manager.io "icp-mongodb-client-cert" deleted
configmap "icp-mongodb" deleted
configmap "icp-mongodb-init" deleted
configmap "icp-mongodb-install" deleted
secret "icp-mongodb-keyfile" deleted
secret "icp-mongodb-metrics" deleted
serviceaccount "ibm-mongodb-operand" deleted
service "mongodb" deleted
certificate.cert-manager.io "mongodb-root-ca-cert" deleted
issuer.cert-manager.io "mongodb-root-ca-issuer" deleted
configmap "namespace-scope" deleted
[✗] Volume for pvc cs-mongodump not found in combank1. It may have already been deleted.
[✔] MongoDB removed from services namespace combank1
```
