### PR TITLE
Add nodeAffinity for Postgres operator, and add new entry cloud-native-postgresql-v1.22

### DIFF
--- a/controllers/constant/odlm_operatorconfig.go
+++ b/controllers/constant/odlm_operatorconfig.go
@@ -32,6 +32,16 @@ spec:
     - name: edb-keycloak
       replicas: placeholder-size
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 90
@@ -68,6 +78,16 @@ spec:
     - name: cloud-native-postgresql
       replicas: placeholder-size
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 90
@@ -104,6 +124,62 @@ spec:
     - name: common-service-postgresql
       replicas: placeholder-size
       affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 90
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - cloud-native-postgresql
+          - weight: 50
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - cloud-native-postgresql
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloud-native-postgresql
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/region
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloud-native-postgresql
+    - name: cloud-native-postgresql-v1.22
+      replicas: placeholder-size
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 90

--- a/controllers/operatorconfig.go
+++ b/controllers/operatorconfig.go
@@ -59,7 +59,7 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 		Namespace: r.Bootstrap.CSData.ServicesNs,
 	}, operatorConfig); err != nil {
 		if !apierrors.IsNotFound(err) {
-			klog.Errorf("failed to get OperandConfig %s/%s: %v", operatorConfig.GetNamespace(), operatorConfig.GetName(), err)
+			klog.Errorf("failed to get OperatorConfig %s/%s: %v", operatorConfig.GetNamespace(), operatorConfig.GetName(), err)
 			return true, err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- When ODLM configures Postgres operator pod with multiple replicas, ODLM will update overwrite the entire `Affinity` field for Postgres operator CSV/deployment. So the configuration for Postgres Operator should contain necessary `nodeAffinity` to ensure pods are distributed on nodes with supported architecture.
- Add an new entry for `cloud-native-postgresql-v1.22` in OperatorConfig, so the Postgres operator requested via `cloud-native-postgresql-v1.22` will get the multi replicas configuration as well.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65071

### Test
1. Install dev build of SC2 4.6.x
2. Patch CS operator CSV with image `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:dev` and `ImagePullPolicy: Always`
3. Edit CommonService CR to configure multiple Postgres operator replicas
    ```yaml
    apiVersion: operator.ibm.com/v3
    kind: CommonService
    metadata:
      name: common-service
    spec:
      license:
        accept: false
      operatorConfigs:
        - name: cloud-native-postgresql
          replicas: 2
      operatorNamespace: sc2-dev
      servicesNamespace: sc2-dev
      size: starterset
    ```
4. Create OperandRequest to request `cloud-native-postgresql-v1.22`
5. Verify the operator pod `affinity` section matching with what we defined in OperatorConfig
    ```console
    ➜  ~ oc get pod postgresql-operator-controller-manager-1-22-7-64c7c847d6-l9pgs -ojsonpath='{.spec.affinity}' | jq
    
    {
      "nodeAffinity": {
        "requiredDuringSchedulingIgnoredDuringExecution": {
          "nodeSelectorTerms": [
            {
              "matchExpressions": [
                {
                  "key": "kubernetes.io/arch",
                  "operator": "In",
                  "values": [
                    "amd64",
                    "ppc64le",
                    "s390x"
                  ]
                }
              ]
            }
          ]
        }
      },
      "podAntiAffinity": {
        "preferredDuringSchedulingIgnoredDuringExecution": [
          {
            "podAffinityTerm": {
              "labelSelector": {
                "matchExpressions": [
                  {
                    "key": "app.kubernetes.io/name",
                    "operator": "In",
                    "values": [
                      "cloud-native-postgresql"
                    ]
                  }
                ]
              },
              "topologyKey": "topology.kubernetes.io/zone"
            },
            "weight": 90
          },
          {
            "podAffinityTerm": {
              "labelSelector": {
                "matchExpressions": [
                  {
                    "key": "app.kubernetes.io/name",
                    "operator": "In",
                    "values": [
                      "cloud-native-postgresql"
                    ]
                  }
                ]
              },
              "topologyKey": "kubernetes.io/hostname"
            },
            "weight": 50
          }
        ]
      }
    }
    ```