### PR TITLE
Revert "Bump golang from 1.23.0-bullseye to 1.23.1-bullseye"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/golang:1.23.1-bullseye as builder
+FROM docker.io/golang:1.23.0-bullseye as builder
 ARG GOARCH
 
 WORKDIR /workspace


### PR DESCRIPTION
Reverts IBM/ibm-common-service-operator#2183

Looks like this build worked 2 weeks ago, but there is no ppc or s390 1.23.1-bullseye image now so builds are failing after the version bump.  Reverting this temporarily until we can switch to bookworm.