### PR TITLE
isolate script should check if cert manager is requested before isolation

### DIFF
--- a/isolate.sh
+++ b/isolate.sh
@@ -1106,9 +1106,6 @@ function prev_fail_check() {
 
     if [[ $cs_op_scale_needed == "true" ]]; then
         check_CSCR "$MASTER_NS"
-        #wait for cert manager to come back ready after scaling up
-        local ns_list=$(gather_csmaps_ns)
-        wait_for_certmanager
     fi
 
 }

--- a/isolate.sh
+++ b/isolate.sh
@@ -122,9 +122,10 @@ function main() {
     check_if_certmanager_requested "${ns_list}"
 
     #verify one and only one cert manager is installed
-    if [[ $REQUEST_CERTMANAGER == "true" ]]
+    if [[ $REQUEST_CERTMANAGER == "true" ]]; then
         check_certmanager_count
     fi
+
     pause
     cleanup_webhook
     cleanup_secretshare
@@ -142,7 +143,7 @@ function main() {
         info "Licensing not marked for backup, skipping."
     fi
     restart
-    if [[ $REQUEST_CERTMANAGER == "true" ]]
+    if [[ $REQUEST_CERTMANAGER == "true" ]]; then
         wait_for_certmanager "${ns_list}"
     fi
     wait_for_nss_update "${ns_list}"

--- a/isolate.sh
+++ b/isolate.sh
@@ -118,8 +118,10 @@ function main() {
     #need to get the namespaces for csmaps generation before pausing cs, otherwise namespace-scope cm does not include all namespaces
     prereq
     local ns_list=$(gather_csmaps_ns)
+    local full_ns_list="${ns_list},${EXCLUDED_NS}"
+    full_ns_list=$(echo "${full_ns_list//,/$'\n'}"| sort -u)
     # verify if cert manager is requested
-    check_if_certmanager_requested "${ns_list},${EXCLUDED_NS}"
+    check_if_certmanager_requested "${full_ns_list}"
 
     #verify one and only one cert manager is installed
     if [[ $REQUEST_CERTMANAGER == "true" ]]; then
@@ -148,7 +150,8 @@ function main() {
         wait_for_certmanager
     else
         # check if certmanager is requested in excluded namespace
-        check_if_certmanager_requested "${EXCLUDED_NS}"
+        excluded_namespace=$(echo "${EXCLUDED_NS//,/$'\n'}"| sort -u)
+        check_if_certmanager_requested "${excluded_namespace}"
         if [[ $REQUEST_CERTMANAGER == "true" ]]; then
             request_certmanager
             wait_for_certmanager

--- a/isolate.sh
+++ b/isolate.sh
@@ -119,7 +119,7 @@ function main() {
     prereq
     local ns_list=$(gather_csmaps_ns)
     # verify if cert manager is requested
-    check_if_certmanager_requested "${ns_list}"
+    check_if_certmanager_requested "${ns_list},${EXCLUDED_NS}"
 
     #verify one and only one cert manager is installed
     if [[ $REQUEST_CERTMANAGER == "true" ]]; then

--- a/isolate.sh
+++ b/isolate.sh
@@ -796,8 +796,6 @@ function check_if_certmanager_requested() {
         REQUEST_CERTMANAGER="false"
     fi
 
-
-
 }
 
 function wait_for_certmanager() {
@@ -833,7 +831,6 @@ function wait_for_certmanager() {
     webhook_ns=$(${OC} get deploy -A | grep cert-manager-webhook | awk '{print $1}')
     success "Cert Manager ready. Cert Manager operands deployed in $webhook_ns"
 }
-
 
 function check_certmanager_count(){
     info "Verifying cert manager is deployed"

--- a/isolate.sh
+++ b/isolate.sh
@@ -147,8 +147,12 @@ function main() {
     if [[ $REQUEST_CERTMANAGER == "true" ]]; then
         wait_for_certmanager
     else
-        request_certmanager
-        wait_for_certmanager
+        # check if certmanager is requested in excluded namespace
+        check_if_certmanager_requested "${EXCLUDED_NS}"
+        if [[ $REQUEST_CERTMANAGER == "true" ]]; then
+            request_certmanager
+            wait_for_certmanager
+        fi
     fi
     wait_for_nss_update "${ns_list}"
     success "Isolation complete"


### PR DESCRIPTION
**What this PR does / why we need it**:
Base on comment: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65281#issuecomment-96802240
- `isolate.sh` requests and checks cert manager before and after isolation IFF `ibm-cert-manager-operator` is requested via OperandRequest in the tenant before isolation.
   - `isolate.sh` would check a cert manager presenting **BEFORE** isolation if any OperandRequest in the tenant contains operand `ibm-cert-manager-operator`.
     - if no `ibm-cert-manager-operator` is requested in OperandRequest, skip checking if cert manager deployment in the cluster
   - `isolate.sh` would wait for cert manager presenting  **AFTER** isolation only if `isolate.sh` checked cert manager presenting before isolation.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65281

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action