### PR TITLE
Add new entry at the end of array to bypass ODLM limitation on object update

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -784,10 +784,10 @@ spec:
                           name: startup-volume
                         - mountPath: /mnt/trust-ca
                           name: trust-ca-volume
-                        - mountPath: /mnt/user-profile
-                          name: user-profile-volume
                         - mountPath: /opt/keycloak/providers
                           name: cs-keycloak-theme
+                        - mountPath: /mnt/user-profile
+                          name: user-profile-volume
                   volumes:
                     - name: truststore-volume
                       emptyDir:
@@ -799,15 +799,15 @@ spec:
                       configMap:
                         name: cs-keycloak-ca-certs
                         optional: true
-                    - name: user-profile-volume
-                      configMap: 
-                        name: cs-keycloak-user-profile
                     - name: cs-keycloak-theme
                       configMap:
                         items:
                           - key: cloudpak-theme.jar
                             path: cloudpak-theme.jar
                         name: cs-keycloak-theme
+                    - name: user-profile-volume
+                      configMap: 
+                        name: cs-keycloak-user-profile
                   affinity:
                     nodeAffinity:
                       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
When we wanna add the new entry in the array, it should be added at the end of array. This could avoid messing the original items in the list due to ODLM deep merge limitation.

This is the intermediate workaround to bypass the ODLM limitation in https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64707#issuecomment-91811361

The final solution will be implemented in ODLM via ticket https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64893