### PR TITLE
exclude internal generated operandrequest from Backup/Restore (#2273)

### DIFF
--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -151,6 +151,17 @@ function label_ns_and_related() {
         operand_requests=$(${OC} get operandrequest -n "$namespace" -o custom-columns=NAME:.metadata.name --no-headers)
         # Loop through each OperandRequest name
         while IFS= read -r operand_request; do
+            # Skip all the operandrequest with ownerreference
+            ownerReferences=$(${OC} get operandrequest $operand_request -n "$namespace" -o jsonpath='{.metadata.ownerReferences}')
+            if [[ $ownerReferences != "" ]]; then
+                continue
+            fi
+            # Skip all the operandrequest generate by ODLM
+            control_by_odlm=$(${OC} get operandrequest $operand_request -n "$namespace" --show-labels --no-headers | grep "operator.ibm.com/opreq-control=true" || echo "false")
+            if [[ $control_by_odlm != "false" ]]; then
+                continue
+            fi
+            
             ${OC} label operandrequests $operand_request foundationservices.cloudpak.ibm.com=operand -n "$namespace" --overwrite=true 2>/dev/null
         done <<< "$operand_requests"
 


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64979

cherry pick: https://github.com/IBM/ibm-common-service-operator/pull/2273