### PR TITLE
label length limited to 64 characters

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -279,10 +279,10 @@ function wait_for_certificate() {
 function wait_for_csv() {
     local namespace=$1
     local package_name=$2
-    local label="${package_name}.${namespace}"
-    local length_limited_label=$(echo ${label:0:63})
-    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_label}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}'"
-    local debug_condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_label}='' -n ${namespace} -o jsonpath='{.items[*].status.conditions}'"
+    local key="${package_name}.${namespace}"
+    local length_limited_key=$(echo ${key:0:63})
+    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_key}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}'"
+    local debug_condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_key}='' -n ${namespace} -o jsonpath='{.items[*].status.conditions}'"
     
     local retries=180
     local sleep_time=10
@@ -339,8 +339,10 @@ function wait_for_operand_request() {
 function wait_for_nss_patch() {
     local namespace=$1
     local package_name=$2
+    local key="${package_name}.${namespace}"
+    local length_limited_key=$(echo ${key:0:63})
 
-    local sub_name=$(${OC} get subscription.operators.coreos.com -n ${namespace} -l operators.coreos.com/${package_name}.${namespace}='' --no-headers | awk '{print $1}')
+    local sub_name=$(${OC} get subscription.operators.coreos.com -n ${namespace} -l operators.coreos.com/${length_limited_key}='' --no-headers | awk '{print $1}')
     local csv_name=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${namespace} --ignore-not-found -o jsonpath={.status.installedCSV})
 
     local condition="${OC} -n ${namespace} get csv ${csv_name} -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[?(@.name==\"WATCH_NAMESPACE\")].valueFrom.configMapKeyRef.name}'| grep 'namespace-scope'"
@@ -490,10 +492,11 @@ function wait_for_operator_upgrade() {
     local package_name=$2
     local channel=$3
     local install_mode=$4
-    local label="${package_name}.${namespace}"
-    local length_limited_label=$(echo ${label:0:63})
-    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_label}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w $channel"
-    local debug_condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_label}='' -n ${namespace} -o jsonpath='{.items[*].status.conditions}'"
+    local key="${package_name}.${namespace}"
+    # k8s label name length limit to 64 characters
+    local length_limited_key=$(echo ${key:0:63})
+    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_key}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w $channel"
+    local debug_condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_key}='' -n ${namespace} -o jsonpath='{.items[*].status.conditions}'"
 
     local retries=120
     local sleep_time=20
@@ -1257,8 +1260,10 @@ function update_operator() {
     local remove_opreq_label=${7:-}
     local retries=5 # Number of retries
     local delay=5 # Delay between retries in seconds
-
-    local sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${package_name}.${ns}='' --no-headers | awk '{print $1}')
+    local key="${package_name}.${ns}"
+    # k8s label name length limit to 64 characters
+    local length_limited_key=$(echo ${key:0:63})
+    local sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${length_limited_key}='' --no-headers | awk '{print $1}')
     if [ -z "$sub_name" ]; then
         warning "Not found subscription ${package_name} in ${ns}"
         return 0
@@ -1392,9 +1397,18 @@ function scale_down() {
     local services_ns=$2
     local channel=$3
     local source=$4
-    local cs_sub=$(${OC} get subscription.operators.coreos.com -n ${operator_ns} -l operators.coreos.com/ibm-common-service-operator.${operator_ns}='' --no-headers | awk '{print $1}')
+    local cs_package="ibm-common-service-operator"    
+    local cs_key="${cs_package}.${operator_ns}"
+    # k8s label name length limit to 64 characters
+    local length_limited_cs_key=$(echo ${cs_key:0:63})
+    local cs_sub=$(${OC} get subscription.operators.coreos.com -n ${operator_ns} -l operators.coreos.com/${length_limited_cs_key}='' --no-headers | awk '{print $1}')
     local cs_CSV=$(${OC} get subscription.operators.coreos.com ${cs_sub} -n ${operator_ns} --ignore-not-found -o jsonpath={.status.installedCSV})
-    local odlm_sub=$(${OC} get subscription.operators.coreos.com -n ${services_ns} -l operators.coreos.com/ibm-odlm.${services_ns}='' --no-headers | awk '{print $1}')
+
+    local odlm_package="ibm-odlm"    
+    local odlm_key="${odlm_package}.${services_ns}"
+    # k8s label name length limit to 64 characters
+    local length_limited_odlm_key=$(echo ${odlm_key:0:63})
+    local odlm_sub=$(${OC} get subscription.operators.coreos.com -n ${services_ns} -l operators.coreos.com/${length_limited_odlm_key}='' --no-headers | awk '{print $1}')
     local odlm_CSV=$(${OC} get subscription.operators.coreos.com ${odlm_sub} -n ${services_ns} --ignore-not-found -o jsonpath={.status.installedCSV})
 
     ${OC} get subscription.operators.coreos.com ${cs_sub} -n ${operator_ns} -o yaml > /tmp/sub.yaml
@@ -1481,7 +1495,9 @@ function scale_up() {
     local services_ns=$2
     local package_name=$3
     local deployment=$4
-    local sub=$(${OC} get subscription.operators.coreos.com -n ${operator_ns} -l operators.coreos.com/${package_name}.${operator_ns}='' --no-headers | awk '{print $1}')
+    local key="${package_name}.${operator_ns}"
+    local length_limited_key=$(echo ${key:0:63})
+    local sub=$(${OC} get subscription.operators.coreos.com -n ${operator_ns} -l operators.coreos.com/${length_limited_key}='' --no-headers | awk '{print $1}')
     local csv=$(${OC} get subscription.operators.coreos.com ${sub} -n ${operator_ns} --ignore-not-found -o jsonpath={.status.installedCSV})
 
     if [[ "$deployment" == "operand-deployment-lifecycle-manager" ]]; then

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -279,8 +279,10 @@ function wait_for_certificate() {
 function wait_for_csv() {
     local namespace=$1
     local package_name=$2
-    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${package_name}.${namespace}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}'"
-    local debug_condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${package_name}.${namespace}='' -n ${namespace} -o jsonpath='{.items[*].status.conditions}'"
+    local label="${package_name}.${namespace}"
+    local length_limited_label=$(echo ${label:0:63})
+    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_label}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}'"
+    local debug_condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_label}='' -n ${namespace} -o jsonpath='{.items[*].status.conditions}'"
     
     local retries=180
     local sleep_time=10
