### PR TITLE
[SC2] Add support for Keycloak 24/re-encrypt Route (#2261)

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -739,6 +739,8 @@ spec:
       - apiVersion: k8s.keycloak.org/v2alpha1
         data:
           spec:
+            proxy:
+              headers: xforwarded
             features:
               enabled:
                 - token-exchange


### PR DESCRIPTION
cherry-pick of https://github.com/IBM/ibm-common-service-operator/pull/2261 to fix issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65100