### PR TITLE
Clean MongoDB preload ConfigMap when the local MongoDB instance is owned by CR

### DIFF
--- a/controllers/goroutines/cleanup_resources.go
+++ b/controllers/goroutines/cleanup_resources.go
@@ -19,6 +19,9 @@ package goroutines
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 
 	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
@@ -26,8 +29,13 @@ import (
 	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 )
 
+const (
+	mongodbPreloadCm   = "mongodb-preload-endpoint"
+	mongodbStatefulSet = "icp-mongodb"
+)
+
 // Cleanup_Keycloak_Cert will delete Keycloak Certificate when OperandConfig is updated to new version
-func CleanupResources(bs *bootstrap.Bootstrap) {
+func CleanupKeycloakCert(bs *bootstrap.Bootstrap) {
 	for {
 		// wait ODLM OperandConfig CR resources
 		if err := bs.WaitResourceReady("operator.ibm.com/v1alpha1", "OperandConfig"); err != nil {
@@ -59,9 +67,9 @@ func CleanupResources(bs *bootstrap.Bootstrap) {
 					time.Sleep(5 * time.Second)
 					continue
 				}
-				if !exist && err == nil {
+				if !exist {
 					klog.Infof("cert-manager CRD does not exist, skip deleting Keycloak Certificate %s", constant.KeycloakCert)
-				} else if exist && err == nil {
+				} else if exist {
 					if err := bs.DeleteFromYaml(constant.KeycloakCertTemplate, bs.CSData); err != nil {
 						klog.Errorf("Failed to delete Keycloak Certificate %s: %v", constant.KeycloakCert, err)
 						time.Sleep(5 * time.Second)
@@ -73,4 +81,60 @@ func CleanupResources(bs *bootstrap.Bootstrap) {
 
 		time.Sleep(2 * time.Minute)
 	}
+}
+
+// Cleanup_MongoDB_Preload_CM will delete mongodb-preload-endpoint ConfigMap when icp-mongodb StatefulSet has owner reference
+func CleanupMongodbPreloadCm(bs *bootstrap.Bootstrap) {
+	for {
+		// check if icp-mongodb StatefulSet exists
+		statefulSet := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "apps/v1",
+				"kind":       "StatefulSet",
+				"metadata": map[string]interface{}{
+					"name":      mongodbStatefulSet,
+					"namespace": bs.CSData.ServicesNs,
+				},
+			},
+		}
+		if err := bs.Reader.Get(ctx, types.NamespacedName{Name: mongodbStatefulSet, Namespace: bs.CSData.ServicesNs}, statefulSet); err != nil {
+			if errors.IsNotFound(err) {
+				klog.Infof("StatefulSet %s does not exist in %s, skip deleting %s ConfigMap", mongodbStatefulSet, bs.CSData.ServicesNs, mongodbPreloadCm)
+				break
+			} else {
+				klog.Errorf("Failed to get StatefulSet %s: %v, retrying...", mongodbStatefulSet, err)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+		}
+
+		// check if icp-mongodb StatefulSet has owner reference, delete mongodb-preload-endpoint ConfigMap
+		if (statefulSet.GetOwnerReferences() != nil) && (len(statefulSet.GetOwnerReferences()) > 0) {
+			preloadCm := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      mongodbPreloadCm,
+						"namespace": bs.CSData.ServicesNs,
+					},
+				},
+			}
+			if err := bs.Client.Delete(ctx, preloadCm); err != nil {
+				if errors.IsNotFound(err) {
+					klog.Infof("ConfigMap %s does not exist in %s, skip deleting", mongodbPreloadCm, bs.CSData.ServicesNs)
+					break
+				}
+				klog.Errorf("Failed to delete ConfigMap %s: %v, retrying...", mongodbPreloadCm, err)
+				time.Sleep(5 * time.Second)
+				continue
+			}
+			klog.Infof(" ConfigMap %s in %s is deleted for the preparation of MongoDB migration.", mongodbPreloadCm, bs.CSData.ServicesNs)
+		}
+	}
+}
+
+func CleanupResources(bs *bootstrap.Bootstrap) {
+	go CleanupKeycloakCert(bs)
+	go CleanupMongodbPreloadCm(bs)
 }

--- a/controllers/goroutines/cleanup_resources.go
+++ b/controllers/goroutines/cleanup_resources.go
@@ -129,8 +129,11 @@ func CleanupMongodbPreloadCm(bs *bootstrap.Bootstrap) {
 				time.Sleep(5 * time.Second)
 				continue
 			}
-			klog.Infof(" ConfigMap %s in %s is deleted for the preparation of MongoDB migration.", mongodbPreloadCm, bs.CSData.ServicesNs)
+			klog.Infof("ConfigMap %s in %s is deleted for the preparation of MongoDB migration.", mongodbPreloadCm, bs.CSData.ServicesNs)
+			break
 		}
+		klog.Infof("StatefulSet %s does not have owner reference, skip deleting %s ConfigMap", mongodbStatefulSet, mongodbPreloadCm)
+		break
 	}
 }
 


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65226

