### PR TITLE
update user-mgmt operator channel in opreg

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1516,7 +1516,7 @@ spec:
   operators:
   - name: ibm-user-management-operator
     namespace: "{{ .CPFSNs }}"
-    channel: v0.1
+    channel: v1.0
     packageName: ibm-user-management-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}


### PR DESCRIPTION
**What this PR does / why we need it**:
bump up user-mgmt operator channel to v1.0 in operandregistry