### PR TITLE
obfuscate metrics secret values

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -1426,6 +1426,8 @@ data:
 type: Opaque
 EOF
     #icp-mongodb-metrics-secret.yaml
+    metrics_pass=$(${OC} get secret icp-mongodb-metrics -n $FROM_NAMESPACE -o=jsonpath='{.data.password}')
+    metrics_user=$(${OC} get secret icp-mongodb-metrics -n $FROM_NAMESPACE -o=jsonpath='{.data.user}')
     cat << EOF | ${OC} apply -f -
 kind: Secret
 apiVersion: v1
@@ -1438,8 +1440,8 @@ metadata:
     app.kubernetes.io/name: icp-mongodb
     release: mongodb
 data:
-  password: aWNwbWV0cmljcw==
-  user: bWV0cmljcw==
+  password: $metrics_pass
+  user: $metrics_user
 type: Opaque
 EOF
     #mongo-rbac.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Metrics pod user and secret values are exposed in the script. We can take the values from the existing mongo in the original namespace instead and obfuscate the value in the script itself.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?
Successful run of preload data script

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
3. The PR will be automatically created in the target branch after merging this PR
4. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action