### PR TITLE
Update ODLM CRs after ODLM is upgraded to desired version

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -256,7 +256,7 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 		return err
 	}
 	// Reinstall/update OperandRegistry and OperandConfig if not installed/updated in the previous step
-	if !existOpreg || !existOpcon {
+	if !existOpreg || !existOpcon || forceUpdateODLMCRs {
 
 		// Set "Pending" condition when creating OperandRegistry and OperandConfig
 		instance.SetPendingCondition(constant.MasterCR, apiv3.ConditionTypePending, corev1.ConditionTrue, apiv3.ConditionReasonInit, apiv3.ConditionMessageInit)

--- a/controllers/bootstrap/init_test.go
+++ b/controllers/bootstrap/init_test.go
@@ -78,11 +78,11 @@ func TestCheckOperatorCSV(t *testing.T) {
 	}
 
 	// Test case 1: Single subscription found with valid semver
-	result, err := bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	result, err := bootstrap.checkOperatorCSV("subscription-1", packageManifest, operatorNs)
 	assert.True(t, result)
 	assert.NoError(t, err)
 
-	// Test case 2: Multiple subscriptions found
+	// Test case 2: Multiple subscriptions found and not subscription name matched
 	err = fakeClient.Create(context.TODO(), &olmv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "subscription-2",
@@ -100,7 +100,7 @@ func TestCheckOperatorCSV(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	result, err = bootstrap.checkOperatorCSV("subscription-non-match", packageManifest, operatorNs)
 	assert.False(t, result)
 	assert.EqualError(t, err, fmt.Sprintf("multiple subscriptions found by packageManifest %s and operatorNs %s", packageManifest, operatorNs))
 
@@ -117,7 +117,7 @@ func TestCheckOperatorCSV(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	result, err = bootstrap.checkOperatorCSV("subscription-1", packageManifest, operatorNs)
 	assert.False(t, result)
 	assert.EqualError(t, err, fmt.Sprintf("no subscription found by packageManifest %s and operatorNs %s", packageManifest, operatorNs))
 
@@ -139,7 +139,7 @@ func TestCheckOperatorCSV(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	result, err = bootstrap.checkOperatorCSV("subscription-3", packageManifest, operatorNs)
 	assert.False(t, result)
 	assert.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestCheckOperatorCSV(t *testing.T) {
 	err = fakeClient.Update(context.TODO(), subscription)
 	assert.NoError(t, err)
 
-	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	result, err = bootstrap.checkOperatorCSV("subscription-3", packageManifest, operatorNs)
 	assert.True(t, result)
 	assert.NoError(t, err)
 
@@ -167,7 +167,7 @@ func TestCheckOperatorCSV(t *testing.T) {
 	err = fakeClient.Update(context.TODO(), subscription)
 	assert.NoError(t, err)
 
-	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	result, err = bootstrap.checkOperatorCSV("subscription-3", packageManifest, operatorNs)
 	assert.False(t, result)
 	assert.NoError(t, err)
 
@@ -181,7 +181,7 @@ func TestCheckOperatorCSV(t *testing.T) {
 	err = fakeClient.Update(context.TODO(), subscription)
 	assert.NoError(t, err)
 
-	result, err = bootstrap.checkOperatorCSV(packageManifest, operatorNs)
+	result, err = bootstrap.checkOperatorCSV("subscription-3", packageManifest, operatorNs)
 	assert.True(t, result)
 	assert.NoError(t, err)
 
@@ -232,12 +232,12 @@ func TestWaitOperatorCSV(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	isWaiting, err := bootstrap.waitOperatorCSV(packageManifest, operatorNs)
+	isWaiting, err := bootstrap.waitOperatorCSV("subscription-1", packageManifest, operatorNs)
 	assert.True(t, isWaiting)
 	assert.NoError(t, err)
 
 	// Test case 2: Operator CSV is already installed
-	isWaiting, err = bootstrap.waitOperatorCSV(packageManifest, operatorNs)
+	isWaiting, err = bootstrap.waitOperatorCSV("subscription-1", packageManifest, operatorNs)
 	assert.False(t, isWaiting)
 	assert.NoError(t, err)
 }

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -77,7 +77,7 @@ func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.ReconcileNonConfigurableCR(ctx, instance)
 	}
 
-	if err := r.Bootstrap.Client.Get(ctx, req.NamespacedName, instance); err != nil {
+	if err := r.Reader.Get(ctx, req.NamespacedName, instance); err != nil {
 		if errors.IsNotFound(err) {
 			if err := r.handleDelete(ctx); err != nil {
 				return ctrl.Result{}, err


### PR DESCRIPTION
**What this PR does / why we need it**:
CS operator should wait ODLM to be upgraded, which will bring new schema for the ODLM CRDs before CS operator apply the latest OperandRegistry and OperandConfig CRs. Otherwise, it is possible that new field in ODLM CRs is pruned by old CRDs.

1. After ODLM is upgraded to desired version via `waitOperatorCSV` func, the OperandRegistry and OperandConfig will be refreshed.
2. Improve function `waitOperatorCSV` to get the subscription by name first, because there is a chance that the label added by OLM is not immediately available.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65138

### Issue reproduced
1. Install Dev build of CPFS
2. Observe the logs that it does not refresh OperandRegistry and OperandConfig after waiting for ODLM to be ready
```
I1030 15:14:15.251426 1 init.go:211] Checking if OperandRegistry and OperandConfig CRD already exist
I1030 15:14:16.851878 1 request.go:601] Waited for 1.595369734s due to client-side throttling, not priority and fairness, request: GET:[https://172.30.0.1:443/apis/monitoring.coreos.com/v1beta1?timeout=32s](https://172.30.0.1/apis/monitoring.coreos.com/v1beta1?timeout=32s)
I1030 15:14:20.856764 1 init.go:218] Checking OperandRegistry and OperandConfig deployment status
I1030 15:14:23.770390 1 init.go:228] Installing/Updating OperandRegistry
I1030 15:14:24.286940 1 init.go:233] Installing/Updating OperandConfig
I1030 15:14:24.317649 1 init.go:239] Installing ODLM Operator
I1030 15:14:24.321856 1 init.go:491] Fetch Subscription: openshift-operators/operand-deployment-lifecycle-manager-app
I1030 15:14:24.325400 1 init.go:244] Waiting for ODLM Operator to be ready
I1030 15:14:24.325415 1 init.go:1899] Waiting for the operator CSV with packageManifest ibm-odlm in namespace openshift-operators to be installed
I1030 15:14:26.875989 1 request.go:601] Waited for 2.547536227s due to client-side throttling, not priority and fairness, request: GET:[https://172.30.0.1:443/apis/infrastructure.cluster.x-k8s.io/v1beta1?timeout=32s](https://172.30.0.1/apis/infrastructure.cluster.x-k8s.io/v1beta1?timeout=32s)
I1030 15:14:29.929772 1 init.go:1160] Checking if resource Issuer CRD exsits
I1030 15:14:32.731539 1 init.go:1168] Skiped deploying Issuer, it is not exist in cluster
```

### Test with fix applied
4. Delete default generated ODLM CRs and ODLM operators for the above build
5. Replace CS operator image to `quay.io/daniel_fan/common-service-operator-amd64:dev` and change ImagePullPolicy to `Always
6. The CS operator pod will be automatically re-generated
7. Observe the logs that it refreshes OperandRegistry and OperandConfig after waiting for ODLM to be ready
```
I1030 19:35:16.038130 1 init.go:211] Checking if OperandRegistry and OperandConfig CRD already exist
I1030 19:35:21.643753 1 init.go:218] Checking OperandRegistry and OperandConfig deployment status
I1030 19:35:21.649772 1 init.go:228] Installing/Updating OperandRegistry
I1030 19:35:21.679304 1 init.go:233] Installing/Updating OperandConfig
I1030 19:35:21.769949 1 init.go:239] Installing ODLM Operator
I1030 19:35:21.778758 1 init.go:244] Waiting for ODLM Operator to be ready
I1030 19:35:21.778781 1 init.go:1899] Waiting for the operator CSV with packageManifest ibm-odlm in namespace openshift-operators to be installed
I1030 19:35:21.781701 1 init.go:1905] The operator CSV with packageManifest ibm-odlm in namespace openshift-operators is not installed yet
I1030 19:35:26.786944 1 init.go:1905] The operator CSV with packageManifest ibm-odlm in namespace openshift-operators is not installed yet
I1030 19:35:32.836016 1 request.go:601] Waited for 1.046011871s due to client-side throttling, not priority and fairness, request: GET:[https://172.30.0.1:443/apis/performance.openshift.io/v1alpha1?timeout=32s](https://172.30.0.1/apis/performance.openshift.io/v1alpha1?timeout=32s)
I1030 19:35:37.397047 1 init.go:267] Installing/Updating OperandRegistry
I1030 19:35:37.406503 1 init.go:428] Updating resource with name: common-service, namespace: ibm-common-services, kind: OperandRegistry, apiversion: operator.ibm.com/v1alpha1
I1030 19:35:37.415532 1 init.go:272] Installing/Updating OperandConfig
```