### PR TITLE
Clean up v3 leftover resources

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-10-31T03:02:18Z"
+    createdAt: "2024-10-31T04:39:08Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -310,22 +310,10 @@ spec:
               verbs:
                 - get
             - apiGroups:
-                - ""
-              resources:
-                - serviceaccounts
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
                 - rbac.authorization.k8s.io
               resources:
-                - rolebindings
-                - roles
+                - clusterrolebindings
+                - clusterroles
               verbs:
                 - create
                 - delete
@@ -579,6 +567,39 @@ spec:
                 - elasticstacks
               verbs:
                 - delete
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.ibm.com
+              resources:
+                - podpresets
+              verbs:
+                - get
+                - delete
+                - list
           serviceAccountName: ibm-common-service-operator
     strategy: deployment
   installModes:

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-10-31T04:39:08Z"
+    createdAt: "2024-10-31T05:22:07Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -466,6 +466,7 @@ spec:
                 - statefulsets
                 - daemonsets
               verbs:
+                - delete
                 - get
                 - list
                 - patch
@@ -600,6 +601,18 @@ spec:
                 - get
                 - delete
                 - list
+            - apiGroups:
+                - ibmcpcs.ibm.com
+              resources:
+                - secretshares
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
           serviceAccountName: ibm-common-service-operator
     strategy: deployment
   installModes:

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2024-10-04T20:02:10Z"
+    createdAt: "2024-10-31T03:02:18Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -309,6 +309,31 @@ spec:
                 - infrastructures
               verbs:
                 - get
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
           serviceAccountName: ibm-common-service-operator
       deployments:
         - label:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -121,6 +121,7 @@ rules:
   - statefulsets
   - daemonsets
   verbs:
+  - delete
   - get
   - list
   - patch
@@ -225,7 +226,7 @@ rules:
   - elasticstacks
   verbs:
   - delete
-# Delete ServiceAccount, RoleBinding, Role
+# Delete ServiceAccount, RoleBinding, Role, secretshares
 - apiGroups:
   - ""
   resources:
@@ -259,3 +260,15 @@ rules:
   - list
   resources:
   - podpresets
+- apiGroups:
+  - ibmcpcs.ibm.com
+  resources:
+  - secretshares
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,6 +66,32 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+# Delete ServiceAccount, RoleBinding, Role
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,24 +66,11 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
-# Delete ServiceAccount, RoleBinding, Role
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-  - rolebindings
-  - roles
+  - clusterrolebindings
+  - clusterroles
   verbs:
   - create
   - delete
@@ -238,3 +225,37 @@ rules:
   - elasticstacks
   verbs:
   - delete
+# Delete ServiceAccount, RoleBinding, Role
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  verbs:
+  - get
+  - delete
+  - list
+  resources:
+  - podpresets

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -894,22 +894,22 @@ func (b *Bootstrap) DeleteV3Resources(mutatingWebhooks, validatingWebhooks, dele
 
 	// Delete the deployments of webhook and secretshare
 	for _, resource := range deleteDeployments {
-		deployKey := types.NamespacedName{Name: resource, Namespace: constant.MasterNamespace}
+		deployKey := types.NamespacedName{Name: resource, Namespace: b.CSData.ServicesNs}
 		deployment := &appsv1.Deployment{}
 		if err := b.Client.Get(ctx, deployKey, deployment); err != nil {
 			if !errors.IsNotFound(err) {
 				return err
 			} else {
-				klog.Infof("Deployment %s/%s not found, skipping...", constant.MasterNamespace, resource)
+				klog.Infof("Deployment %s/%s not found, skipping...", b.CSData.ServicesNs, resource)
 				continue
 			}
 		}
 
 		if err := b.Client.Delete(ctx, deployment); err != nil {
-			klog.Errorf("Failed to delete Deployment %s/%s: %v", constant.MasterNamespace, resource, err)
+			klog.Errorf("Failed to delete Deployment %s/%s: %v", b.CSData.ServicesNs, resource, err)
 			return err
 		}
-		klog.Infof("Successfully deleted Deployment %s/%s", constant.MasterNamespace, resource)
+		klog.Infof("Successfully deleted Deployment %s/%s", b.CSData.ServicesNs, resource)
 	}
 	return nil
 }

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -1270,7 +1270,7 @@ func (b *Bootstrap) IsBYOCert() (bool, error) {
 		client.MatchingLabels(
 			map[string]string{"app.kubernetes.io/instance": "cs-ca-certificate"}),
 	}
