### PR TITLE
conditionally wait for ibm-licensing-instance

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -494,7 +494,8 @@ function wait_for_licensing_instance_deployment() {
         if [ -z "$ns" ]; then
             info "RETRYING: Waiting for Deployment ibm-licensing-service-instance to be ready (${retries} left)"
         else
-          break
+            info "Found licensing instance"
+            break
         fi
 
         ((retries--))

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -231,7 +231,15 @@ function is_migrate_licensing() {
     fi
 
     title "Check migrating LTSR ibm-licensing-operator"
-    wait_for_licensing_instance_deployment
+    # wait for ibm-licensing-operator instance 
+    local licensing_operator_exist=$("$OC" get clusterserviceversion.operators.coreos.com -A | (grep ibm-licensing-operator || echo "fail"))
+    if [[ $licensing_operator_exist != "fail" ]]; then
+        wait_for_licensing_instance_deployment
+    else
+        info "No ibm-licensing-operator found, skipping"
+        return 0
+    fi
+
     local ns=$("$OC" get deployments -A | grep ibm-licensing-service-instance | cut -d ' ' -f1)
     if [ -z "$ns" ]; then
         info "No LTSR ibm-licensing-operator to migrate, skipping"

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -232,7 +232,7 @@ function is_migrate_licensing() {
 
     title "Check migrating LTSR ibm-licensing-operator"
     # wait for ibm-licensing-operator instance 
-    local licensing_operator_exist=$("$OC" get clusterserviceversion.operators.coreos.com -A | (grep ibm-licensing-operator || echo "fail"))
+    local licensing_operator_exist=$("$OC" get deployment -A | (grep ibm-licensing-operator || echo "fail"))  
     if [[ $licensing_operator_exist != "fail" ]]; then
         wait_for_licensing_instance_deployment
     else

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -236,12 +236,6 @@ function is_migrate_licensing() {
     if [[ $licensing_operator_exist != "fail" ]]; then
         wait_for_licensing_instance_deployment
     else
-        info "No ibm-licensing-operator found, skipping"
-        return 0
-    fi
-
-    local ns=$("$OC" get deployments -A | grep ibm-licensing-service-instance | cut -d ' ' -f1)
-    if [ -z "$ns" ]; then
         info "No LTSR ibm-licensing-operator to migrate, skipping"
         return 0
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:
We should only wait for ibm-licensing-instance when ibm-licensing operator is found, it could help to reducing the waiting time.