### PR TITLE
stop labeling opconfig, platform-auth-idp cm, label nss

### DIFF
--- a/velero/backup/common-service/env.properties
+++ b/velero/backup/common-service/env.properties
@@ -6,6 +6,9 @@ OPERATOR_NS="" # Pass the namespace where the cs operator is installed
 SERVICES_NS="" 
 CONTROL_NS="" # Pass the control namespace if it is needed to be backed up
 
+#Pass any additional namespaces in the tenant that are not the operator or services namespace. Comma delimited
+TETHERED_NS=""
+
 # Change to the namespace where cert-manager, licensing and LSR are installed
 CERT_MANAGER_NAMESPACE="ibm-cert-manager" 
 LICENSING_NAMESPACE="ibm-licensing"

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -52,6 +52,9 @@ function main() {
     label_subscription
     label_lsr
     label_cs
+    if [[ $SERVICES_NS != "" ]]; then
+        label_nss
+    fi
     success "Successfully labeled all the resources"
 }
 
@@ -170,7 +173,6 @@ function label_configmap() {
     title "Start to label the ConfigMaps... "
     ${OC} label configmap common-service-maps foundationservices.cloudpak.ibm.com=configmap -n kube-public --overwrite=true 2>/dev/null
     ${OC} label configmap cs-onprem-tenant-config foundationservices.cloudpak.ibm.com=configmap -n $SERVICES_NS --overwrite=true 2>/dev/null
-    ${OC} label configmap platform-auth-idp foundationservices.cloudpak.ibm.com=configmap -n $SERVICES_NS --overwrite=true 2>/dev/null
     echo ""
 }
 
@@ -225,7 +227,28 @@ function label_cs(){
     title "Start to label the CommonService CR... "
     ${OC} label customresourcedefinition commonservices.operator.ibm.com foundationservices.cloudpak.ibm.com=crd --overwrite=true 2>/dev/null
     ${OC} label commonservices common-service foundationservices.cloudpak.ibm.com=commonservice -n $OPERATOR_NS --overwrite=true 2>/dev/null
-    ${OC} label operandconfig common-service foundationservices.cloudpak.ibm.com=operand -n $SERVICES_NS --overwrite=true 2>/dev/null
+    echo ""
+}
+
+function label_nss(){
+    title "Label Namespacescope resources"
+    local nss_pm="ibm-namespace-scope-operator"
+    ${OC} label subscriptions.operators.coreos.com $nss_pm foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label namespacescopes.operator.ibm.com common-service foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label customresourcedefinition namespacescopes.operator.ibm.com foundationservices.cloudpak.ibm.com=nss --overwrite=true 2>/dev/null
+    ${OC} label serviceaccount ibm-namespace-scope-operator foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ${OC} label configmap namespace-scope foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
+    if [[ $TETHERED_NS != "" ]]; then
+        for namespace in ${TETHERED_NS//,/ }
+        do
+            ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true 2>/dev/null
+            ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $namespace --overwrite=true 2>/dev/null
+        done
+    fi
     echo ""
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the labeling scripts to no longer label operandconfig and the platform-auth-idp cm. After more testing with the CPD team, it is more of a hassle to include these items than it is to regenerate them. Both of these items should be configured by changes to the commonservice CR which we already backup and restore.

This change also labels the namespacescope related resources so we can move away from using setup tenant (specifically in Fusion recipes).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action