### PR TITLE
added configuration for instana metrics collection

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -119,6 +119,8 @@ type CommonServiceSpec struct {
 	OperatorConfigs []OperatorConfig `json:"operatorConfigs,omitempty"`
 	// +optional
 	License LicenseList `json:"license"`
+	// +optional
+	EnableInstanaMetricCollection bool `json:"enableInstanaMetricCollection,omitempty"`
 }
 
 // OperatorConfig is configuration composed of key-value pairs to be injected into specified CSVs

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-09-09T21:00:30Z"
+    createdAt: "2024-10-04T20:02:10Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""

--- a/bundle/manifests/operator.ibm.com_commonservices.yaml
+++ b/bundle/manifests/operator.ibm.com_commonservices.yaml
@@ -71,6 +71,8 @@ spec:
                   DefalutAdminUser is the name of the default admin user for foundational
                   services IM, default is cpadmin
                 type: string
+              enableInstanaMetricCollection:
+                type: boolean
               features:
                 description: Features defines the configurations of Cloud Pak Services
                 properties:

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -68,6 +68,8 @@ spec:
                   DefalutAdminUser is the name of the default admin user for foundational
                   services IM, default is cpadmin
                 type: string
+              enableInstanaMetricCollection:
+                type: boolean
               features:
                 description: Features defines the configurations of Cloud Pak Services
                 properties:

--- a/controllers/constant/instanaEnable.go
+++ b/controllers/constant/instanaEnable.go
@@ -1,0 +1,28 @@
+//
+// Copyright 2024 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package constant
+
+const InstanaEnableTemplate = `
+- name: ibm-im-operator
+  spec:
+    authentication:
+      enableInstanaMetricCollection: {{ .InstanaEnable }}
+- name: ibm-idp-config-ui-operator
+  spec:
+    commonWebUI:
+      enableInstanaMetricCollection: {{ .InstanaEnable }}
+`


### PR DESCRIPTION
# How to test

1. Install cs-operator
2. Update image on cluster with changes from this PR
3. Update CRD on cluster with changes from this PR
4. Update CommonService CR with `enableInstanaMetricCollection: true`
5. Verify that setting propagates to OperandConfig for IM and UI