### PR TITLE
reduce the number of certs and secrets labeled to just cs-ca and zen-…

### DIFF
--- a/velero/backup/cert-manager/label-cert-manager.sh
+++ b/velero/backup/cert-manager/label-cert-manager.sh
@@ -35,8 +35,8 @@ do
     oc label issuer $NAME -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
 done
 
-# Get all certificates in all namespaces and add foundationservices.cloudpak.ibm.com=cert-manager
-CURRENT_CERTIFICATES=($(oc get certificates --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:metadata.namespace --no-headers=True))
+# Label all cs-ca-certificates
+CURRENT_CERTIFICATES=($(oc get certificates --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:metadata.namespace --no-headers=True | grep cs-ca-certificate))
 i=0
 len=${#CURRENT_CERTIFICATES[@]}
 while [ $i -lt $len ];
@@ -49,9 +49,11 @@ do
     echo $NAMESPACE
     echo "---"
     oc label certificates $NAME -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+    oc label secret cs-ca-certificate-secret -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
 done
 
-CURRENT_CERTIFICATES=($(oc get certificates.cert-manager.io --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:metadata.namespace --no-headers=True))
+#cover the different api for certificates
+CURRENT_CERTIFICATES=($(oc get certificates.cert-manager.io --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:metadata.namespace --no-headers=True | grep cs-ca-certificate))
 i=0
 len=${#CURRENT_CERTIFICATES[@]}
 while [ $i -lt $len ];
@@ -64,22 +66,7 @@ do
     echo $NAMESPACE
     echo "---"
     oc label certificates $NAME -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
-done
-
-# Get all secrets with label operator.ibm.com/watched-by-cert-manager="" and add foundationservices.cloudpak.ibm.com=cert-manager
-CURRENT_SECRETS=($(oc get secrets -l operator.ibm.com/watched-by-cert-manager="" --all-namespaces -o custom-columns=NAME:.metadata.name,NAMESPACE:metadata.namespace --no-headers=True))
-i=0
-len=${#CURRENT_SECRETS[@]}
-while [ $i -lt $len ];
-do
-    NAME=${CURRENT_SECRETS[$i]}
-    let i++
-    NAMESPACE=${CURRENT_SECRETS[$i]}
-    let i++
-    echo $NAME
-    echo $NAMESPACE
-    echo "---"
-    oc label secret $NAME -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+    oc label secret cs-ca-certificate-secret -n $NAMESPACE foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
 done
 
 CURRENT_CRD_ISSUERS=($(oc get crd | grep issuer | cut -d ' ' -f1))
@@ -119,6 +106,7 @@ if [[ $zen_namespace_list != "fail" ]]; then
             echo $zen_namespace
             echo "---"
             oc label secret $zen_secret_name -n $zen_namespace foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
+            oc label secret zen-ca-cert-secret -n $zen_namespace foundationservices.cloudpak.ibm.com=cert-manager --overwrite=true
         done
     done
 else


### PR DESCRIPTION
…ca plus already specified

**What this PR does / why we need it**:
Instead of labeling every secret and certificate watched by cert manager, we limit it to the "primary" resources that all other secrets are generated based on. These are the cs-ca-certificate and its accompanying secret and the zen-ca-cert-secret. In addition, there are other secrets previously specified in the script that are still labeled like the IM admin credentials since we do not want those to be regenerated with a different value.

Previously, it did not matter if we labeled them all but now that we need to support restoring into a different namespace, it is very difficult to create the logic that would individually update namespace related values (like dns lists) in secrets like the common-service-db-tls-cert. The secret values should be the same as on the original cluster because they are inherited from the cs-ca-certificate-secret so as long as that secret is carried over, the regenerated secret should contain the same values but with updated namespace values.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?
Test BR as normal but using this script to label certs and secrets
If resources fail to come up due to certificate issues after restore then we are missing certs/secrets.

I have tested this previously but it was a few weeks ago with a simple BR setup (one without zen or im) so it's possible this is not sufficient when including zen and im

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
3. The PR will be automatically created in the target branch after merging this PR
4. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action