### Description
The ConfigMap `mongodb-preload-endpoint` will be removed if an MongoDB statefulSet with owner Reference is running  in the service namespace.

An MongoDB statefulSet with owner Reference indicates that it is an active instance in CPFS 4.0-4.5, and it will be used for IM database migration, meaning the ConfigMap `mongodb-preload-endpoint` is no longer required.

### Test case 1: Simulate upgrade from 4.0-4.5 to 4.6+ where ConfigMap should be deleted
#### MongoDB StatefulSet has ownerReference and it is created by MongoDB operator 4.x, ConfigMap `mongodb-preload-endpoint` should be deleted.

1. Install CS operator from daily CD build.
2. Create following dummy ConfigMap `mongodb-preload-endpoint`
    ```yaml
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: mongodb-preload-endpoint
      labels:
        app.kubernetes.io/component: database
        app.kubernetes.io/instance: mongodb-preload-endpoint
        app.kubernetes.io/managed-by: preload_data.sh
        app.kubernetes.io/name: mongodb-preload-endpoint
        app.kubernetes.io/part-of: common-services-cloud-pak
    data:
      ENDPOINT: "mongodb.ibm-common-services.svc.cluster.local"
      CA_CERT: mongodb-root-ca-cert
      CLIENT_CERT: icp-mongodb-client-cert
    ```
