### PR TITLE
remove velero addon and cold backup annotations

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1417,8 +1417,6 @@ spec:
         name: common-service-db          
         force: true
         annotations:
-          k8s.enterprisedb.io/addons: '["velero"]'
-          k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled
           productID: 068a62892a1e4db39641342e592daa25
           productMetric: FREE
           productName: IBM Cloud Platform Common Services


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert the changes to add the velero addon annotation and its required accompanying annotation `k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled` since we have never adopted its use in BR and it is causing problems with CPD BR process.

Originally, this was implemented because this addon method is what is officially supported by EDB and the CPD team is able to overwrite it with their own addon (external-backup-adapter). However, the `k8s.enterprisedb.io/snapshotAllowColdBackupOnPrimary: enabled` annotation is not overwritten and there is an edge case defined in the linked issue where this label is problematic. Since we do not use these sets of annotations, I believe it best to go ahead and remove them for the 4.10 release.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/31335

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action