### PR TITLE
 Addon egress network policy

### DIFF
--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-remote-svc-inst-status-cron-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-remote-svc-inst-status-cron-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs
+  name: egress-zen-remote-svc-inst-status-cron-job
+  namespace: "zenNamespace"
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      component: zen-remote-svc-inst-status-cron-job
+  policyTypes:
+  - Egress

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-remote-svc-inst-status-cron-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-remote-svc-inst-status-cron-job.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    component: cpfs
+    component: cpfs3
   name: egress-zen-remote-svc-inst-status-cron-job
   namespace: "zenNamespace"
 spec:

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-svc-inst-status-cron-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-svc-inst-status-cron-job.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    component: cpfs
+    component: cpfs3
   name: egress-zen-svc-inst-status-cron-job
   namespace: "zenNamespace"
 spec:

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-svc-inst-status-cron-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-svc-inst-status-cron-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs
+  name: egress-zen-svc-inst-status-cron-job
+  namespace: "zenNamespace"
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      component: zen-svc-inst-status-cron-job
+  policyTypes:
+  - Egress

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-create-tables-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-create-tables-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs
+  name: egress-zen-watchdog-create-tables-job
+  namespace: "zenNamespace"
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      component: zen-watchdog-create-tables-job
+  policyTypes:
+  - Egress

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-create-tables-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-create-tables-job.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    component: cpfs
+    component: cpfs3
   name: egress-zen-watchdog-create-tables-job
   namespace: "zenNamespace"
 spec:

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-post-requisite-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-post-requisite-job.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    component: cpfs
+    component: cpfs3
   name: egress-zen-watchdog-post-requisite-job
   namespace: "zenNamespace"
 spec:

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-post-requisite-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-post-requisite-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs
+  name: egress-zen-watchdog-post-requisite-job
+  namespace: "zenNamespace"
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      component: zen-watchdog-post-requisite-job
+  policyTypes:
+  - Egress

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-pre-requisite-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-pre-requisite-job.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    component: cpfs
+  name: egress-zen-watchdog-pre-requisite-job
+  namespace: "zenNamespace"
+spec:
+  egress:
+  - {}
+  podSelector:
+    matchLabels:
+      component: zen-watchdog-pre-requisite-job
+  policyTypes:
+  - Egress

--- a/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-pre-requisite-job.yaml
+++ b/cp3-networkpolicy/egress/zen/zen-egress-zen-watchdog-pre-requisite-job.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    component: cpfs
+    component: cpfs3
   name: egress-zen-watchdog-pre-requisite-job
   namespace: "zenNamespace"
 spec:


### PR DESCRIPTION
Zen installation failed because some of the NetworkPolicy YAML definitions were missing from the script. I manually deployed the missing YAML definitions and then successfully completed the Zen installation. Below, I have listed the YAML definitions of NetworkPolicies that I deployed on the cluster.

1. zen-egress-zen-remote-svc-inst-status-cron-job.yaml
2. zen-egress-zen-svc-inst-status-cron-job.yaml
3. zen-egress-zen-watchdog-create-tables-job.yaml
4. zen-egress-zen-watchdog-post-requisite-job.yaml
5. zen-egress-zen-watchdog-pre-requisite-job.yaml