4. Replace CS operator image with `quay.io/daniel_fan/common-service-operator-amd64:dev` in the CSV and change ImagePullPolicy to `Always`
5. Update OperandRegistry to remove `installMode: no-op` for `ibm-im-mongodb-operator` entry
6. Create OperandRequest to install MongoDB service
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      labels:
        app.kubernetes.io/instance: operand-deployment-lifecycle-manager
        app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
        app.kubernetes.io/name: operand-deployment-lifecycle-manager
      name: mongodb-service
    spec:
      requests:
        - operands:
            - name: ibm-im-mongodb-operator
          registry: common-service
    ```
7. Validate that the `icp-mongodb` statefulSet contains the OwnerReference
    ```console
    ➜  ~ oc get statefulset icp-mongodb -ojsonpath='{.metadata.ownerReferences}' | jq
    [
      {
        "apiVersion": "operator.ibm.com/v1alpha1",
        "blockOwnerDeletion": true,
        "controller": true,
        "kind": "MongoDB",
        "name": "ibm-mongodb",
        "uid": "d6921cb6-a688-40fd-b094-eb4f2b6ce93e"
      }
    ]
    ```
8. Restart the pod of `ibm-common-service-operator`, to simulate the upgrade scenario where the new common service operator pod is generated.
    ```console
    ➜  ~  oc delete pod -l name=ibm-common-service-operator
    pod "ibm-common-service-operator-696c4d8b56-pvjq5" deleted
    ```
9. Inspect the logs in `ibm-common-service-operator` pod, and see that the ConfigMap has been deleted
      ```console
      ➜  ~ oc logs -l name=ibm-common-service-operator --tail=-1 | grep mongodb-preload-endpoint
      
      I1114 02:54:17.095837       1 cleanup_resources.go:132]  ConfigMap mongodb-preload-endpoint in cd-dev is deleted for the preparation of MongoDB migration.
      ```
12. Check ConfigMap `mongodb-preload-endpoint` does not exist
      ```console
      ➜  ~ oc get configmap mongodb-preload-endpoint
      Error from server (NotFound): configmaps "mongodb-preload-endpoint" not found
      ```

### Test case 2: Simulate upgrade from 3.x to 4.6+ or any corner case.
#### MongoDB StatefulSet does not exist, ConfigMap `mongodb-preload-endpoint` should NOT be removed
#### A MongoDB StatefulSet was created by `preload_data.sh` and it is not removed by any reason. In this case, the MongoDB StatefulSet does not have any owner reference. ConfigMap `mongodb-preload-endpoint` should NOT be removed

1. Continue the test based on above instance, create the same dummy ConfigMap `mongodb-preload-endpoint`
    ```yaml
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: mongodb-preload-endpoint
      labels:
        app.kubernetes.io/component: database
        app.kubernetes.io/instance: mongodb-preload-endpoint
        app.kubernetes.io/managed-by: preload_data.sh
        app.kubernetes.io/name: mongodb-preload-endpoint
        app.kubernetes.io/part-of: common-services-cloud-pak
    data:
      ENDPOINT: "mongodb.ibm-common-services.svc.cluster.local"
      CA_CERT: mongodb-root-ca-cert
      CLIENT_CERT: icp-mongodb-client-cert
    ```
2.  Scale down `ibm-mongodb-operator` deployment
    ```console
    ➜  ~ oc scale deployment ibm-mongodb-operator --replicas=0
    deployment.apps/ibm-mongodb-operator scaled
    ```
3. Manually edit `icp-mongodb` statefulSet, to remove ownerReference section, and verify the ownerrenfere is removed
    ```console
    ➜  ~ oc edit statefulset icp-mongodb
    statefulset.apps/icp-mongodb edited
    ➜  ~ oc get statefulset icp-mongodb -ojsonpath='{.metadata.ownerReferences}' | jq
    ➜  ~
    ```
4. Restart the pod of `ibm-common-service-operator`, to simulate the upgrade scenario where the new common service operator pod is generated.
    ```console
    ➜  ~  oc delete pod -l name=ibm-common-service-operator
    pod "ibm-common-service-operator-696c4d8b56-pvjq5" deleted
    ```
5. Inspect the logs in `ibm-common-service-operator` pod, and see that the ConfigMap is NOT deleted
      ```console
      ➜  ~ oc logs -l name=ibm-common-service-operator --tail=-1 | grep "owner reference"
      I1114 03:27:27.574963       1 cleanup_resources.go:135] StatefulSet icp-mongodb does not have owner reference, skip deleting mongodb-preload-endpoint ConfigMap
      ```
6. Check ConfigMap `mongodb-preload-endpoint` still exist
      ```console
      ➜  ~ oc get configmap mongodb-preload-endpoint
      NAME                       DATA   AGE
      mongodb-preload-endpoint   3      6m39s
      ```
7. Delete StatefulSet `icp-mongodb`
    ```console
    ➜  ~ oc delete statefulset icp-mongodb
    ```
8. Restart the pod of `ibm-common-service-operator`
    ```console
    ➜  ~  oc delete pod -l name=ibm-common-service-operator
    pod "ibm-common-service-operator-696c4d8b56-pvjq5" deleted
    ```
9. Inspect the logs in `ibm-common-service-operator` pod, and see that the ConfigMap is NOT deleted
    ```console
    ➜  ~ oc logs -l name=ibm-common-service-operator --tail=-1 | grep "StatefulSet"
    I1114 03:30:27.893703       1 cleanup_resources.go:102] StatefulSet icp-mongodb does not exist in cd-dev, skip deleting mongodb-preload-endpoint ConfigMap
    ```
10. Check ConfigMap `mongodb-preload-endpoint` still exist
    ```console
    ➜  ~ oc get configmap mongodb-preload-endpoint
    NAME                       DATA   AGE
    mongodb-preload-endpoint   3      11m
    ```