### PR TITLE
remove whole storageClassName field in pvc on ROKs env

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -591,6 +591,7 @@ function swapmongopvc() {
     if [[ -z $stgclass ]]; then
       error "Cannnot get storage class name from PVC mongodbdir-icp-mongodb-0 in $FROM_NAMESPACE"
     fi
+    
     cat <<EOF >$TEMPFILE
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -610,21 +611,6 @@ EOF
 
   else
     debug1 "Preload run on ROKS, not setting storageclass name"
-    cat <<EOF >$TEMPFILE
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: cs-mongodump
-  namespace: $TO_NAMESPACE
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
-  volumeMode: Filesystem
-  volumeName: $VOL
-EOF
     deprecated_region='{.metadata.labels.failure-domain\.beta\.kubernetes\.io\/region}'
     deprecated_zone='{.metadata.labels.failure-domain\.beta\.kubernetes\.io\/zone}'
 
@@ -640,6 +626,22 @@ EOF
         debug1 "Replacing depracated PV labels"
         "${OC}" label pv $VOL $not_deprecated_region_label=$region $deprecated_region_label- $not_deprecated_zone_label=$zone $deprecated_zone_label- --overwrite 
     fi
+
+    cat <<EOF >$TEMPFILE
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cs-mongodump
+  namespace: $TO_NAMESPACE
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  volumeMode: Filesystem
+  volumeName: $VOL
+EOF
   fi
 
 

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -591,9 +591,40 @@ function swapmongopvc() {
     if [[ -z $stgclass ]]; then
       error "Cannnot get storage class name from PVC mongodbdir-icp-mongodb-0 in $FROM_NAMESPACE"
     fi
+    cat <<EOF >$TEMPFILE
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cs-mongodump
+  namespace: $TO_NAMESPACE
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: "$stgclass"
+  volumeMode: Filesystem
+  volumeName: $VOL
+EOF
+
   else
     debug1 "Preload run on ROKS, not setting storageclass name"
-    stgclass=""
+    cat <<EOF >$TEMPFILE
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cs-mongodump
+  namespace: $TO_NAMESPACE
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  volumeMode: Filesystem
+  volumeName: $VOL
+EOF
     deprecated_region='{.metadata.labels.failure-domain\.beta\.kubernetes\.io\/region}'
     deprecated_zone='{.metadata.labels.failure-domain\.beta\.kubernetes\.io\/zone}'
 
@@ -611,22 +642,6 @@ function swapmongopvc() {
     fi
   fi
 
-  cat <<EOF >$TEMPFILE
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: cs-mongodump
-  namespace: $TO_NAMESPACE
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 20Gi
-  storageClassName: "$stgclass"
-  volumeMode: Filesystem
-  volumeName: $VOL
-EOF
 
   ${OC} create -f $TEMPFILE
 


### PR DESCRIPTION
**What this PR does / why we need it**:
remove whole storageClassName field in cs-mongodump pvc if it is running on ROKs cluster
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64674

<details>
<summary> test logs </summary>


```
ibm-common-service-operator % ./preload_data.sh --original-cs-ns ibm-common-services --services-ns sysqa --rerun
All arguments passed into the script: --original-cs-ns ibm-common-services --services-ns sysqa --rerun
[✔] oc command available
[✔] yq command available
[✔] oc command logged in as IAM#pgondhalekar@in.ibm.com
[INFO] Checking cert manager readiness.
issuer.cert-manager.io/test-issuer created
certificate.cert-manager.io/test-certificate created
certificate.cert-manager.io "test-certificate" deleted
issuer.cert-manager.io "test-issuer" deleted
[✔] Cert manager is ready, preload can proceed.
[INFO] Rerun specified...
# Deleting the stand up mongodb statefulset in sysqa
-----------------------------------------------------------------------
configmap "ibm-cpp-config" deleted
[✗] Volume for pvc cs-mongodump not found in sysqa. It may have already been deleted.
[✔] MongoDB removed from services namespace sysqa
[INFO] Copying mongodb from namespace ibm-common-services to namespace sysqa
# Cleaning up any previous copy operations...
-----------------------------------------------------------------------
[✔] Previous run cleaned up.
# Deploying a temporary mongodb in sysqa
-----------------------------------------------------------------------
configmap/icp-mongodb-install created
configmap/icp-mongodb-init created
issuer.cert-manager.io/god-issuer created
configmap/ibm-cpp-config created
secret/icp-mongodb-admin configured
certificate.cert-manager.io/icp-mongodb-client-cert created
configmap/icp-mongodb created
secret/icp-mongodb-keyfile created
secret/icp-mongodb-metrics created
serviceaccount/ibm-mongodb-operand created
service/mongodb created
service/icp-mongodb created
certificate.cert-manager.io/mongodb-root-ca-cert created
issuer.cert-manager.io/mongodb-root-ca-issuer created
configmap/namespace-scope created
statefulset.apps/icp-mongodb created
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:0/2   0     11s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     21s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     32s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     43s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     53s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     64s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Init:1/2   0     75s
[INFO] Waiting for MongoDB copy to initialize
icp-mongodb-0   0/1   Running   0     85s
[✔] Temporary Mongo copy deployed to namespace sysqa
# Creating a PVC for the MongoDB dump
-----------------------------------------------------------------------
Now using project "ibm-common-services" on server "https://c101-e.us-east.containers.cloud.ibm.com:30125".
persistentvolumeclaim/cs-mongodump created
[INFO] Waiting for pvc cs-mongodump to bind
[INFO] Waiting for pvc cs-mongodump to bind
[INFO] Waiting for pvc cs-mongodump to bind
[INFO] Waiting for pvc cs-mongodump to bind
[✔] MongoDB PVC ready
# Backing up MongoDB in namespace ibm-common-services
-----------------------------------------------------------------------
[INFO] Running Backup
job.batch/mongodb-backup created
mongodb-backup-47vcj                                   0/1     Pending     0          0s
[INFO] Waiting for job pod mongodb-backup to complete
[INFO] RETRYING: Waiting for job pod mongodb-backup to complete (15 left)
[✔] Job mongodb-backup completed in namespace ibm-common-services

[INFO] Saving mongodb-backup logs in _mongodb-backup.log
[INFO] Deleting job mongodb-backup
job.batch "mongodb-backup" deleted
[✔] Backup Complete
# Moving restored mongodb volume to sysqa
-----------------------------------------------------------------------
Warning: spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].key: failure-domain.beta.kubernetes.io/region is deprecated since v1.17; use "topology.kubernetes.io/region" instead
Warning: spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[1].key: failure-domain.beta.kubernetes.io/zone is deprecated since v1.17; use "topology.kubernetes.io/zone" instead
persistentvolume/pvc-b1d2c3b9-30fb-40ae-a695-87af97a64fcd patched
persistentvolumeclaim "cs-mongodump" deleted
Warning: spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].key: failure-domain.beta.kubernetes.io/region is deprecated since v1.17; use "topology.kubernetes.io/region" instead
Warning: spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[1].key: failure-domain.beta.kubernetes.io/zone is deprecated since v1.17; use "topology.kubernetes.io/zone" instead
persistentvolume/pvc-b1d2c3b9-30fb-40ae-a695-87af97a64fcd patched
Warning: spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].key: failure-domain.beta.kubernetes.io/region is deprecated since v1.17; use "topology.kubernetes.io/region" instead
Warning: spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[1].key: failure-domain.beta.kubernetes.io/zone is deprecated since v1.17; use "topology.kubernetes.io/zone" instead
persistentvolume/pvc-b1d2c3b9-30fb-40ae-a695-87af97a64fcd labeled
persistentvolumeclaim/cs-mongodump created
[✔] Restored MongoDB volume moved to namespace sysqa
# Restoring MongoDB to copy in namespace sysqa
-----------------------------------------------------------------------
[INFO] Running Restore
job.batch/mongodb-restore created
[INFO] Waiting for job pod mongodb-restore to complete
[INFO] RETRYING: Waiting for job pod mongodb-restore to complete (15 left)
[✔] Job mongodb-restore completed in namespace sysqa

[INFO] Saving mongodb-restore logs in _mongodb-restore.log
[INFO] Deleting job mongodb-restore
job.batch "mongodb-restore" deleted
[✔] Restore Complete
# Deleting the stand up mongodb statefulset in sysqa
-----------------------------------------------------------------------
statefulset.apps "icp-mongodb" deleted
service "icp-mongodb" deleted
issuer.cert-manager.io "god-issuer" deleted
configmap "ibm-cpp-config" deleted
certificate.cert-manager.io "icp-mongodb-client-cert" deleted
configmap "icp-mongodb" deleted
configmap "icp-mongodb-init" deleted
configmap "icp-mongodb-install" deleted
secret "icp-mongodb-keyfile" deleted
secret "icp-mongodb-metrics" deleted
serviceaccount "ibm-mongodb-operand" deleted
service "mongodb" deleted
certificate.cert-manager.io "mongodb-root-ca-cert" deleted
issuer.cert-manager.io "mongodb-root-ca-issuer" deleted
configmap "namespace-scope" deleted
Warning: spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[0].key: failure-domain.beta.kubernetes.io/region is deprecated since v1.17; use "topology.kubernetes.io/region" instead
Warning: spec.nodeAffinity.required.nodeSelectorTerms[0].matchExpressions[1].key: failure-domain.beta.kubernetes.io/zone is deprecated since v1.17; use "topology.kubernetes.io/zone" instead
persistentvolume/pvc-b1d2c3b9-30fb-40ae-a695-87af97a64fcd patched
persistentvolumeclaim "cs-mongodump" deleted
persistentvolume "pvc-b1d2c3b9-30fb-40ae-a695-87af97a64fcd" deleted
[✔] MongoDB removed from services namespace sysqa
configmap/mongodb-preload-endpoint unchanged
#  Copying secret platform-auth-idp-credentials from ibm-common-services to sysqa 
secret/platform-auth-idp-credentials unchanged
[✔] secret platform-auth-idp-credentials copied over to sysqa.
#  Copying secret platform-auth-ldaps-ca-cert from ibm-common-services to sysqa 
secret/platform-auth-ldaps-ca-cert unchanged
[✔] secret platform-auth-ldaps-ca-cert copied over to sysqa.
#  Copying secret platform-oidc-credentials from ibm-common-services to sysqa 
secret/platform-oidc-credentials unchanged
[✔] secret platform-oidc-credentials copied over to sysqa.
#  Copying secret oauth-client-secret from ibm-common-services to sysqa 
secret/oauth-client-secret unchanged
[✔] secret oauth-client-secret copied over to sysqa.
#  Copying configmap ibm-cpp-config from ibm-common-services to sysqa 
configmap/ibm-cpp-config created
[✔] configmap ibm-cpp-config copied over to sysqa.
#  Copying configmap common-web-ui-config from ibm-common-services to sysqa 
configmap/common-web-ui-config unchanged
[✔] configmap common-web-ui-config copied over to sysqa.
#  Copying configmap platform-auth-idp from ibm-common-services to sysqa 
configmap/platform-auth-idp unchanged
[✔] configmap platform-auth-idp copied over to sysqa.
#  Copying commonservice common-service from ibm-common-services to sysqa 
commonservice.operator.ibm.com/preload-common-service-from-ibm-common-services configured
[✔] commonservice preload-common-service-from-ibm-common-services copied over to sysqa.
#  Copying secret icp-mongodb-client-cert from ibm-common-services to sysqa 
secret/icp-mongodb-client-cert unchanged
[✔] secret icp-mongodb-client-cert copied over to sysqa.
#  Copying secret mongodb-root-ca-cert from ibm-common-services to sysqa 
secret/mongodb-root-ca-cert unchanged
[✔] secret mongodb-root-ca-cert copied over to sysqa.
#  Copying secret icp-mongodb-admin from ibm-common-services to sysqa 
secret/icp-mongodb-admin configured
[✔] secret icp-mongodb-admin copied over to sysqa.
```


</details>