### PR TITLE
add fallback channels for EDB operator

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -269,6 +269,8 @@ spec:
     packageName: rhbk-operator
     scope: public
   - channel: stable
+    fallbackChannels:
+      - stable-v1.22
     installPlanApproval: {{ .ApprovalMode }}
     name: edb-keycloak
     namespace: "{{ .CPFSNs }}"
@@ -294,6 +296,8 @@ metadata:
 spec:
   operators:
   - channel: stable-v1.22
+    fallbackChannels:
+      - stable
     installPlanApproval: {{ .ApprovalMode }}
     name: common-service-postgresql
     namespace: "{{ .CPFSNs }}"
@@ -1601,6 +1605,8 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
   - channel: stable-v1.22
+    fallbackChannels:
+      - stable
     name: cloud-native-postgresql-v1.22
     namespace: "{{ .CPFSNs }}"
     packageName: cloud-native-postgresql


### PR DESCRIPTION
Add fallback channels for `common-service-postgresql`, `edb-keycloak` and `cloud-native-postgresql-v1.22`, so they could tolerate both `stable` and `stable-v1.22` channels.

issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64744