-	if certerr := b.Reader.List(ctx, certList, opts...); err != nil {
+	if certerr := b.Reader.List(ctx, certList, opts...); certerr != nil {
 		return false, certerr
 	}
 
@@ -1416,9 +1416,9 @@ func (b *Bootstrap) CleanNamespaceScopeResources() error {
 	if isOpregAPI, err := b.CheckCRD(constant.OpregAPIGroupVersion, constant.OpregKind); err != nil {
 		klog.Errorf("Failed to check if %s CRD exists: %v", constant.OpregKind, err)
 		return err
-	} else if !isOpregAPI && err == nil {
+	} else if !isOpregAPI {
 		klog.Infof("%s CRD does not exist, skip checking no-op installMode", constant.OpregKind)
-	} else if isOpregAPI && err == nil {
+	} else if isOpregAPI {
 		// Get the common-service OperandRegistry
 		operandRegistry, err := b.GetOperandRegistry(ctx, constant.MasterCR, b.CSData.ServicesNs)
 		if err != nil {

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -909,7 +909,7 @@ func (b *Bootstrap) deleteWebhookResources() error {
 		return err
 	}
 
-	if err := b.deleteResource(&rbacv1.ClusterRoleBinding{}, "ibm-common-service-webhook-placeholder", "", "ClusterRoleBinding"); err != nil {
+	if err := b.deleteResource(&rbacv1.ClusterRoleBinding{}, "ibm-common-service-webhook-"+b.CSData.ServicesNs, "", "ClusterRoleBinding"); err != nil {
 		return err
 	}
 
@@ -932,7 +932,7 @@ func (b *Bootstrap) deleteSecretShareResources() error {
 		return err
 	}
 
-	if err := b.deleteResource(&rbacv1.ClusterRoleBinding{}, "secretshare-placeholder", "", "ClusterRoleBinding"); err != nil {
+	if err := b.deleteResource(&rbacv1.ClusterRoleBinding{}, "secretshare-"+b.CSData.ServicesNs, "", "ClusterRoleBinding"); err != nil {
 		return err
 	}
 

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -104,6 +104,10 @@ const (
 	OpconKind = "OperandConfig"
 	// DefaultHugePageAllocation is the default huge page allocation
 	DefaultHugePageAllocation = "100Mi"
+	// WebhookServiceName is the name of the webhook service used for v3 operator
+	WebhookServiceName = "ibm-common-service-webhook"
+	// Secretshare is the name of the secretshare
+	Secretshare = "secretshare"
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -108,6 +108,10 @@ const (
 	WebhookServiceName = "ibm-common-service-webhook"
 	// Secretshare is the name of the secretshare
 	Secretshare = "secretshare"
+	// Some WebhookConfigurations
+	CSWebhookConfig = "ibm-common-service-webhook-configuration"
+	OperanReqConfig = "ibm-operandrequest-webhook-configuration"
+	CSMappingConfig = "ibm-cs-ns-mapping-webhook-configuration"
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/main.go
+++ b/main.go
@@ -24,7 +24,10 @@ import (
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	admv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -66,6 +69,9 @@ func init() {
 	utilruntime.Must(nssv1.AddToScheme(scheme))
 	utilruntime.Must(ssv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv3.AddToScheme(scheme))
+	utilruntime.Must(appsv1.AddToScheme(scheme))
+	utilruntime.Must(rbacv1.AddToScheme(scheme))
+	utilruntime.Must(admv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 
 	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))

--- a/main.go
+++ b/main.go
@@ -25,9 +25,7 @@ import (
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	admv1 "k8s.io/api/admissionregistration/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -69,8 +67,6 @@ func init() {
 	utilruntime.Must(nssv1.AddToScheme(scheme))
 	utilruntime.Must(ssv1.AddToScheme(scheme))
 	utilruntime.Must(operatorv3.AddToScheme(scheme))
-	utilruntime.Must(appsv1.AddToScheme(scheme))
-	utilruntime.Must(rbacv1.AddToScheme(scheme))
 	utilruntime.Must(admv1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64483

Clean up unused resources when upgrading from the v3 operator:

-  MutatingWebhookConfiguration ibm-common-service-webhook-configuration
-  MutatingWebhookConfiguration ibm-operandrequest-webhook-configuration
- ValidatingWebhookConfiguration ibm-cs-ns-mapping-webhook-configuration 
- secretshare in all namespaces
- podpresets.operator.ibm.com in all namespaces
- deployment ibm-common-service-webhook in ibm-common-services 
- deployment secretshare in ibm-common-services

test image: quay.io/yuchen_shen/cs_operator:cleanv3

