### PR TITLE
[WIP] Recipe shrink

### DIFF
--- a/velero/backup/common-service/env.properties
+++ b/velero/backup/common-service/env.properties
@@ -6,6 +6,9 @@ OPERATOR_NS="" # Pass the namespace where the cs operator is installed
 SERVICES_NS="" 
 CONTROL_NS="" # Pass the control namespace if it is needed to be backed up
 
+#Pass any additional namespaces in the tenant that are not the operator or services namespace. Comma delimited
+TETHERED_NS=""
+
 # Change to the namespace where cert-manager, licensing and LSR are installed
 CERT_MANAGER_NAMESPACE="ibm-cert-manager" 
 LICENSING_NAMESPACE="ibm-licensing"

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -237,16 +237,16 @@ function label_nss(){
     ${OC} label namespacescopes.operator.ibm.com common-service foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
     ${OC} label customresourcedefinition namespacescopes.operator.ibm.com foundationservices.cloudpak.ibm.com=nss --overwrite=true --ignore-not-found 2>/dev/null
     ${OC} label serviceaccount ibm-namespace-scope-operator foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label role nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label role nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_S foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
     ${OC} label configmap namespace-scope foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
     if [[ $TETHERED_NS != "" ]]; then
         for namespace in ${TETHERED_NS//,/ }
         do
-            ${OC} label role nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true --ignore-not-found 2>/dev/null
-            ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true --ignore-not-found 2>/dev/null
+            ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true --ignore-not-found 2>/dev/null
+            ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true --ignore-not-found 2>/dev/null
         done
     fi
     echo ""

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -52,6 +52,9 @@ function main() {
     label_subscription
     label_lsr
     label_cs
+    if [[ $SERVICES_NS != "" ]]; then
+        label_nss
+    fi
     success "Successfully labeled all the resources"
 }
 
@@ -170,7 +173,6 @@ function label_configmap() {
     title "Start to label the ConfigMaps... "
     ${OC} label configmap common-service-maps foundationservices.cloudpak.ibm.com=configmap -n kube-public --overwrite=true 2>/dev/null
     ${OC} label configmap cs-onprem-tenant-config foundationservices.cloudpak.ibm.com=configmap -n $SERVICES_NS --overwrite=true 2>/dev/null
-    ${OC} label configmap platform-auth-idp foundationservices.cloudpak.ibm.com=configmap -n $SERVICES_NS --overwrite=true 2>/dev/null
     echo ""
 }
 
@@ -225,7 +227,28 @@ function label_cs(){
     title "Start to label the CommonService CR... "
     ${OC} label customresourcedefinition commonservices.operator.ibm.com foundationservices.cloudpak.ibm.com=crd --overwrite=true 2>/dev/null
     ${OC} label commonservices common-service foundationservices.cloudpak.ibm.com=commonservice -n $OPERATOR_NS --overwrite=true 2>/dev/null
-    ${OC} label operandconfig common-service foundationservices.cloudpak.ibm.com=operand -n $SERVICES_NS --overwrite=true 2>/dev/null
+    echo ""
+}
+
+function label_nss(){
+    title "Label Namespacescope resources"
+    local nss_pm="ibm-namespace-scope-operator"
+    ${OC} label subscriptions.operators.coreos.com $nss_pm foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label namespacescopes.operator.ibm.com common-service foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label customresourcedefinition namespacescopes.operator.ibm.com foundationservices.cloudpak.ibm.com=nss --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label serviceaccount ibm-namespace-scope-operator foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label role nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label role nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label configmap namespace-scope foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
+    if [[ $TETHERED_NS != "" ]]; then
+        for namespace in ${TETHERED_NS//,/ }
+        do
+            ${OC} label role nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true --ignore-not-found 2>/dev/null
+            ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NAMESPACE foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true --ignore-not-found 2>/dev/null
+        done
+    fi
     echo ""
 }
 

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -240,7 +240,7 @@ function label_nss(){
     ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
     ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
     ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_S foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
     ${OC} label configmap namespace-scope foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
     if [[ $TETHERED_NS != "" ]]; then
         for namespace in ${TETHERED_NS//,/ }

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -233,20 +233,20 @@ function label_cs(){
 function label_nss(){
     title "Label Namespacescope resources"
     local nss_pm="ibm-namespace-scope-operator"
-    ${OC} label subscriptions.operators.coreos.com $nss_pm foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label namespacescopes.operator.ibm.com common-service foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label customresourcedefinition namespacescopes.operator.ibm.com foundationservices.cloudpak.ibm.com=nss --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label serviceaccount ibm-namespace-scope-operator foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
-    ${OC} label configmap namespace-scope foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true --ignore-not-found 2>/dev/null
+    ${OC} label subscriptions.operators.coreos.com $nss_pm foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label namespacescopes.operator.ibm.com common-service foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label customresourcedefinition namespacescopes.operator.ibm.com foundationservices.cloudpak.ibm.com=nss --overwrite=true 2>/dev/null
+    ${OC} label serviceaccount ibm-namespace-scope-operator foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ${OC} label configmap namespace-scope foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
     if [[ $TETHERED_NS != "" ]]; then
         for namespace in ${TETHERED_NS//,/ }
         do
-            ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true --ignore-not-found 2>/dev/null
-            ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true --ignore-not-found 2>/dev/null
+            ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true 2>/dev/null
+            ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true 2>/dev/null
         done
     fi
     echo ""

--- a/velero/spectrum-fusion/recipes/4.9-example-multi-ns-recipev2.yaml
+++ b/velero/spectrum-fusion/recipes/4.9-example-multi-ns-recipev2.yaml
@@ -1,0 +1,607 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  name: cs-recipe
+  namespace: ibm-spectrum-fusion-ns
+spec:
+  appType: common-service
+  groups:
+    - includeClusterResources: true
+      name: backup-parent-group
+      type: resource
+      includedResourceTypes:
+        - secrets
+        - certificates.cert-manager.io
+        - issuers.cert-manager.io
+        - customresourcedefinitions.apiextensions.k8s.io
+        - ibmlicenseservicereporters.operator.ibm.com
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+        - catalogsources.operators.coreos.com
+        - operatorgroups.operators.coreos.com
+        - subscriptions.operators.coreos.com
+        - jobs
+        - commonservices.operator.ibm.com
+        - namespacescopes.operator.ibm.com
+        - operandrequests.operator.ibm.com
+        - zenservices.zen.cpd.ibm.com
+        - namespaces
+      labelSelector: foundationservices.cloudpak.ibm.com=cert-manager,foundationservices.cloudpak.ibm.com=lsr,foundationservices.cloudpak.ibm.com=lsr-data,foundationservices.cloudpak.ibm.com=licensing,foundationservices.cloudpak.ibm.com=catalog,foundationservices.cloudpak.ibm.com=pull-secret,foundationservices.cloudpak.ibm.com=configmap,foundationservices.cloudpak.ibm.com=namespace,foundationservices.cloudpak.ibm.com=operatorgroup,foundationservices.cloudpak.ibm.com=subscription,foundationservices.cloudpak.ibm.com=singleton-subscription,foundationservices.cloudpak.ibm.com=crd,foundationservices.cloudpak.ibm.com=cpfs-util-backup,foundationservices.cloudpak.ibm.com=setup-tenant-job,foundationservices.cloudpak.ibm.com=commonservice,foundationservices.cloudpak.ibm.com=nss,foundationservices.cloudpak.ibm.com=operand,foundationservices.cloudpak.ibm.com=zen5-data,foundationservices.cloudpak.ibm.com=zen,foundationservices.cloudpak.ibm.com=cs-db-data
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data,foundationservices.cloudpak.ibm.com=cs-db-data,foundationservices.cloudpak.ibm.com=zen5-data
+      name: backup-parent-volume
+      type: volume
+    - includeClusterResources: true
+      includedResourceTypes:
+        - secrets
+        - certificates.cert-manager.io
+        - issuers.cert-manager.io
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=cert-manager
+      name: cert-manager-resources
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      name: cert-manager-crd
+      type: resource
+    - includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-parent
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      name: license-service-reporter-crd
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      name: license-service-reporter-instances
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=licensing
+      name: licensing-resources
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: license-service-reporter-resources
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: lsr-pre-deploy
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+      name: lsr-deployment
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-volume
+      type: volume
+      backupRef: backup-parent-volume
+    - includedResourceTypes:
+        - catalogsources.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=catalog
+      name: common-services-catalogs
+      type: resource
+      backupRef: backup-parent-group
+    - includedNamespaces:
+        - openshift-config
+      includedResourceTypes:
+        - secrets
+      labelSelector: foundationservices.cloudpak.ibm.com=pull-secret
+      name: pull-secret
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includedNamespaces:
+        - openshift-config
+      includedResourceTypes:
+        - secrets
+      labelSelector: foundationservices.cloudpak.ibm.com=pull-secret
+      name: ow-pull-secret
+      restoreOverwriteResources: true
+      type: resource
+    - includedResourceTypes:
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=configmap
+      name: common-services-configmaps
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=namespace
+      name: common-services-namespace
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - operatorgroups.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=operatorgroup
+      name: common-services-operatorgroups
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=subscription
+      name: common-services-subscriptions
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=singleton-subscription
+      name: singleton-subscriptions
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-subscriptions
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=crd
+      name: commonservice-crd
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - roles
+        - serviceaccounts
+        - rolebindings
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=cpfs-util-backup
+      name: setup-tenant-resources
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - jobs
+      labelSelector: foundationservices.cloudpak.ibm.com=setup-tenant-job
+      name: setup-tenant-job-yaml
+      restoreStatus:
+        excludedResources:
+          - jobs
+      type: resource
+      backupRef: backup-parent-group
+    - labelSelector: foundationservices.cloudpak.ibm.com=cpfs-util-backup
+      name: cpfs-util-volume
+      type: volume
+      backupRef: backup-parent-volume
+    - includedResourceTypes:
+        - commonservices.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=commonservice
+      name: commonservice-cr
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - namespacescopes.operator.ibm.com
+        - customresourcedefinitions.apiextensions.k8s.io
+        - roles
+        - rolebindings
+        - serviceaccounts
+        - subscriptions.operators.coreos.com
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=nss
+      name: namespacescope
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - operandrequests.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=operand
+      name: odlm-resources
+      type: resource
+      backupRef: backup-parent-group
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen-volume
+      type: volume
+      backupRef: backup-parent-volume
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen-br-resources
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - zenservices.zen.cpd.ibm.com
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=zen
+      name: zenservice
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: zen-pre-deploy
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      includedResourceTypes:
+        - deployments
+      name: zen-deployment
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      name: cs-db-volume
+      type: volume
+      backupRef: backup-parent-volume
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      name: cs-db-br-resources
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: cs-db-pre-deploy
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      includedResourceTypes:
+        - deployments
+      name: cs-db-deployment
+      type: resource
+  hooks:
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      name: common-service-db-check
+      namespace: <service namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 1200
+      labelSelector: app.kubernetes.io/name=operand-deployment-lifecycle-manager
+      name: odlm-check
+      namespace: <operator namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 1200
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=cpfs-util-backup
+      name: setup-tenant-check
+      namespace: <operator namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: app.kubernetes.io/name=cert-manager
+      name: cert-manager-operator-check
+      namespace: ibm-cert-manager
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: cert-manager-webhook-check
+      nameSelector: cert-manager-webhook
+      namespace: ibm-cert-manager
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: license-service-reporter-check
+      labelSelector: app.kubernetes.io/name=ibm-license-service-reporter
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-deployment
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-data
+      namespace: <lsr namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace> backup"]
+          container: lsr-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/lsr/br_lsr.sh <lsr namespace> restore"]
+          container: lsr-backup-job
+          name: restore
+          timeout: 2000
+      selectResource: pod
+      type: exec
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 1200
+      labelSelector: 'k8s.enterprisedb.io/cluster=zen-metastore-edb,role=primary'
+      name: zen-metastore-edb-check
+      namespace: <service namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 1200
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=cpfs-util-backup
+      name: setup-tenant
+      namespace: <operator namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "/cs-br/setup_tenant.sh --operator-namespace <operator namespace> --services-namespace <service namespace> --tethered-namespaces <comma delimited (no spaces) list of Cloud Pak workload namespaces that use this foundational services instance> --license-accept -c v<foundational services version number in use i.e. 4.0, 4.1, 4.2, etc> -p <.spec.size value from commonservice cr> -i <install mode, either Manual or Automatic> -s <catalog source name> -n <catalog source namespace> -v"]
+          container: cpfs-util
+          name: setup-tenant-command
+          timeout: 600
+      selectResource: pod
+      type: exec
+    - labelSelector: foundationservices.cloudpak.ibm.com=cpfs-util-backup
+      name: setup-tenant-job
+      namespace: <operator namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "oc patch job setup-tenant-job -n <operator namespace> --type=\"json\" -p '[{\"op\": \"remove\", \"path\":\"/spec/suspend\"}]'"]
+          container: cpfs-util
+          name: trigger-setup-tenant-job
+          timeout: 600
+      selectResource: pod
+      type: exec
+    - chks:
+        - condition: '{$.status.phase} == {"Succeeded"}'
+          name: jobComplete
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=setup-tenant-job
+      name: setup-tenant-job-check
+      namespace: cs-op
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      name: cs-db-deployment
+      namespace: <service namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: platform-identity-provider
+      nameSelector: platform-identity-provider
+      namespace: <service namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: platform-auth-service
+      nameSelector: platform-auth-service
+      namespace: <service namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: platform-identity-management
+      nameSelector: platform-identity-management
+      namespace: <service namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      name: cs-db-data
+      namespace: <service namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "/cs-db/br_cs-db.sh backup <service namespace>"]
+          container: cs-db-br
+          name: cs-db-backup-pre
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /cs-db/cs-db-backup/database"]
+          container: cs-db-br
+          name: cs-db-backup-post
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "sleep 120 && /cs-db/br_cs-db.sh restore <service namespace>"]
+          container: cs-db-br
+          name: restore
+          timeout: 2000
+      selectResource: pod
+      type: exec
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen5-deployment
+      namespace: <service namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen5-data
+      namespace: <service namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace; /zen5/backup_zen5.sh <service namespace>"]
+          container: zen5-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/zen5/restore_zen5.sh <service namespace> <zenservice name>"]
+          container: zen5-backup-job
+          name: restore
+          timeout: 3600
+      selectResource: pod
+      type: exec
+  workflows:
+    - failOn: any-error
+      name: backup
+      sequence:
+        - hook: cs-db-data/cs-db-backup-pre
+        - hook: lsr-data/backup
+        - hook: zen5-data/backup
+        - group: setup-tenant-resources
+        - group: setup-tenant-job-yaml
+        - group: backup-parent-group
+        - group: backup-parent-volume
+        - hook: cs-db-data/cs-db-backup-post
+    - failOn: any-error
+      name: restore
+      sequence:
+        - group: common-services-namespace
+        - group: pull-secret
+        - group: ow-pull-secret
+        - group: common-services-catalogs
+        - group: common-services-operatorgroups
+        - group: common-services-configmaps
+        - group: commonservice-crd
+        - group: cert-manager-crd
+        - group: license-service-reporter-crd
+        - group: singleton-subscriptions
+        - group: commonservice-cr
+        - hook: cert-manager-operator-check/podReady
+        - hook: cert-manager-webhook-check/podReady
+        - group: cert-manager-resources
+        - group: licensing-resources
+        - group: license-service-reporter-subscriptions
+        - hook: license-service-reporter-check/podReady
+        - group: license-service-reporter-instances
+        - group: lsr-pre-deploy
+        - group: lsr-volume
+        - group: lsr-deployment
+        - hook: lsr-deployment/podReady
+        - hook: lsr-data/restore
+        - group: common-services-subscriptions
+        # - group: cpfs-util-volume
+        # - group: setup-tenant-resources
+        # - group: setup-tenant-job-yaml
+        # - hook: setup-tenant-check/podReady
+        # - hook: setup-tenant-job/trigger-setup-tenant-job
+        # - hook: setup-tenant-job-check/jobComplete
+        - group: namespacescope
+        - hook: odlm-check/podReady
+        - group: odlm-resources
+        - hook: common-service-db-check/podReady
+        - group: zenservice
+        - group: cs-db-pre-deploy
+        - group: cs-db-volume
+        - group: cs-db-deployment
+        - hook: cs-db-deployment/podReady
+        - hook: platform-identity-management/podReady
+        - hook: platform-auth-service/podReady
+        - hook: platform-identity-provider/podReady
+        - hook: cs-db-data/restore
+        - hook: zen-metastore-edb-check/podReady
+        - group: zen-pre-deploy
+        - group: zen-volume
+        - group: zen-deployment
+        - hook: zen5-deployment/podReady
+        - hook: zen5-data/restore
+    

--- a/velero/spectrum-fusion/recipes/4.9-example-multi-ns-recipev2.yaml
+++ b/velero/spectrum-fusion/recipes/4.9-example-multi-ns-recipev2.yaml
@@ -111,17 +111,13 @@ spec:
       name: common-services-catalogs
       type: resource
       backupRef: backup-parent-group
-    - includedNamespaces:
-        - openshift-config
-      includedResourceTypes:
+    - includedResourceTypes:
         - secrets
       labelSelector: foundationservices.cloudpak.ibm.com=pull-secret
       name: pull-secret
       type: resource
       backupRef: backup-parent-group
     - backupRef: backup-parent-group
-      includedNamespaces:
-        - openshift-config
       includedResourceTypes:
         - secrets
       labelSelector: foundationservices.cloudpak.ibm.com=pull-secret

--- a/velero/spectrum-fusion/recipes/4.9-example-multi-ns-recipev2.yaml
+++ b/velero/spectrum-fusion/recipes/4.9-example-multi-ns-recipev2.yaml
@@ -18,7 +18,9 @@ spec:
         - deployments
         - serviceaccount
         - role
+        - clusterrole
         - rolebinding
+        - clusterrolebinding
         - configmaps
         - catalogsources.operators.coreos.com
         - operatorgroups.operators.coreos.com
@@ -29,8 +31,8 @@ spec:
         - operandrequests.operator.ibm.com
         - zenservices.zen.cpd.ibm.com
         - namespaces
-      labelSelector: foundationservices.cloudpak.ibm.com=cert-manager,foundationservices.cloudpak.ibm.com=lsr,foundationservices.cloudpak.ibm.com=lsr-data,foundationservices.cloudpak.ibm.com=licensing,foundationservices.cloudpak.ibm.com=catalog,foundationservices.cloudpak.ibm.com=pull-secret,foundationservices.cloudpak.ibm.com=configmap,foundationservices.cloudpak.ibm.com=namespace,foundationservices.cloudpak.ibm.com=operatorgroup,foundationservices.cloudpak.ibm.com=subscription,foundationservices.cloudpak.ibm.com=singleton-subscription,foundationservices.cloudpak.ibm.com=crd,foundationservices.cloudpak.ibm.com=cpfs-util-backup,foundationservices.cloudpak.ibm.com=setup-tenant-job,foundationservices.cloudpak.ibm.com=commonservice,foundationservices.cloudpak.ibm.com=nss,foundationservices.cloudpak.ibm.com=operand,foundationservices.cloudpak.ibm.com=zen5-data,foundationservices.cloudpak.ibm.com=zen,foundationservices.cloudpak.ibm.com=cs-db-data
-    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data,foundationservices.cloudpak.ibm.com=cs-db-data,foundationservices.cloudpak.ibm.com=zen5-data
+      labelSelector: foundationservices.cloudpak.ibm.com
+    - labelSelector: foundationservices.cloudpak.ibm.com
       name: backup-parent-volume
       type: volume
     - includeClusterResources: true

--- a/velero/spectrum-fusion/recipes/4.9-example-single-ns-recipev2.yaml
+++ b/velero/spectrum-fusion/recipes/4.9-example-single-ns-recipev2.yaml
@@ -1,0 +1,510 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  name: cs-recipe
+  namespace: ibm-spectrum-fusion-ns
+spec:
+  appType: common-service
+  groups:
+    - includeClusterResources: true
+      name: backup-parent-group
+      type: resource
+      includedResourceTypes:
+        - secrets
+        - certificates.cert-manager.io
+        - issuers.cert-manager.io
+        - customresourcedefinitions.apiextensions.k8s.io
+        - ibmlicenseservicereporters.operator.ibm.com
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+        - catalogsources.operators.coreos.com
+        - operatorgroups.operators.coreos.com
+        - subscriptions.operators.coreos.com
+        - jobs
+        - commonservices.operator.ibm.com
+        - namespacescopes.operator.ibm.com
+        - operandrequests.operator.ibm.com
+        - zenservices.zen.cpd.ibm.com
+        - namespaces
+      labelSelector: foundationservices.cloudpak.ibm.com=cert-manager,foundationservices.cloudpak.ibm.com=lsr,foundationservices.cloudpak.ibm.com=lsr-data,foundationservices.cloudpak.ibm.com=licensing,foundationservices.cloudpak.ibm.com=catalog,foundationservices.cloudpak.ibm.com=pull-secret,foundationservices.cloudpak.ibm.com=configmap,foundationservices.cloudpak.ibm.com=namespace,foundationservices.cloudpak.ibm.com=operatorgroup,foundationservices.cloudpak.ibm.com=subscription,foundationservices.cloudpak.ibm.com=singleton-subscription,foundationservices.cloudpak.ibm.com=crd,foundationservices.cloudpak.ibm.com=cpfs-util-backup,foundationservices.cloudpak.ibm.com=setup-tenant-job,foundationservices.cloudpak.ibm.com=commonservice,foundationservices.cloudpak.ibm.com=nss,foundationservices.cloudpak.ibm.com=operand,foundationservices.cloudpak.ibm.com=zen5-data,foundationservices.cloudpak.ibm.com=zen,foundationservices.cloudpak.ibm.com=cs-db-data
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data,foundationservices.cloudpak.ibm.com=cs-db-data,foundationservices.cloudpak.ibm.com=zen5-data
+      name: backup-parent-volume
+      type: volume
+    - includeClusterResources: true
+      backupRef: backup-parent-group
+      includedResourceTypes:
+        - secrets
+        - certificates.cert-manager.io
+        - issuers.cert-manager.io
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=cert-manager
+      name: cert-manager-resources
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      name: cert-manager-crd
+      type: resource
+    - includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-parent
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      name: license-service-reporter-crd
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      name: license-service-reporter-instances
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=licensing
+      name: licensing-resources
+      type: resource
+    - includeClusterResources: true
+      backupRef: backup-parent-group
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: license-service-reporter-resources
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: lsr-pre-deploy
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+      name: lsr-deployment
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-volume
+      type: volume
+      backupRef: backup-parent-volume
+    - includedResourceTypes:
+        - catalogsources.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=catalog
+      name: common-services-catalogs
+      type: resource
+      backupRef: backup-parent-group
+    - includedNamespaces:
+        - openshift-config
+      includedResourceTypes:
+        - secrets
+      labelSelector: foundationservices.cloudpak.ibm.com=pull-secret
+      name: pull-secret
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includedNamespaces:
+        - openshift-config
+      includedResourceTypes:
+        - secrets
+      labelSelector: foundationservices.cloudpak.ibm.com=pull-secret
+      name: ow-pull-secret
+      restoreOverwriteResources: true
+      type: resource
+    - includedResourceTypes:
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=configmap
+      name: common-services-configmaps
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - roles
+        - rolebindings
+        - serviceaccounts
+      labelSelector: foundationservices.cloudpak.ibm.com=permissions
+      name: cs-operator-permissions
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=namespace
+      name: common-services-namespace
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - operatorgroups.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=operatorgroup
+      name: common-services-operatorgroups
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=subscription
+      name: common-services-subscriptions
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=singleton-subscription
+      name: singleton-subscriptions
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-subscriptions
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=crd
+      name: commonservice-crd
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - roles
+        - serviceaccounts
+        - rolebindings
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=cpfs-util-backup
+      name: setup-tenant-resources
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=crd
+      name: nss-crd
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - commonservices.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=commonservice
+      name: commonservice-cr
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - namespacescopes.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=nss
+      name: nss-cr
+      type: resource
+      backupRef: backup-parent-group
+    - includedResourceTypes:
+        - operandrequests.operator.ibm.com
+        - operandconfigs.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=operand
+      name: odlm-resources
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includedResourceTypes:
+        - operandrequests.operator.ibm.com
+        - operandconfigs.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=operand
+      name: operand-resources
+      restoreOverwriteResources: true
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen-volume
+      type: volume
+      backupRef: backup-parent-volume
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen-br-resources
+      type: resource
+      backupRef: backup-parent-group
+    - includeClusterResources: true
+      includedResourceTypes:
+        - zenservices.zen.cpd.ibm.com
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=zen
+      name: zenservice
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: zen-pre-deploy
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+      name: zen-deployment
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      name: cs-db-volume
+      type: volume
+      backupRef: backup-parent-volume
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      name: cs-db-br-resources
+      type: resource
+      backupRef: backup-parent-group
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: cs-db-pre-deploy
+      type: resource
+    - backupRef: backup-parent-group
+      includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+      name: cs-db-deployment
+      type: resource
+  hooks:
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      name: common-service-db-check
+      namespace: <operator namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 1200
+      labelSelector: app.kubernetes.io/name=operand-deployment-lifecycle-manager
+      name: odlm-check
+      namespace: <operator namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 1200
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: app.kubernetes.io/name=cert-manager
+      name: cert-manager-operator-check
+      namespace: ibm-cert-manager
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: cert-manager-webhook-check
+      nameSelector: cert-manager-webhook
+      namespace: ibm-cert-manager
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: license-service-reporter-check
+      labelSelector: app.kubernetes.io/name=ibm-license-service-reporter
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-deployment
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-data
+      namespace: <lsr namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace> backup"]
+          container: lsr-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/lsr/br_lsr.sh <lsr namespace> restore"]
+          container: lsr-backup-job
+          name: restore
+          timeout: 2000
+      selectResource: pod
+      type: exec
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 1200
+      labelSelector: 'k8s.enterprisedb.io/cluster=zen-metastore-edb,role=primary'
+      name: zen-metastore-edb-check
+      namespace: <operator namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 1200
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      name: cs-db-deployment
+      namespace: <operator namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=cs-db-data
+      name: cs-db-data
+      namespace: <operator namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "/cs-db/br_cs-db.sh backup <operator namespace>"]
+          container: cs-db-br
+          name: cs-db-backup-pre
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /cs-db/cs-db-backup/database"]
+          container: cs-db-br
+          name: cs-db-backup-post
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/cs-db/br_cs-db.sh restore <operator namespace>"]
+          container: cs-db-br
+          name: restore
+          timeout: 2000
+      selectResource: pod
+      type: exec
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen5-deployment
+      namespace: <operator namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen5-data
+      namespace: <operator namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace; /zen5/backup_zen5.sh <operator namespace>"]
+          container: zen5-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/zen5/restore_zen5.sh <operator namespace> <zenservice name>"]
+          container: zen5-backup-job
+          name: restore
+          timeout: 3600
+      selectResource: pod
+      type: exec
+  workflows:
+    - failOn: any-error
+      name: backup
+      sequence:
+        - hook: cs-db-data/cs-db-backup-pre
+        - hook: lsr-data/backup
+        - hook: zen5-data/backup
+        - group: backup-parent-group
+        - group: backup-parent-volume
+        - hook: cs-db-data/cs-db-backup-post
+    - failOn: any-error
+      name: restore
+      sequence:
+        - group: common-services-namespace
+        - group: pull-secret
+        - group: ow-pull-secret
+        - group: common-services-catalogs
+        - group: common-services-operatorgroups
+        - group: common-services-configmaps
+        - group: commonservice-crd
+        - group: cert-manager-crd
+        - group: license-service-reporter-crd
+        - group: singleton-subscriptions
+        - group: commonservice-cr
+        - hook: cert-manager-operator-check/podReady
+        - hook: cert-manager-webhook-check/podReady
+        - group: cert-manager-resources
+        - group: licensing-resources
+        - group: license-service-reporter-subscriptions
+        - hook: license-service-reporter-check/podReady
+        - group: license-service-reporter-instances
+        - group: lsr-pre-deploy
+        - group: lsr-volume
+        - group: lsr-deployment
+        - hook: lsr-deployment/podReady
+        - hook: lsr-data/restore
+        - group: common-services-subscriptions
+        - hook: odlm-check/podReady
+        - group: odlm-resources
+        - group: operand-resources
+        - hook: common-service-db-check/podReady
+        - group: zenservice
+        - group: cs-db-pre-deploy
+        - group: cs-db-volume
+        - group: cs-db-deployment
+        - hook: cs-db-deployment/podReady
+        - hook: cs-db-data/restore
+        - hook: zen-metastore-edb-check/podReady
+        - group: zen-pre-deploy
+        - group: zen-volume
+        - group: zen-deployment
+        - hook: zen5-deployment/podReady
+        - hook: zen5-data/restore

--- a/velero/spectrum-fusion/recipes/4.9-example-single-ns-recipev2.yaml
+++ b/velero/spectrum-fusion/recipes/4.9-example-single-ns-recipev2.yaml
@@ -29,8 +29,8 @@ spec:
         - operandrequests.operator.ibm.com
         - zenservices.zen.cpd.ibm.com
         - namespaces
-      labelSelector: foundationservices.cloudpak.ibm.com=cert-manager,foundationservices.cloudpak.ibm.com=lsr,foundationservices.cloudpak.ibm.com=lsr-data,foundationservices.cloudpak.ibm.com=licensing,foundationservices.cloudpak.ibm.com=catalog,foundationservices.cloudpak.ibm.com=pull-secret,foundationservices.cloudpak.ibm.com=configmap,foundationservices.cloudpak.ibm.com=namespace,foundationservices.cloudpak.ibm.com=operatorgroup,foundationservices.cloudpak.ibm.com=subscription,foundationservices.cloudpak.ibm.com=singleton-subscription,foundationservices.cloudpak.ibm.com=crd,foundationservices.cloudpak.ibm.com=cpfs-util-backup,foundationservices.cloudpak.ibm.com=setup-tenant-job,foundationservices.cloudpak.ibm.com=commonservice,foundationservices.cloudpak.ibm.com=nss,foundationservices.cloudpak.ibm.com=operand,foundationservices.cloudpak.ibm.com=zen5-data,foundationservices.cloudpak.ibm.com=zen,foundationservices.cloudpak.ibm.com=cs-db-data
-    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data,foundationservices.cloudpak.ibm.com=cs-db-data,foundationservices.cloudpak.ibm.com=zen5-data
+      labelSelector: foundationservices.cloudpak.ibm.com
+    - labelSelector: foundationservices.cloudpak.ibm.com
       name: backup-parent-volume
       type: volume
     - includeClusterResources: true


### PR DESCRIPTION
**What this PR does / why we need it**:
CPD has requested that we reduce the number of backup steps to as few as possible. Every "group" step in the backup workflow is a separate velero backup.

Unfortunately, I am having trouble getting the volumes to restore properly and am still working on it. If I keep the volume steps separate (aas opposed to trying to include them all in one backup step) it works fine. But if I merge them all together then I get the following failure:
```
BMYBR0009 There was an error when processing the job in the Transaction Manager service. The underlying error was: "Execution of workflow restore of recipe cs-recipe failed. Exception: 'appMetadata'".
```

Still trying to figure this out but it's my understanding CPD does not restore/backup the same volume groups we do since we backup CS DB, Zen metastore db, and License Service reporter in our recipe (CPD has their own process for CS DB and zen).

This recipe also restores the namespace scope resources directly instead of using the setup tenant script and all the peripheral resources required to do that. Something we could benefit from elsewhere too