### PR TITLE
[CD] new entry for event-v5.1

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1758,6 +1758,12 @@ spec:
     packageName: ibm-events-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+  - channel: v5.1
+    name: ibm-events-operator-v5.1
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-events-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
     channel: v6.1


### PR DESCRIPTION
**What this PR does / why we need it**:
add new entry for ibm-events-operator-v5.1
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65011
