### PR TITLE
check length of operatorsStatus in OperandRegistry to trigger the CR reconciliation

### DIFF
--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -557,8 +557,8 @@ func (r *CommonServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 						return false
 					}
 
-					// Check if the .status field has changed
-					return !reflect.DeepEqual(oldOperandRegistry.Status, newOperandRegistry.Status)
+					// Return true if the length of .status.operatorsStatus array has changed, indicating that a operator has been added or removed
+					return len(oldOperandRegistry.Status.OperatorsStatus) != len(newOperandRegistry.Status.OperatorsStatus)
 				},
 			},
 			))


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64775

### Context
The reconciliation request on CommonService CR is constantly generated [by the status update in OperandRegistry](https://github.com/IBM/ibm-common-service-operator/blob/963f33528827d0e73f1db0c5b53c0ec5b2cd81e9/controllers/commonservice_controller.go#L561)

By looking into the status update in OperandRegistry, the sequence of items listed in `reconcileRequests` for one operator is changing. This is due to the constant reconciliation on OperandRegistry by ODLM.
<img width="1700" alt="Screenshot 2024-09-12 at 10 44 41 AM" src="https://github.com/user-attachments/assets/2039020f-b09d-4ae8-92d6-b07a5482c557">


So looking into ODLM logs, ODLM is constantly reconciling OperandRequest because of missing correct Catalog for Zen operator. And the reconciliation on OperandRequest will trigger the reconciliation of OperandRegistry.
```
E0912 14:59:53.975913 1 manager.go:183] Not found PackageManifest ibm-zen-operator in the namespace cpd-operator has channel v6.0
I0912 14:59:54.025780 1 reconcile_operand.go:174] Subscription ibm-platformui-operator in the namespace cpd-operator is NOT managed by cpd-instance/zen-ca-operand-request, Skip reconciling Operands
I0912 14:59:54.025800 1 reconcile_operand.go:219] Finished reconciling Operands for OperandRequest: cpd-instance/zen-ca-operand-request
I0912 14:59:54.037816 1 operatorconfig_controller.go:66] Reconciling OperatorConfig for OperandRequest: cpd-instance/zen-ca-operand-request
E0912 14:59:54.073330 1 manager.go:183] Not found PackageManifest ibm-zen-operator in the namespace cpd-operator has channel v6.0
```

Overall speaking, due to missing correct catalog on zen operator - this is expected, user has not yet updated the catalog for zen yet,
1. ODLM will consistently reconcile OperandRequest to find the right catalog.
2. OperandRequest status update triggers the OperandRegistry reconciliation with status update.
3. Subsequently, OperandRegistry status update triggers the reconciliation on CommonService CR.

### To-do
In order to break the above chain reaction, we update the logic on how OperandRegistry status update will trigger the reconciliation on CommonService CR. Instead of simply comparing the status field of OperandRegistry, Common Service Operator will check the length of `operatorStatus`, to determine whether or not triggering the CommonService CR reconciliation. 

### Test
After applying the dev image `quay.io/daniel_fan/common-service-operator-amd64` on the cluster, the reconciliation is stopped.
```console
➜  ~ oc get deployment ibm-common-service-operator -n cpd-operator -ojsonpath='{.spec.template.spec.containers[0].image}'
quay.io/daniel_fan/common-service-operator-amd64%

➜  ~ oc get commonservice common-service -n cpd-operator -ojsonpath='{.status.phase}'
Succeeded%
```