### PR TITLE
fix typo in finalizers

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -1388,8 +1388,8 @@ rules:
       - zenextensions
       - zenextension/status
       - zenextensions/status
-      - zenextension/finalizer
-      - zenextensions/finalizer
+      - zenextension/finalizers
+      - zenextensions/finalizers
   - verbs:
       - get
       - list


### PR DESCRIPTION
The resource name is `zenextension/finalizers`, not `zenextension/finalizer`