### PR TITLE
Add meta api deployment in zen/platformUI entries

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -572,21 +572,69 @@ metadata:
 spec:
   services:
   - name: ibm-platformui-operator-v4.0
+    resources:
+      - apiVersion: apps/v1
+        force: true
+        kind: Deployment
+        labels:
+          operator.ibm.com/opreq-control: 'true'
+        name: meta-api-deploy
+        namespace: {{ .OperatorNs }}
     spec:
       operandBindInfo: {}
   - name: ibm-platformui-operator-v4.1
+    resources:
+      - apiVersion: apps/v1
+        force: true
+        kind: Deployment
+        labels:
+          operator.ibm.com/opreq-control: 'true'
+        name: meta-api-deploy
+        namespace: {{ .OperatorNs }}
     spec:
       operandBindInfo: {}
   - name: ibm-platformui-operator-v4.2
+    resources:
+      - apiVersion: apps/v1
+        force: true
+        kind: Deployment
+        labels:
+          operator.ibm.com/opreq-control: 'true'
+        name: meta-api-deploy
+        namespace: {{ .OperatorNs }}
     spec:
       operandBindInfo: {}
   - name: ibm-platformui-operator-v4.3
+    resources:
+      - apiVersion: apps/v1
+        force: true
+        kind: Deployment
+        labels:
+          operator.ibm.com/opreq-control: 'true'
+        name: meta-api-deploy
+        namespace: {{ .OperatorNs }}
     spec:
       operandBindInfo: {}
   - name: ibm-platformui-operator-v4.4
+    resources:
+      - apiVersion: apps/v1
+        force: true
+        kind: Deployment
+        labels:
+          operator.ibm.com/opreq-control: 'true'
+        name: meta-api-deploy
+        namespace: {{ .OperatorNs }}
     spec:
       operandBindInfo: {}
   - name: ibm-platformui-operator-v6.0
+    resources:
+      - apiVersion: apps/v1
+        force: true
+        kind: Deployment
+        labels:
+          operator.ibm.com/opreq-control: 'true'
+        name: meta-api-deploy
+        namespace: {{ .OperatorNs }}
     spec:
       operandBindInfo: {}
   - name: ibm-platformui-operator-v6.1
@@ -2309,6 +2357,14 @@ spec:
               - name: ibm-im-operator
             registry: common-service
   - name: ibm-zen-operator
+    resources:
+      - apiVersion: apps/v1
+        force: true
+        kind: Deployment
+        labels:
+          operator.ibm.com/opreq-control: 'true'
+        name: meta-api-deploy
+        namespace: {{ .OperatorNs }}
     spec:
       operandBindInfo: {}
   - name: ibm-platformui-operator


### PR DESCRIPTION
**What this PR does / why we need it**: 
Added zen deployment `meta-api-deploy` with label `operator.ibm.com/opreq-control: 'true'` into each zen/platformui operator entry in OperandConfig so that ODLM can delete this specific deployment when the Zen/Platform operator is removed.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64488

**How to test**:

1. test image: quay.io/yuchen_shen/cs_operator:cleanzen
2. test step could refer to:  https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1095
