### PR TITLE
[SC2] add opreq-control label for EDB License Job

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -950,6 +950,8 @@ spec:
         force: true
         name: create-postgres-license-config
         namespace: "{{ .OperatorNs }}"
+        labels:
+          operator.ibm.com/opreq-control: 'true'
         data:
           spec:
             activeDeadlineSeconds: 600
@@ -1834,6 +1836,8 @@ spec:
         kind: Job
         name: create-postgres-license-config
         namespace: "{{ .OperatorNs }}"
+        labels:
+          operator.ibm.com/opreq-control: 'true'
         data:
           spec:
             activeDeadlineSeconds: 600
@@ -1974,6 +1978,8 @@ spec:
         kind: Job
         name: create-postgres-license-config
         namespace: "{{ .OperatorNs }}"
+        labels:
+          operator.ibm.com/opreq-control: 'true'
         data:
           spec:
             activeDeadlineSeconds: 600


### PR DESCRIPTION
**What this PR does / why we need it**:
During the upgrade, ODLM should be able to reclaim the ownership of EDB License Job `create-postgres-license-config` when the label `opreq-control` is explicitly specified in OperandConfig template

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64885#issuecomment-91863036