@@ -488,8 +490,10 @@ function wait_for_operator_upgrade() {
     local package_name=$2
     local channel=$3
     local install_mode=$4
-    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${package_name}.${namespace}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w $channel"
-    local debug_condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${package_name}.${namespace}='' -n ${namespace} -o jsonpath='{.items[*].status.conditions}'"
+    local label="${package_name}.${namespace}"
+    local length_limited_label=$(echo ${label:0:63})
+    local condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_label}='' -n ${namespace} -o yaml -o jsonpath='{.items[*].status.installedCSV}' | grep -w $channel"
+    local debug_condition="${OC} get subscription.operators.coreos.com -l operators.coreos.com/${length_limited_label}='' -n ${namespace} -o jsonpath='{.items[*].status.conditions}'"
 
     local retries=120
     local sleep_time=20

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -636,7 +636,9 @@ function install_cs_operator() {
     else
         for ns in ${ns_list//,/ }; do
             if [[ "$ns" != "$OPERATOR_NS" ]]; then
-                local sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${pm}.${ns}='' --no-headers | awk '{print $1}')
+                local key="${pm}.${ns}"
+                local length_limited_key=$(echo ${key:0:63})
+                local sub_name=$(${OC} get subscription.operators.coreos.com -n ${ns} -l operators.coreos.com/${length_limited_key}='' --no-headers | awk '{print $1}')
                 if [ ! -z "$sub_name" ]; then
                     op_source=$SOURCE
                     op_source_ns=$SOURCE_NS
@@ -787,7 +789,10 @@ EOF
 function upgrade_mitigation() {
     # When it is upgrade scenario, and it is complex toppology, then do the mitigation
     if [[ $IS_UPGRADE -eq 1 && $IS_NOT_COMPLEX_TOPOLOGY -eq 0 ]]; then
-        local sub_name=$(${OC} get subscription.operators.coreos.com -n ${OPERATOR_NS} -l operators.coreos.com/ibm-common-service-operator.${OPERATOR_NS}='' --no-headers | awk '{print $1}')
+        local package_name="ibm-common-service-operator"
+        local key="${package_name}.${OPERATOR_NS}"
+        local length_limited_key=$(echo ${key:0:63})
+        local sub_name=$(${OC} get subscription.operators.coreos.com -n ${OPERATOR_NS} -l operators.coreos.com/${length_limited_key}='' --no-headers | awk '{print $1}')
         local csv_name=$(${OC} get subscription.operators.coreos.com ${sub_name} -n ${OPERATOR_NS} --ignore-not-found -o jsonpath={.status.installedCSV})
         if [[ ! -z ${csv_name} ]]; then
             local csv_deleted=$(${OC} get csv -n ${OPERATOR_NS} --ignore-not-found -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep ibm-common-service-operator | grep -v ${csv_name})


### PR DESCRIPTION
**What this PR does / why we need it**:
 k8s label name length limit to 64 characters, so olm will cut off any label longer than 64 characters
 We rely on label to find csv and subscription, so we also need to cut of the label if it is longer than 64 characters.
**Which issue(s) this PR fixes**:
script enhancement for # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64378
(will open pr for odlm and nss operator) 
