### PR TITLE
using`ibm-licensing-service-instance` deployment to ensure the exact namespace

### DIFF
--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -231,11 +231,16 @@ function is_migrate_licensing() {
     fi
 
     title "Check migrating LTSR ibm-licensing-operator"
-    
-    local ns=$("$OC" get deployments -A | grep ibm-licensing-operator | cut -d ' ' -f1)
+    local ns=$("$OC" get deployments -A | grep ibm-licensing-service-instance | cut -d ' ' -f1)
     if [ -z "$ns" ]; then
         info "No LTSR ibm-licensing-operator to migrate, skipping"
         return 0
+    fi
+
+    local licensing_service_count=$("$OC" get deployments -A | grep ibm-licensing-service-instance | wc -l)
+    # If multiple Licensing service deployment is found, it should error out
+    if [ "$licensing_service_count" -ge 2 ]; then
+        error "More than one ibm-licensing-service-instance found"
     fi
 
     local version=$("$OC" get ibmlicensings.operator.ibm.com instance -o jsonpath='{.spec.version}' --ignore-not-found)
@@ -383,7 +388,7 @@ function install_licensing() {
         info "There is no ibm-licensing-operator-app Subscription installed\n"
     fi
 
-    local ns=$("$OC" get deployments -A | grep ibm-licensing-operator | cut -d ' ' -f1)
+    local ns=$("$OC" get deployments -A | grep ibm-licensing-service-instance | cut -d ' ' -f1)
     if [ ! -z "$ns" ]; then
         if [ "$ns" != "$LICENSING_NAMESPACE" ]; then
             error "An ibm-licensing-operator already installed in namespace: $ns, expected namespace is: $LICENSING_NAMESPACE"

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -240,7 +240,7 @@ function is_migrate_licensing() {
     local licensing_service_count=$("$OC" get deployments -A | grep ibm-licensing-service-instance | wc -l)
     # If multiple Licensing service deployment is found, it should error out
     if [ "$licensing_service_count" -ge 2 ]; then
-        error "More than one ibm-licensing-service-instance found"
+        error "More than one ibm-licensing-service-instance found in namespace: $ns. There should be only one ibm-licensing-service-instance each cluster."
     fi
 
     local version=$("$OC" get ibmlicensings.operator.ibm.com instance -o jsonpath='{.spec.version}' --ignore-not-found)


### PR DESCRIPTION
**What this PR does / why we need it**:
Handle the edge case which v3 and v4 licensing operator co-existence in the same cluster.

- If multiple Licensing operators is found, we use `ibm-licensing-service-instance` deployment to ensure the exact namespace where licensing v4 is installed.
- If multiple licensing-service-instance found, error out

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64782
