### PR TITLE
Fix fusion script/recipe issue found in SERT testing

### DIFF
--- a/br-testing-automation/env.properties
+++ b/br-testing-automation/env.properties
@@ -1,5 +1,6 @@
 #variables for both hub and spoke setup
-CATALOG_SOURCE="ibm-operator-catalog" #default
+FUSION_CATALOG_SOURCE="ibm-operator-catalog" #default
+CS_CATALOG_SOURCE="opencloud-operators"
 CAT_SRC_NS="openshift-marketplace" #default
 OC="oc" #default, can be overridden with --oc option when calling script
 YQ="yq" #default, can be overridden with --yq option when calling script

--- a/br-testing-automation/fusion-backup-setup.sh
+++ b/br-testing-automation/fusion-backup-setup.sh
@@ -375,7 +375,7 @@ function label_cs_resources() {
     mv ../velero/backup/common-service/env.properties ../velero/backup/common-service/og-env.properties
     cp env.properties ../velero/backup/common-service/env.properties
     export TETHERED_NS="$TETHERED_NAMESPACE1,$TETHERED_NAMESPACE2"
-    nfo "Labeling remaining CPFS resources..."
+    info "Labeling remaining CPFS resources..."
     ./../velero/backup/common-service/label-common-service.sh || error "Unable to complete labeling of CPFS resources."
 
     success "CPFS resources labeled."

--- a/br-testing-automation/fusion-backup-setup.sh
+++ b/br-testing-automation/fusion-backup-setup.sh
@@ -374,7 +374,8 @@ function label_cs_resources() {
 
     mv ../velero/backup/common-service/env.properties ../velero/backup/common-service/og-env.properties
     cp env.properties ../velero/backup/common-service/env.properties
-    info "Labeling remaining CPFS resources..."
+    export TETHERED_NS="$TETHERED_NAMESPACE1,$TETHERED_NAMESPACE2"
+    nfo "Labeling remaining CPFS resources..."
     ./../velero/backup/common-service/label-common-service.sh || error "Unable to complete labeling of CPFS resources."
 
     success "CPFS resources labeled."

--- a/br-testing-automation/fusion-backup-setup.sh
+++ b/br-testing-automation/fusion-backup-setup.sh
@@ -125,8 +125,8 @@ function prereq() {
     elif [[ $BACKUP_SETUP == "false" ]] && [[ $RESTORE_SETUP == "false" ]]; then
         error "Neither Hub nor Spoke setup options selected. Please rerun selecting one or the other (Hub has to come first)."
     elif [[ $BACKUP_SETUP == "true" ]] || [[ $RESTORE_SETUP == "true" ]]; then
-        if [[ -z $CATALOG_SOURCE ]] || [[ -z $CAT_SRC_NS ]] || [[ -z $SF_NAMESPACE ]] || [[ -z $GITHUB_USER ]] || [[ -z $GITHUB_TOKEN ]] || [[ -z $STORAGE_CLASS ]]; then
-            error "Missing value for one or more of CATALOG_SOURCE, CAT_SRC_NS, SF_NAMESPACE, GITHUB_USER, GITHUB_TOKEN, or STORAGE_CLASS. Please update env.properties file with correct parameters and rerun."
+        if [[ -z $CS_CATALOG_SOURCE ]] || [[ -z $FUSION_CATALOG_SOURCE ]] || [[ -z $CAT_SRC_NS ]] || [[ -z $SF_NAMESPACE ]] || [[ -z $GITHUB_USER ]] || [[ -z $GITHUB_TOKEN ]] || [[ -z $STORAGE_CLASS ]]; then
+            error "Missing value for one or more of CS_CATALOG_SOURCE, FUSION_CATALOG_SOURCE, CAT_SRC_NS, SF_NAMESPACE, GITHUB_USER, GITHUB_TOKEN, or STORAGE_CLASS. Please update env.properties file with correct parameters and rerun."
         fi
         if [[ $BACKUP_SETUP == "true" ]]; then
             if [[ -z $OPERATOR_NS ]] || [[ -z $SERVICES_NS ]] || [[ -z $BACKUP_STORAGE_LOCATION_NAME ]] || [[ -z $STORAGE_BUCKET_NAME ]] || [[ -z $S3_URL ]] || [[ -z $STORAGE_SECRET_ACCESS_KEY ]] || [[ -z $STORAGE_SECRET_ACCESS_KEY_ID ]] || [[ -z $CERT_MANAGER_NAMESPACE ]] || [[ -z $LICENSING_NAMESPACE ]] || [[ -z $LSR_NAMESPACE ]] || [[ -z $CPFS_VERSION ]] || [[ -z $ZENSERVICE_NAME ]]; then
@@ -181,13 +181,13 @@ EOF
 }
 
 function install_sf_br(){
-    title "Installing Spectrum Fusion and its Backup and Restore service from catalog $CATALOG_SOURCE."
+    title "Installing Spectrum Fusion and its Backup and Restore service from catalog $FUSION_CATALOG_SOURCE."
     role=$1
     info "Cloning SF cmd-line-install repo..."
     git clone https://$GITHUB_USER:$GITHUB_TOKEN@github.ibm.com/ProjectAbell/cmd-line-install.git
     
     #TODO verify catalog source pod is actually running
-    catalog_image=$(${OC} get catalogsource -o jsonpath='{.spec.image}' $CATALOG_SOURCE -n $CAT_SRC_NS)
+    catalog_image=$(${OC} get catalogsource -o jsonpath='{.spec.image}' $FUSION_CATALOG_SOURCE -n $CAT_SRC_NS)
 
     info "executing install-isf-br.sh script with catalog image $catalog_image in namespace $SF_NAMESPACE."
     if [[ $role == "hub" ]]; then
@@ -334,7 +334,7 @@ function create_sf_resources(){
     size=$(${OC} get commonservice common-service -n $OPERATOR_NS -o jsonpath='{.spec.size}')
     sed -i -E "s/<.spec.size value from commonservice cr>/$size/" ./templates/multi-ns-recipe.yaml
     sed -i -E "s/<install mode, either Manual or Automatic>/Automatic/" ./templates/multi-ns-recipe.yaml
-    sed -i -E "s/<catalog source name>/$CATALOG_SOURCE/" ./templates/multi-ns-recipe.yaml
+    sed -i -E "s/<catalog source name>/$CS_CATALOG_SOURCE/" ./templates/multi-ns-recipe.yaml
     sed -i -E "s/<catalog source namespace>/$CAT_SRC_NS/" ./templates/multi-ns-recipe.yaml
 
     if [[ $change_ns == "true" ]]; then

--- a/velero/spectrum-fusion/recipes/4.0-4.5-example-recipe-multi-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.0-4.5-example-recipe-multi-ns.yaml
@@ -317,7 +317,7 @@ spec:
           timeout: 600
       labelSelector: foundationservices.cloudpak.ibm.com=setup-tenant-job
       name: setup-tenant-job-check
-      namespace: cs-op
+      namespace: <operator namespace>
       onError: fail
       selectResource: pod
       timeout: 600

--- a/velero/spectrum-fusion/recipes/4.0-4.5-example-recipe-multi-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.0-4.5-example-recipe-multi-ns.yaml
@@ -135,14 +135,12 @@ spec:
       type: resource
     - includedResourceTypes:
         - operandrequests.operator.ibm.com
-        - operandconfigs.operator.ibm.com
       labelSelector: foundationservices.cloudpak.ibm.com=operand
       name: odlm-resources
       type: resource
     - backupRef: odlm-resources
       includedResourceTypes:
         - operandrequests.operator.ibm.com
-        - operandconfigs.operator.ibm.com
       labelSelector: foundationservices.cloudpak.ibm.com=operand
       name: operand-resources
       restoreOverwriteResources: true

--- a/velero/spectrum-fusion/recipes/4.0-4.5-example-recipe-single-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.0-4.5-example-recipe-single-ns.yaml
@@ -113,14 +113,12 @@ spec:
       type: resource
     - includedResourceTypes:
         - operandrequests.operator.ibm.com
-        - operandconfigs.operator.ibm.com
       labelSelector: foundationservices.cloudpak.ibm.com=operand
       name: odlm-resources
       type: resource
     - backupRef: odlm-resources
       includedResourceTypes:
         - operandrequests.operator.ibm.com
-        - operandconfigs.operator.ibm.com
       labelSelector: foundationservices.cloudpak.ibm.com=operand
       name: operand-resources
       restoreOverwriteResources: true

--- a/velero/spectrum-fusion/recipes/4.7-example-recipe-multi-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.7-example-recipe-multi-ns.yaml
@@ -400,7 +400,7 @@ spec:
           timeout: 600
       labelSelector: foundationservices.cloudpak.ibm.com=setup-tenant-job
       name: setup-tenant-job-check
-      namespace: cs-op
+      namespace: <operator namespace>
       onError: fail
       selectResource: pod
       timeout: 600

--- a/velero/spectrum-fusion/recipes/4.7-example-recipe-multi-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.7-example-recipe-multi-ns.yaml
@@ -178,14 +178,12 @@ spec:
       type: resource
     - includedResourceTypes:
         - operandrequests.operator.ibm.com
-        - operandconfigs.operator.ibm.com
       labelSelector: foundationservices.cloudpak.ibm.com=operand
       name: odlm-resources
       type: resource
     - backupRef: odlm-resources
       includedResourceTypes:
         - operandrequests.operator.ibm.com
-        - operandconfigs.operator.ibm.com
       labelSelector: foundationservices.cloudpak.ibm.com=operand
       name: operand-resources
       restoreOverwriteResources: true

--- a/velero/spectrum-fusion/recipes/4.7-example-recipe-single-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.7-example-recipe-single-ns.yaml
@@ -166,14 +166,12 @@ spec:
       type: resource
     - includedResourceTypes:
         - operandrequests.operator.ibm.com
-        - operandconfigs.operator.ibm.com
       labelSelector: foundationservices.cloudpak.ibm.com=operand
       name: odlm-resources
       type: resource
     - backupRef: odlm-resources
       includedResourceTypes:
         - operandrequests.operator.ibm.com
-        - operandconfigs.operator.ibm.com
       labelSelector: foundationservices.cloudpak.ibm.com=operand
       name: operand-resources
       restoreOverwriteResources: true


### PR DESCRIPTION
**What this PR does / why we need it**:
### export variable
label-common-service.sh is using variable `TETHERED_NS`, but fusion-backup-setup.sh is using variable `TETHERED_NAMESPACE1="" TETHERED_NAMESPACE2=""`

We need to report new variable name for different script

### remove operandconfig from recipe
since we are not labeling operandconfig, we need to remove it from recipe. Otherwise recipe will fail in backup

### add fusion catalog and cs catalog in to the env var
add fusion catalog name and common-service catalog name, so we can use different catalogsource to install cs and fusion

### update recipe
update namespace in the recipe