### PR TITLE
Use Unstructured obj to copy CR to other ns

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1581,43 +1581,47 @@ func (b *Bootstrap) ConfigCertManagerOperandManagedByOperator(ctx context.Contex
 func (b *Bootstrap) PropagateDefaultCR(instance *apiv3.CommonService) error {
 	// Copy Master CR into namespace in WATCH_NAMESPACE list
 	watchNamespaceList := strings.Split(b.CSData.WatchNamespaces, ",")
-	csLabel := make(map[string]string)
-	// Copy from the original labels to the target labels
-	for k, v := range instance.Labels {
-		csLabel[k] = v
-	}
-	csAnnotation := make(map[string]string)
-	// Copy from the original Annotations to the target Annotations
-	for k, v := range instance.Annotations {
-		csAnnotation[k] = v
-	}
-
 	// Exclude CommonService cloned in AllNamespace Mode
 	if len(watchNamespaceList) > 1 {
+		// Get the unstructured object of the main CommonService CR
+		mainCsInstance := &unstructured.Unstructured{}
+		mainCsInstance.SetGroupVersionKind(apiv3.GroupVersion.WithKind("CommonService"))
+		if err := b.Client.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, mainCsInstance); err != nil {
+			return fmt.Errorf("failed to get CommonService CR %s in namespace %s: %v", instance.Name, instance.Namespace, err)
+		}
+		csLabel := make(map[string]string)
+		// Copy from the original labels to the target labels
+		for k, v := range mainCsInstance.GetLabels() {
+			csLabel[k] = v
+		}
+		csLabel[constant.CsClonedFromLabel] = b.CSData.OperatorNs
+
+		csAnnotation := make(map[string]string)
+		// Copy from the original Annotations to the target Annotations
+		for k, v := range mainCsInstance.GetAnnotations() {
+			csAnnotation[k] = v
+		}
 		for _, watchNamespace := range watchNamespaceList {
-			if watchNamespace == instance.Namespace {
+			if watchNamespace == mainCsInstance.GetNamespace() {
 				continue
 			}
-			copiedCsInstance := &apiv3.CommonService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        constant.MasterCR,
-					Namespace:   watchNamespace,
-					Labels:      csLabel,
-					Annotations: csAnnotation,
-				},
-				Spec: instance.Spec,
-			}
-			util.EnsureLabelsForCsCR(copiedCsInstance, map[string]string{
-				constant.CsClonedFromLabel: b.CSData.OperatorNs,
-			})
+			copiedCsInstance := &unstructured.Unstructured{}
+			copiedCsInstance.SetGroupVersionKind(apiv3.GroupVersion.WithKind("CommonService"))
+			copiedCsInstance.SetNamespace(watchNamespace)
+			copiedCsInstance.SetName(constant.MasterCR)
+			copiedCsInstance.SetLabels(csLabel)
+			copiedCsInstance.SetAnnotations(csAnnotation)
+			copiedCsInstance.Object["spec"] = mainCsInstance.Object["spec"]
+
 			if err := b.Client.Create(ctx, copiedCsInstance); err != nil {
 				if errors.IsAlreadyExists(err) {
 					csKey := types.NamespacedName{Name: constant.MasterCR, Namespace: watchNamespace}
-					existingCsInstance := &apiv3.CommonService{}
+					existingCsInstance := &unstructured.Unstructured{}
+					existingCsInstance.SetGroupVersionKind(apiv3.GroupVersion.WithKind("CommonService"))
 					if err := b.Client.Get(ctx, csKey, existingCsInstance); err != nil {
 						return fmt.Errorf("failed to get cloned CommonService CR in namespace %s: %v", watchNamespace, err)
 					}
-					if needUpdate := util.CompareCsCR(copiedCsInstance, existingCsInstance); needUpdate {
+					if needUpdate := util.CompareObj(copiedCsInstance, existingCsInstance); needUpdate {
 						copiedCsInstance.SetResourceVersion(existingCsInstance.GetResourceVersion())
 						if err := b.Client.Update(ctx, copiedCsInstance); err != nil {
 							return fmt.Errorf("failed to update cloned CommonService CR in namespace %s: %v", watchNamespace, err)
@@ -1764,12 +1768,11 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 	}
 
 	if len(labelsMap) == 0 {
-		klog.Infof("No labels found in the spec of CommonService CR")
 		return nil
 	}
 
 	// Update labels in the CommonService CRs
-	klog.Infof("Update labels in the CommonService CRs")
+	klog.Infof("Update labels for resources managed by CommonService CR %s/%s", instance.GetNamespace(), instance.GetName())
 	for _, cs := range csObjectList.Items {
 		util.EnsureLabelsForCsCR(&cs, labelsMap)
 		if err := b.Client.Update(context.TODO(), &cs); err != nil {

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -804,8 +804,8 @@ func EnsureLabelsForCsCR(cs *apiv3.CommonService, labels map[string]string) {
 	}
 }
 
-func CompareCsCR(csCR *apiv3.CommonService, existingCsCR *apiv3.CommonService) (needUpdate bool) {
-	return !equality.Semantic.DeepEqual(csCR.GetLabels(), existingCsCR.GetLabels()) || !equality.Semantic.DeepEqual(csCR.GetAnnotations(), existingCsCR.GetAnnotations()) || !equality.Semantic.DeepEqual(csCR.Spec, existingCsCR.Spec)
+func CompareObj(newObj *unstructured.Unstructured, existingObj *unstructured.Unstructured) (needUpdate bool) {
+	return !equality.Semantic.DeepEqual(newObj.GetLabels(), existingObj.GetLabels()) || !equality.Semantic.DeepEqual(newObj.GetAnnotations(), existingObj.GetAnnotations()) || !equality.Semantic.DeepEqual(newObj.Object["spec"], existingObj.Object["spec"])
 }
 
 // ReadFile reads file from local path

--- a/controllers/recocile_pause.go
+++ b/controllers/recocile_pause.go
@@ -34,7 +34,6 @@ func (r *CommonServiceReconciler) reconcilePauseRequest(instance *apiv3.CommonSe
 
 	// if the given CommnService CR has not been existing
 	if instance == nil {
-		klog.Warningf("CommonService CR %s/%s is not existing", instance.Name, instance.Namespace)
 		return false
 	}
 


### PR DESCRIPTION
issue: https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/28858

### Context
When there are old CS 3.x installed together with CS 4.x in the same cluster, it is usual that old CS 3.x installed later on the cluster, so entire OCP cluster is using the old CRD from CS 3.x. In this case, the field `.spec.services[*].spec` is a required field on old CRD from CS 3.x.

And we have documented that user has to explicitly set field `.spec.services[*].spec: {}` even it is empty
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
  namespace: operator-ns
spec:
  license:
    accept: true
  operatorNamespace: latest-validated
  services:
    - name: common-service-postgresql
      resources:
         ...
      spec: {}
```

### Issue
When CS 4.x propagates CS CR from operator namespace into other namespaces into the tenant, CS operator renders CS CR into structure `apiv3.CommonService`. However, this API structure will automatically **ignore** the field when it is empty.
Therefore, field `.spec.services[*].spec: {}` is pruned after the CR is copied into other namespace. And it is causing CRD compatibility issues
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: common-service
  namespace: operator-ns
spec:
  license:
    accept: true
  operatorNamespace: latest-validated
  services:
    - name: common-service-postgresql
      resources:
         ...
      # spec: {}       <-------------- this line will be removed when converting template into structure `apiv3.CommonService`
```

### Solution
In order to always preserve the field `.spec.services[*].spec: {}` even it is empty, we would use Unstructured obj to store the CS CR object, which will preserve every field in the template.

### Test
After applying the dev image `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:dev`, I could see that the CS CR in tenant namespace contains all empty fields and they are NOT pruned.
<img width="618" alt="Screenshot 2024-09-16 at 2 02 50 PM" src="https://github.com/user-attachments/assets/1e10a370-490e-49d5-a65a-78548ccd5883">