### PR TITLE
label-length-limitation

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1916,9 +1916,10 @@ func (b *Bootstrap) checkOperatorCSV(packageManifest, operatorNs string) (bool, 
 	// List the subscription by packageManifest and operatorNs
 	// The subscription contain label "operators.coreos.com/<packageManifest>.<operatorNs>: ''"
 	subList := &olmv1alpha1.SubscriptionList{}
+	labelKey := util.GetFirstNCharacter(packageManifest+"."+operatorNs, 63)
 	if err := b.Client.List(context.TODO(), subList, &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(labels.Set{
-			"operators.coreos.com/" + packageManifest + "." + operatorNs: "",
+			"operators.coreos.com/" + labelKey: "",
 		}),
 		Namespace: operatorNs,
 	}); err != nil {

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -871,3 +871,10 @@ func SanitizeData(data interface{}, valueType string, isEmpty bool) interface{} 
 		return nil
 	}
 }
+
+func GetFirstNCharacter(str string, n int) string {
+	if n >= len(str) {
+		return str
+	}
+	return str[:n]
+}


### PR DESCRIPTION
What this PR does / why we need it:
k8s label name length limit to 64 characters, so olm will cut off any label longer than 64 characters
We rely on label to find csv and subscription, so we also need to cut of the label if it is longer than 64 characters.
Which issue(s) this PR fixes:
enhancement for # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64378