### PR TITLE
Collect new minimal RBAC by Bedrock 4.10

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -13,21 +13,11 @@ rules:
       - update
       - watch
     apiGroups:
-      - apps
-    resources:
-      - deployments/status
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
       - ''
     resources:
       - configmaps
+      - secrets
+      - services
   - verbs:
       - get
       - patch
@@ -36,6 +26,7 @@ rules:
       - ''
     resources:
       - configmaps/status
+      - secrets/status
   - verbs:
       - create
       - patch
@@ -43,14 +34,6 @@ rules:
       - ''
     resources:
       - events
-  - verbs:
-      - get
-      - list
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - namespaces
   - verbs:
       - get
       - list
@@ -70,27 +53,7 @@ rules:
       - ''
     resources:
       - persistentvolumeclaims
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - watch
-    apiGroups:
-      - ''
-    resources:
       - pods
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - watch
-    apiGroups:
-      - ''
-    resources:
       - pods/exec
   - verbs:
       - get
@@ -98,26 +61,6 @@ rules:
       - ''
     resources:
       - pods/status
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - secrets
-  - verbs:
-      - get
-      - patch
-      - update
-    apiGroups:
-      - ''
-    resources:
-      - secrets/status
   - verbs:
       - create
       - get
@@ -130,34 +73,12 @@ rules:
     resources:
       - serviceaccounts
   - verbs:
-      - create
-      - delete
       - get
-      - list
       - patch
-      - update
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - services
-  - verbs:
-      - get
-      - list
-      - patch
-      - update
     apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations
-  - verbs:
-      - get
-      - list
-      - patch
-      - update
-    apiGroups:
-      - admissionregistration.k8s.io
-    resources:
       - validatingwebhookconfigurations
   - verbs:
       - get
@@ -233,6 +154,9 @@ rules:
       - postgresql.k8s.enterprisedb.io
     resources:
       - backups
+      - clusters
+      - poolers
+      - scheduledbackups
   - verbs:
       - get
       - patch
@@ -241,50 +165,13 @@ rules:
       - postgresql.k8s.enterprisedb.io
     resources:
       - backups/status
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - postgresql.k8s.enterprisedb.io
-    resources:
-      - clusters
+      - scheduledbackups/status
   - verbs:
       - update
     apiGroups:
       - postgresql.k8s.enterprisedb.io
     resources:
       - clusters/finalizers
-  - verbs:
-      - get
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - postgresql.k8s.enterprisedb.io
-    resources:
-      - clusters/status
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - postgresql.k8s.enterprisedb.io
-    resources:
-      - poolers
-  - verbs:
-      - update
-    apiGroups:
-      - postgresql.k8s.enterprisedb.io
-    resources:
       - poolers/finalizers
   - verbs:
       - get
@@ -294,27 +181,8 @@ rules:
     apiGroups:
       - postgresql.k8s.enterprisedb.io
     resources:
+      - clusters/status
       - poolers/status
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - postgresql.k8s.enterprisedb.io
-    resources:
-      - scheduledbackups
-  - verbs:
-      - get
-      - patch
-      - update
-    apiGroups:
-      - postgresql.k8s.enterprisedb.io
-    resources:
-      - scheduledbackups/status
   - verbs:
       - create
       - get
@@ -326,16 +194,6 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - rolebindings
-  - verbs:
-      - create
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - rbac.authorization.k8s.io
-    resources:
       - roles
   - verbs:
       - create
@@ -377,6 +235,7 @@ rules:
       - certificates
       - issuers
   - verbs:
+      - delete
       - get
       - list
       - patch
@@ -484,6 +343,51 @@ rules:
       - elasticstack.ibm.com
     resources:
       - elasticstacks
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+  - verbs:
+      - get
+      - delete
+      - list
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - podpresets
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - ibmcpcs.ibm.com
+    resources:
+      - secretshares
   - verbs:
       - get
     apiGroups:
@@ -683,6 +587,14 @@ rules:
       - get
       - list
       - watch
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - authentications
+  - verbs:
+      - get
+      - list
+      - watch
       - create
       - patch
       - update
@@ -691,8 +603,25 @@ rules:
       - ibmevents.ibm.com
     resources:
       - kafkatopics
-      - kafkatopics/status
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+    apiGroups:
+      - ibmevents.ibm.com
+    resources:
       - kafkausers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - ibmevents.ibm.com
