### PR TITLE
add related permission for MongoDB cleanup in post DB migration

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -850,34 +850,6 @@ rules:
     resources:
       - poddisruptionbudgets
   - verbs:
-      - create
-      - delete
-      - watch
-      - get
-      - list
-      - patch
-      - update
-    apiGroups:
-      - oidc.security.ibm.com
-    resources:
-      - clients
-      - clients/finalizers
-      - clients/status
-  - verbs:
-      - create
-      - delete
-      - watch
-      - get
-      - list
-      - patch
-      - update
-    apiGroups:
-      - ''
-    resources:
-      - secrets
-      - services
-      - endpoints
-  - verbs:
       - get
       - list
       - watch
@@ -1113,6 +1085,107 @@ rules:
       - zen.cpd.ibm.com
     resources:
       - zenextensions
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - serviceaccounts
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+  - verbs:
+      - get
+      - create
+    apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+  - verbs:
+      - update
+    apiGroups:
+      - apps
+    resources:
+      - deployments/finalizers
+    resourceNames:
+      - ibm-mongodb-operator
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - mongodbs
+      - mongodbs/finalizers
+      - mongodbs/status
+  - verbs:
+      - delete
+      - get
+      - list
+      - watch
+    apiGroups:
+      - certmanager.k8s.io
+    resources:
+      - certificates
+      - certificaterequests
+      - orders
+      - challenges
+      - issuers
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+      - certificaterequests
+      - orders
+      - challenges
+      - issuers
+  - verbs:
+      - delete
+      - get
+      - list
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - operandrequests
   - verbs:
       - create
       - get


### PR DESCRIPTION
Fix https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65347

Test result: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65347#issuecomment-97316777

### The latest set of permission is gathered via following steps
1. Install latest CPFS 4.10 dev build with full permission in advanced topology
2. Create OperandRequest to install IM, Zen and Events services
    ```yaml
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: common-service
    spec:
      requests:
        - operands:
            - name: ibm-im-operator
            - name: ibm-platformui-operator
            - name: ibm-events-operator
          registry: common-service
    ```
3. Create ZenService CR
    ```yaml
    apiVersion: zen.cpd.ibm.com/v1
    kind: ZenService
    metadata:
      name: lite-zen
    spec:
      blockStorageClass: rook-ceph-block
      fileStorageClass: rook-cephfs
      iamIntegration: true
      iam_provider_card_enabled: true
    ```
4. After ZenService CR status is completed, and IM service is up and running,
    - Update OperandRegistry to remove `installMode: no-op` for `ibm-im-mongodb-operator`
    - Create OperandRequest to install MongoDB service.
    - *NOTE: Do not install MongoDB service when IM service is not ready. Otherwise, it will confuse IM operator and IM operator will kick off DB migration*
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      labels:
        app.kubernetes.io/instance: operand-deployment-lifecycle-manager
        app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
        app.kubernetes.io/name: operand-deployment-lifecycle-manager
      name: mongodb-service
      namespace: nss-service
    spec:
      requests:
        - operands:
            - name: ibm-im-mongodb-operator
          registry: common-service
    ```
5. Collect the set of runtime permission from role `nss-runtime-managed-role-from-<operator-namespace>` and remove any wildcard permission `*`.