### PR TITLE
Revert "Bump golang from 1.23.0-bullseye to 1.23.2-bullseye"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.23.2-bullseye as builder
+FROM docker.io/golang:1.23.0-bullseye as builder
 ARG GOARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
Reverts IBM/ibm-common-service-operator#2231

The new golang image does not appear to support ppc or s390 currently