### PR TITLE
updated BYO EDB operator handling

### DIFF
--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -284,6 +284,14 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Noeffect", fmt.Sprintf("No update, resource sizings in the OperandConfig %s/%s are larger than the profile from CommonService CR %s/%s", r.Bootstrap.CSData.OperatorNs, "common-service", instance.Namespace, instance.Name))
 	}
 
+	if err := r.Bootstrap.UpdateEDBUserManaged(); err != nil {
+		if statusErr := r.updatePhase(ctx, instance, CRFailed); statusErr != nil {
+			klog.Error(statusErr)
+		}
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		return ctrl.Result{}, statusErr
+	}
+
 	if isEqual, statusErr = r.updateOperatorConfig(ctx, instance.Spec.OperatorConfigs); statusErr != nil {
 		if statusErr := r.updatePhase(ctx, instance, CRFailed); statusErr != nil {
 			klog.Error(statusErr)

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1604,6 +1604,13 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
+  - channel: stable
+    name: internal-use-only-edb
+    namespace: "{{ .CPFSNs }}"
+    packageName: cloud-native-postgresql
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    installMode: no-op
   - channel: stable-v1.22
     fallbackChannels:
       - stable


### PR DESCRIPTION
- enables configuration via ibm-cpp-config
- with EDB_USER_MANAGED_OPERATOR_ENABLED: "true"
- which updates default CS CR with operatorConfig for internal-use-only-edb and sets userManaged
- internal-use-only-edb is new entry that references package for EDB, but has no-op so ODLM does not install it even if user creates OperandRequest for it

How to test

1. deploy common-services from CD catalog
2. update OperandRegistry with entry for `internal-use-only-edb`
3. ` make build-dev-image` and update cs-operator image on your cluster
4. create following configmap and restart cs-operator
5. verify that OperandRegistry is updated with `userManaged: true` for EDB entries
6. remove ibm-cpp-config and restart cs-operator
7. verify that OperandRegistry is updated with `userManaged` field removed

```yaml
  - channel: stable
    name: internal-use-only-edb
    namespace: "{{ .CPFSNs }}"
    packageName: cloud-native-postgresql
    scope: public
    installPlanApproval: Automatic
    installMode: no-op
```

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: ibm-cpp-config
  labels:
    operator.ibm.com/managedByCsOperator: 'true'
data:
  EDB_USER_MANAGED_OPERATOR_ENABLED: "true"
```