### PR TITLE
added new flag to indicate whether service is user managed

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -129,6 +129,10 @@ type OperatorConfig struct {
 	// zero and not specified. Defaults to 1.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
+	// UserManaged is a flag that indicates whether the operator is managed by
+	// user or not. If set the value will propagate down to UserManaged field
+	// in the OperandRegistry
+	UserManaged bool `json:"userManaged,omitempty"`
 }
 
 // LicenseList defines the license specification in CSV

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles470.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-04-11T02:45:28Z"
+    createdAt: "2024-09-09T21:00:30Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -395,8 +395,6 @@ spec:
                         ephemeral-storage: 256Mi
                         memory: 200Mi
                     securityContext:
-                      seccompProfile:
-                        type: RuntimeDefault
                       allowPrivilegeEscalation: false
                       capabilities:
                         drop:
@@ -404,6 +402,8 @@ spec:
                       privileged: false
                       readOnlyRootFilesystem: true
                       runAsNonRoot: true
+                      seccompProfile:
+                        type: RuntimeDefault
                     volumeMounts:
                       - mountPath: /tmp/k8s-webhook-server/serving-certs
                         name: cert

--- a/bundle/manifests/operator.ibm.com_commonservices.yaml
+++ b/bundle/manifests/operator.ibm.com_commonservices.yaml
@@ -150,6 +150,12 @@ spec:
                         zero and not specified. Defaults to 1.
                       format: int32
                       type: integer
+                    userManaged:
+                      description: |-
+                        UserManaged is a flag that indicates whether the operator is managed by
+                        user or not. If set the value will propagate down to UserManaged field
+                        in the OperandRegistry
+                      type: boolean
                   type: object
                 type: array
                 x-kubernetes-preserve-unknown-fields: true

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -147,6 +147,12 @@ spec:
                         zero and not specified. Defaults to 1.
                       format: int32
                       type: integer
+                    userManaged:
+                      description: |-
+                        UserManaged is a flag that indicates whether the operator is managed by
+                        user or not. If set the value will propagate down to UserManaged field
+                        in the OperandRegistry
+                      type: boolean
                   type: object
                 type: array
                 x-kubernetes-preserve-unknown-fields: true

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -50,6 +50,7 @@ import (
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
 	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/v4/api/v1"
+	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
 )
 
 type CsMaps struct {
@@ -870,4 +871,30 @@ func SanitizeData(data interface{}, valueType string, isEmpty bool) interface{} 
 		klog.Errorf("data type is not map[string]interface{}")
 		return nil
 	}
+}
+
+func UpdateOpRegUserManaged(opreg *odlm.OperandRegistry, operatorName string, value bool) error {
+	packageName := GetPackageNameByServiceName(opreg, operatorName)
+	if packageName == "" {
+		return fmt.Errorf("failed to find package name while updating OperandRegistry with user managed field")
+	}
+	for i := range opreg.Spec.Operators {
+		i := i
+		if opreg.Spec.Operators[i].PackageName != packageName {
+			continue
+		}
+
+		opreg.Spec.Operators[i].UserManaged = value
+	}
+	return nil
+}
+
+func GetPackageNameByServiceName(opreg *odlm.OperandRegistry, operatorName string) string {
+	for _, v := range opreg.Spec.Operators {
+		v := v
+		if v.Name == operatorName {
+			return v.PackageName
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
How to test

1. Deploy common-service-operator from catalogs with 4.6.6+
2. Build this PR `make build-dev-image`
3. Change image in CSV on cluster to use built image
4. Update CommonService CR with following example
5. Verify OperandRegistry contains `userManaged: true` for all postgresql entries

CommonService CR example

```yaml
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
  labels:
    foundationservices.cloudpak.ibm.com: commonservice
spec:
  license:
    accept: false
  operatorConfigs:
    - name: common-service-postgresql
      userManaged: true
  operatorNamespace: byo
  servicesNamespace: byo
  size: starterset
```