### PR TITLE
update cs-operator description

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ The `ibm-common-service-operator` is a bridge to connect IBM Cloud Paks and Oper
 
 When you install this operator, the operator completes the following tasks:
 
-- Installs ODLM in all namespaces mode
-- Creates the `ibm-common-services` namespace
-- Creates the Common Services `OperandRegistry` and `OperandConfig` in the `ibm-common-services` namespace
+- Installs ODLM operator namespace
+- Creates the Common Services `OperandRegistry` and `OperandConfig` in the service namespace
 
 For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).
 

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -182,9 +182,8 @@ spec:
 
     When you install this operator, the operator completes the following tasks:
 
-      - Installs ODLM in all namespaces mode
-      - Creates the `ibm-common-services` namespace
-      - Creates the Common Services `OperandRegistry` and `OperandConfig` in the `ibm-common-services` namespace
+      - Installs ODLM operator namespace
+      - Creates the Common Services `OperandRegistry` and `OperandConfig` in the service namespace
 
     # Details
     For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -170,9 +170,8 @@ spec:
 
     When you install this operator, the operator completes the following tasks:
 
-      - Installs ODLM in all namespaces mode
-      - Creates the `ibm-common-services` namespace
-      - Creates the Common Services `OperandRegistry` and `OperandConfig` in the `ibm-common-services` namespace
+      - Installs ODLM operator namespace
+      - Creates the Common Services `OperandRegistry` and `OperandConfig` in the service namespace
 
     # Details
     For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). If you are using this operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).


### PR DESCRIPTION
**What this PR does / why we need it**:
update ibm common service operator description, remove `ibm-common-services` namespace in description
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64615
