### PR TITLE
Re-create NSS CR after NSS operator upgrade in migration

### DIFF
--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -165,6 +165,11 @@ function main() {
             ${BASE_DIR}/common/authorize-namespace.sh $ns -to $OPERATOR_NS
         done
 
+        # In the case that CPFS 4.x accidentally delete the NamespaceScope CR
+        # due to misunderstanding simple topology or All namespaces topology(namespace-scope ConfigMap is not updated in time)
+        # Re-Create/Update NamespaceScope CR common-service after NSS operator upgrade.
+        update_nss_kind "$OPERATOR_NS" "$NS_LIST"
+
         accept_license "namespacescope" "$OPERATOR_NS" "common-service"
     fi
     # Check master CommonService CR status


### PR DESCRIPTION
### Context
There is [a corner case](https://github.com/IBM/ibm-common-service-operator/blob/a61e662e2c984fe8effbd51d5203327eda9dacf0/cp3pt0-deployment/migrate_tenant.sh#L149) in `migrate_tenant.sh` where
1. **Common Service operator is upgraded to v4.x**
    - So it detects its own installation mode, and clean NSS operator and CR when following requirements are all met
         - NamespaceScope Operator is at v3.x level
         - namespace-scope ConfigMap only contains one namespace or empty(single topology or all namespace mode)
         - no `no-op` service is requested in OperandRegistry
3. **NamespaceScope Operator is not yet upgraded**
4. **All NamespaceScope CRs from CPFS v3.x are cleaned**
   - So `namespace-scope` ConfigMap only contains one namespace.

### Issue
CS operator will delete the NamespaceScope CR that are just created by the script. This will result no NamespaceScope CR in the tenant for permission projection.

```logs
[INFO] Updating the NamespaceScope object
namespacescope.operator.ibm.com/common-service created       <--------- NSS CR was created
...

# Updating ibm-namespace-scope-operator in namesapce cs2...
subscription.operators.coreos.com/ibm-namespace-scope-operator created
...

Authorizing the NamespaceScope operator in cs2 to manage namespace cp2 
...

# Accepting license for namespacescope common-service in namespace cs2...
[✗] Not found namespacescope common-service in cs2, skipping updating license acceptance     <---------- NSS CR was not found because it has been deleted by CS operator
```

### Solution
The script will re-create the NamespaceScope CR after NSS operator is upgraded to v4.x level.
When CPFS 4.x detects NSS operator v4, it will not delete NamespaceScope CR.