### PR TITLE
Use 2 replicas for Keycloak EDB on starterset

### DIFF
--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -897,7 +897,7 @@ const StarterSet = `
     name: keycloak-edb-cluster
     data:
       spec:
-        instances: 1
+        instances: 2
         resources:
           limits:
             cpu: 200m

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -897,7 +897,7 @@ const StarterSet = `
     name: keycloak-edb-cluster
     data:
       spec:
-        instances: 1
+        instances: 2
         resources:
           limits:
             cpu: 200m

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -899,7 +899,7 @@ const StarterSet = `
     name: keycloak-edb-cluster
     data:
       spec:
-        instances: 1
+        instances: 2
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
**What this PR does / why we need it**:

Using one replica prevents cluster upgrade due to the pod disruption budget, so set the default to use two.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65103

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action