### PR TITLE
Add support for Keycloak 24/re-encrypt Route

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -875,6 +875,8 @@ spec:
       - apiVersion: k8s.keycloak.org/v2alpha1
         data:
           spec:
+            proxy:
+              headers: xforwarded
             features:
               enabled:
                 - token-exchange


### PR DESCRIPTION
**What this PR does / why we need it**:

In Keycloak 24, when it is behind re-encrypt Route, any incoming http requests fail with http/500, with NPE exception saying http Host header is missing. Seems the fix is to add the proxy headers setting to parse `x-forwarded` http header.

**Which issue(s) this PR fixes**:
Fixes  https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65100 and https://github.com/keycloak/keycloak/issues/33988

**Special notes for your reviewer**:

1. How the test is done?

Do fresh deploy of Keycloak 24 on ROSA cluster. Check Route `keycloak` created works fine and renders Keycloak Admin UI