### PR TITLE
update cs module version to v4

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -46,10 +46,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
-	"github.com/IBM/ibm-common-service-operator/controllers/deploy"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/deploy"
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/v4/api/v1"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
 

--- a/controllers/cert-manager/certificaterefresh_controller.go
+++ b/controllers/cert-manager/certificaterefresh_controller.go
@@ -33,7 +33,7 @@ import (
 
 	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/apis/cert-manager/v1"
 
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
 var logd = log.Log.WithName("controller_certificaterefresh")

--- a/controllers/cert-manager/v1_add_label_controller.go
+++ b/controllers/cert-manager/v1_add_label_controller.go
@@ -33,7 +33,7 @@ import (
 
 	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/apis/cert-manager/v1"
 
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
 // V1AddLabelReconciler reconciles a Certificate object

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -47,8 +47,8 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/v4/api/v1"
 )
 

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -38,11 +38,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/configurationcollector"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/configurationcollector"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
 )
 

--- a/controllers/commonservice_controller_test.go
+++ b/controllers/commonservice_controller_test.go
@@ -29,9 +29,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
 // +kubebuilder:docs-gen:collapse=Imports

--- a/controllers/configurationcollector/collector.go
+++ b/controllers/configurationcollector/collector.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 
-	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
 func Buildconfig(config map[string]string, bs *bootstrap.Bootstrap) map[string]string {

--- a/controllers/deploy/manager.go
+++ b/controllers/deploy/manager.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
 )
 
 type Manager struct {

--- a/controllers/goroutines/cleanup_resources.go
+++ b/controllers/goroutines/cleanup_resources.go
@@ -21,9 +21,9 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
 // Cleanup_Keycloak_Cert will delete Keycloak Certificate when OperandConfig is updated to new version

--- a/controllers/goroutines/operator_status.go
+++ b/controllers/goroutines/operator_status.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
 var ctx = context.Background()

--- a/controllers/goroutines/waitToCreateCsCR.go
+++ b/controllers/goroutines/waitToCreateCsCR.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
 )
 
 // WaitToCreateCsCR waits for the creation of the CommonService CR in the operator namespace.

--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -30,10 +30,10 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
-	"github.com/IBM/ibm-common-service-operator/controllers/rules"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/rules"
 )
 
 var (

--- a/controllers/operatorconfig.go
+++ b/controllers/operatorconfig.go
@@ -26,8 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 
-	v3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	v3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
 )
 

--- a/controllers/recocile_pause.go
+++ b/controllers/recocile_pause.go
@@ -19,7 +19,7 @@ package controllers
 import (
 	"k8s.io/klog"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
 )
 
 const (

--- a/controllers/render_template.go
+++ b/controllers/render_template.go
@@ -27,10 +27,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
-	"github.com/IBM/ibm-common-service-operator/controllers/size"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/size"
 )
 
 func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured) ([]interface{}, map[string]string, error) {

--- a/controllers/render_template_test.go
+++ b/controllers/render_template_test.go
@@ -22,7 +22,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
 )
 
 var _ = Describe("Render Template", func() {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -34,10 +34,10 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	apiv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
-	"github.com/IBM/ibm-common-service-operator/controllers/deploy"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/deploy"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/controllers/webhooks/commonservice/validatingwebhook.go
+++ b/controllers/webhooks/commonservice/validatingwebhook.go
@@ -30,10 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	operatorv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	controller "github.com/IBM/ibm-common-service-operator/controllers"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
+	operatorv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	controller "github.com/IBM/ibm-common-service-operator/v4/controllers"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
 // +kubebuilder:webhook:path=/validate-operator-ibm-com-v3-commonservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=operator.ibm.com,resources=commonservices,verbs=create;update,versions=v3,name=vcommonservice.kb.io,admissionReviewVersions=v1

--- a/controllers/webhooks/operandrequest/mutatingwebhook.go
+++ b/controllers/webhooks/operandrequest/mutatingwebhook.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
-module github.com/IBM/ibm-common-service-operator
+module github.com/IBM/ibm-common-service-operator/v4
 
-go 1.21
-
-toolchain go1.21.3
+go 1.22.6
 
 require (
 	github.com/IBM/controller-filtered-cache v0.3.5

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/IBM/ibm-common-service-operator/v4
 
-go 1.22.6
+go 1.21
+
+toolchain go1.21.3
 
 require (
 	github.com/IBM/controller-filtered-cache v0.3.5

--- a/main.go
+++ b/main.go
@@ -43,15 +43,15 @@ import (
 
 	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/apis/cert-manager/v1"
 
-	operatorv3 "github.com/IBM/ibm-common-service-operator/api/v3"
-	"github.com/IBM/ibm-common-service-operator/controllers"
-	"github.com/IBM/ibm-common-service-operator/controllers/bootstrap"
-	certmanagerv1controllers "github.com/IBM/ibm-common-service-operator/controllers/cert-manager"
-	util "github.com/IBM/ibm-common-service-operator/controllers/common"
-	"github.com/IBM/ibm-common-service-operator/controllers/constant"
-	"github.com/IBM/ibm-common-service-operator/controllers/goroutines"
-	commonservicewebhook "github.com/IBM/ibm-common-service-operator/controllers/webhooks/commonservice"
-	operandrequestwebhook "github.com/IBM/ibm-common-service-operator/controllers/webhooks/operandrequest"
+	operatorv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
+	certmanagerv1controllers "github.com/IBM/ibm-common-service-operator/v4/controllers/cert-manager"
+	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/goroutines"
+	commonservicewebhook "github.com/IBM/ibm-common-service-operator/v4/controllers/webhooks/commonservice"
+	operandrequestwebhook "github.com/IBM/ibm-common-service-operator/v4/controllers/webhooks/operandrequest"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
To facilitate changes required for https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64551, we need to update the module version for the cs operator to v4 so we can specify v4 tags and releases when importing in go.mod. Should be similar to this ODLM pr that did the same https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1039/files