+    resources:
+      - kafkatopics/status
       - kafkausers/status
   - verbs:
       - create
@@ -743,27 +672,33 @@ rules:
       - list
       - watch
       - create
-      - delete
       - patch
       - update
     apiGroups:
       - ibmevents.ibm.com
     resources:
       - kafkas
-      - kafkas/status
       - kafkanodepools
-      - kafkanodepools/status
       - kafkaconnects
-      - kafkaconnects/status
       - kafkaconnectors
-      - kafkaconnectors/status
       - kafkamirrormakers
-      - kafkamirrormakers/status
       - kafkabridges
-      - kafkabridges/status
       - kafkamirrormaker2s
-      - kafkamirrormaker2s/status
       - kafkarebalances
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - ibmevents.ibm.com
+    resources:
+      - kafkas/status
+      - kafkanodepools/status
+      - kafkaconnects/status
+      - kafkaconnectors/status
+      - kafkamirrormakers/status
+      - kafkabridges/status
+      - kafkamirrormaker2s/status
       - kafkarebalances/status
   - verbs:
       - get
@@ -781,10 +716,6 @@ rules:
       - get
       - patch
       - update
-      - create
-      - delete
-      - list
-      - watch
     apiGroups:
       - core.ibmevents.ibm.com
     resources:
@@ -918,6 +849,34 @@ rules:
       - policy
     resources:
       - poddisruptionbudgets
+  - verbs:
+      - create
+      - delete
+      - watch
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - oidc.security.ibm.com
+    resources:
+      - clients
+      - clients/finalizers
+      - clients/status
+  - verbs:
+      - create
+      - delete
+      - watch
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+      - services
+      - endpoints
   - verbs:
       - get
       - list
@@ -1151,98 +1110,9 @@ rules:
       - update
       - watch
     apiGroups:
-      - ''
+      - zen.cpd.ibm.com
     resources:
-      - pods
-      - services
-      - services/finalizers
-      - serviceaccounts
-      - endpoints
-      - persistentvolumeclaims
-      - events
-      - configmaps
-      - secrets
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - apps
-    resources:
-      - deployments
-      - daemonsets
-      - replicasets
-      - statefulsets
-  - verbs:
-      - get
-      - create
-    apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-  - verbs:
-      - update
-    apiGroups:
-      - apps
-    resources:
-      - deployments/finalizers
-    resourceNames:
-      - ibm-mongodb-operator
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - operator.ibm.com
-    resources:
-      - mongodbs
-      - mongodbs/finalizers
-      - mongodbs/status
-  - verbs:
-      - delete
-      - get
-      - list
-      - watch
-    apiGroups:
-      - certmanager.k8s.io
-    resources:
-      - certificates
-      - certificaterequests
-      - orders
-      - challenges
-      - issuers
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - cert-manager.io
-    resources:
-      - certificates
-      - certificaterequests
-      - orders
-      - challenges
-      - issuers
-  - verbs:
-      - delete
-      - get
-      - list
-    apiGroups:
-      - operator.ibm.com
-    resources:
-      - operandrequests
+      - zenextensions
   - verbs:
       - create
       - get
@@ -1422,6 +1292,7 @@ rules:
       - operator.ibm.com
     resources:
       - commonservices
+      - authentications
   - verbs:
       - create
       - delete
@@ -1488,6 +1359,8 @@ rules:
       - get
       - list
       - watch
+      - update
+      - patch
     apiGroups:
       - operators.coreos.com
     resources:
@@ -1701,4 +1574,4 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - postgresql-operator-controller-manager-1-18-12-service-cert
+      - postgresql-operator-controller-manager-1-22-7-service-cert


### PR DESCRIPTION
**What this PR does / why we need it**: 
Collect new minimal RBAC required for the full Bedrock installation for both CD and SC2 stream.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65217

**How to test**:

1. Using `ibm-pak` to get and apply the full catalog from latest 4.10.0 CASE and zen catalog
2. install core services
    ```
    - name: ibm-im-operator
    - name: ibm-platformui-operator
    - name: ibm-events-operator
    ```
3. Collect all rules from `nss-runtime-managed-role-from-<ns>` Role
4. Testing Cluster info: `https://console-openshift-console.apps.cutie2.cp.fyre.ibm.com/k8s/ns/tenant1/roles/nss-runtime-managed-role-from-nss-permission/` with w3 ID login
