### PR TITLE
Correct permissions and nss cm namespace in labeling script

### DIFF
--- a/velero/backup/common-service/label-bedrock-role.yaml
+++ b/velero/backup/common-service/label-bedrock-role.yaml
@@ -16,7 +16,8 @@ rules:
       - policy
       - zen.cpd.ibm.com
       - operators.coreos.com
-      - operator.ibm.com 
+      - operator.ibm.com
+      - rbac.authorization.k8s.io 
     resources:
       - namespaces
       - zenservices
@@ -28,8 +29,8 @@ rules:
       - secrets
       - commonservices
       - namespacescopes
-      - role
-      - rolebinding
+      - roles
+      - rolebindings
       - serviceaccount
       #not necessary for cpd
       #- ibmlicenseservicereporters.operator.ibm.com

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -372,7 +372,7 @@ function label_nss(){
     ${OC} label role nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
     ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
     ${OC} label rolebinding nss-managed-role-from-$OPERATOR_NS foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
-    ${OC} label configmap namespace-scope foundationservices.cloudpak.ibm.com=nss -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ${OC} label configmap namespace-scope foundationservices.cloudpak.ibm.com=nss -n $OPERATOR_NS --overwrite=true 2>/dev/null
     if [[ $TETHERED_NS != "" ]]; then
         for namespace in ${TETHERED_NS//,/ }
         do


### PR DESCRIPTION
**What this PR does / why we need it**: The label-common-service script currently looks for the namespacescope configmap in the services namespace instead of the operator namespace where it will always live. Also updated the role for the label job to specify rbac resources.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/PrivateCloud-analytics/Zen/issues/38771#issuecomment-93472154

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action