### PR TITLE
[SC2] apply customized user-profile for keycloak-24

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -506,6 +506,7 @@ spec:
             cs-keycloak-entrypoint.sh: |
               #!/usr/bin/env bash
               CA_DIR=/mnt/trust-ca
+              USERPROFILE_DIR=/mnt/user-profile
               TRUSTSTORE_DIR=/mnt/truststore
               echo "Building the truststore file ..."
               cp /etc/pki/java/cacerts ${TRUSTSTORE_DIR}/keycloak-truststore.jks

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -539,7 +539,7 @@ spec:
                   "attributes": [
                     {
                       "name": "username",
-                      "displayName": "${variable}{username}",
+                      "displayName": "${username}",
                       "validations": {
                         "length": {
                           "min": 3,
@@ -562,7 +562,7 @@ spec:
                     },
                     {
                       "name": "email",
-                      "displayName": "${variable}{email}",
+                      "displayName": "${email}",
                       "validations": {
                         "email": {},
                         "length": {
@@ -584,7 +584,7 @@ spec:
                     },
                     {
                       "name": "firstName",
-                      "displayName": "${variable}{firstName}",
+                      "displayName": "${firstName}",
                       "validations": {
                         "length": {
                           "max": 255
@@ -605,7 +605,7 @@ spec:
                     },
                     {
                       "name": "lastName",
-                      "displayName": "${variable}{lastName}",
+                      "displayName": "${lastName}",
                       "validations": {
                         "length": {
                           "max": 255

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -530,7 +530,112 @@ spec:
                 keytool -importcert -file ${CA_DIR}/${cert} -keystore ${TRUSTSTORE_DIR}/keycloak-truststore.jks -storepass changeit -alias ${cert} -noprompt
               done
               echo "Truststore file built, starting Keycloak ..."
-              "/opt/keycloak/bin/kc.sh" "$@" --spi-truststore-file-file=${TRUSTSTORE_DIR}/keycloak-truststore.jks --spi-truststore-file-password=changeit --spi-truststore-file-hostname-verification-policy=WILDCARD
+              "/opt/keycloak/bin/kc.sh" "$@" --spi-truststore-file-file=${TRUSTSTORE_DIR}/keycloak-truststore.jks --spi-truststore-file-password=changeit --spi-truststore-file-hostname-verification-policy=WILDCARD --spi-user-profile-declarative-user-profile-config-file=${USERPROFILE_DIR}/cs-keycloak-user-profile.json
+        - apiVersion: v1
+          data:
+            data:
+              cs-keycloak-user-profile.json: |
+                {
+                  "attributes": [
+                    {
+                      "name": "username",
+                      "displayName": "${variable}{username}",
+                      "validations": {
+                        "length": {
+                          "min": 3,
+                          "max": 255
+                        },
+                        "username-prohibited-characters": {},
+                        "up-username-not-idn-homograph": {}
+                      },
+                      "permissions": {
+                        "view": [
+                          "admin",
+                          "user"
+                        ],
+                        "edit": [
+                          "admin",
+                          "user"
+                        ]
+                      },
+                      "multivalued": false
+                    },
+                    {
+                      "name": "email",
+                      "displayName": "${variable}{email}",
+                      "validations": {
+                        "email": {},
+                        "length": {
+                          "max": 255
+                        }
+                      },
+                      "annotations": {},
+                      "permissions": {
+                        "view": [
+                          "admin",
+                          "user"
+                        ],
+                        "edit": [
+                          "admin",
+                          "user"
+                        ]
+                      },
+                      "multivalued": false
+                    },
+                    {
+                      "name": "firstName",
+                      "displayName": "${variable}{firstName}",
+                      "validations": {
+                        "length": {
+                          "max": 255
+                        },
+                        "person-name-prohibited-characters": {}
+                      },
+                      "permissions": {
+                        "view": [
+                          "admin",
+                          "user"
+                        ],
+                        "edit": [
+                          "admin",
+                          "user"
+                        ]
+                      },
+                      "multivalued": false
+                    },
+                    {
+                      "name": "lastName",
+                      "displayName": "${variable}{lastName}",
+                      "validations": {
+                        "length": {
+                          "max": 255
+                        },
+                        "person-name-prohibited-characters": {}
+                      },
+                      "permissions": {
+                        "view": [
+                          "admin",
+                          "user"
+                        ],
+                        "edit": [
+                          "admin",
+                          "user"
+                        ]
+                      },
+                      "multivalued": false
+                    }
+                  ],
+                  "groups": [
+                    {
+                      "name": "user-metadata",
+                      "displayHeader": "User metadata",
+                      "displayDescription": "Attributes, which refer to user metadata"
+                    }
+                  ]
+                }
+          force: true
+          kind: ConfigMap
+          name: cs-keycloak-user-profile
       - apiVersion: v1
         annotations:
           service.beta.openshift.io/serving-cert-secret-name: cpfs-opcon-cs-keycloak-tls-secret
@@ -678,6 +783,8 @@ spec:
                           name: startup-volume
                         - mountPath: /mnt/trust-ca
                           name: trust-ca-volume
+                        - mountPath: /mnt/user-profile
+                          name: user-profile-volume
                         - mountPath: /opt/keycloak/providers
                           name: cs-keycloak-theme
                   volumes:
@@ -691,6 +798,9 @@ spec:
                       configMap:
                         name: cs-keycloak-ca-certs
                         optional: true
+                    - name: user-profile-volume
+                      configMap: 
+                        name: cs-keycloak-user-profile
                     - name: cs-keycloak-theme
                       configMap:
                         items:


### PR DESCRIPTION
**What this PR does / why we need it**:
After upgrade keycloak from 22 to 24, email will required by default. We want to keep the consistency with keycloak-22, so we need to apply a customized user-profile-config
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64707

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action