### PR TITLE
[scripts dev] change when the database dir cleanup takes place

### DIFF
--- a/velero/schedule/common-service-db/cs-db-backup-deployment.yaml
+++ b/velero/schedule/common-service-db/cs-db-backup-deployment.yaml
@@ -13,9 +13,8 @@ spec:
     metadata:
       annotations:
         backup.velero.io/backup-volumes: cs-db-backup
-        pre.hook.backup.velero.io/command: '["sh", "-c", "/cs-db/br_cs-db.sh backup <cs-db namespace>"]'
+        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /cs-db/cs-db-backup/database; /cs-db/br_cs-db.sh backup <cs-db namespace>"]'
         pre.hook.backup.velero.io/timeout: 300s
-        post.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /cs-db/cs-db-backup/database"]'
         post.hook.restore.velero.io/command: '["sh", "-c", "/cs-db/br_cs-db.sh restore <cs-db namespace>"]'
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s


### PR DESCRIPTION
**What this PR does / why we need it**: Ran into a problem when working with CP4BA testing where the database dir and its contents were not carried over from backup cluster to restore cluster. After some trial and error, the necessary files were copied over after removing the line where the database dir was removed as part of the backup posthook. We need the dir to be gone for the script to run smoothly but we can remove it at the beginning of a run instead of at the end to side step this problem where the dir is never present after restore. 

What makes this test weird is I am not sure I have ever seen this be a problem, we have had this pre/posthook setup since we started BR'ing EDB. But this change should be more consistent and it matches what we do with zen so I think it's worth making.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65149

**Special notes for your reviewer**:

1. How the test is done?
- Setup backup cluster with CS DB
- verify backup completes successfully
- setup restore cluster
- restore csdb
- verify database dir is present in restored cs-db-backup pod as expected

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
3. The PR will be automatically created in the target branch after merging this PR
4. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action