### PR TITLE
Use 2 replicas for Keycloak EDB on starterset (#2256)

### DIFF
--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -845,7 +845,7 @@ const StarterSet = `
     name: keycloak-edb-cluster
     data:
       spec:
-        instances: 1
+        instances: 2
         resources:
           limits:
             cpu: 200m

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -845,7 +845,7 @@ const StarterSet = `
     name: keycloak-edb-cluster
     data:
       spec:
-        instances: 1
+        instances: 2
         resources:
           limits:
             cpu: 200m

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -847,7 +847,7 @@ const StarterSet = `
     name: keycloak-edb-cluster
     data:
       spec:
-        instances: 1
+        instances: 2
         resources:
           limits:
             cpu: 200m


### PR DESCRIPTION
Using one replica prevents cluster upgrade due to the pod disruption budget, so set the default to use two.
cherry pick of #2256 