### PR TITLE
add common-web-ui-config cm to labeling script

### DIFF
--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -309,6 +309,7 @@ function label_configmap() {
     title "Start to label the ConfigMaps... "
     ${OC} label configmap common-service-maps foundationservices.cloudpak.ibm.com=configmap -n kube-public --overwrite=true 2>/dev/null
     ${OC} label configmap cs-onprem-tenant-config foundationservices.cloudpak.ibm.com=configmap -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ${OC} label configmap common-web-ui-config foundationservices.cloudpak.ibm.com=configmap -n $SERVICES_NS --overwrite=true 2>/dev/null
     echo ""
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: add common-web-ui-config cm to labeling script so it can be included in the backup

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65250

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action