### PR TITLE
Use Reader.Get() to retrieve the resource outside of cache scope (#2315)

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -953,11 +953,11 @@ func (b *Bootstrap) deleteResource(resource client.Object, name, namespace strin
 		namespacedName.Namespace = namespace
 	}
 
-	if err := b.Client.Get(ctx, namespacedName, resource); err != nil {
+	if err := b.Reader.Get(ctx, namespacedName, resource); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
-		klog.Infof("%s %s/%s not found, skipping deletion", resourceType, namespace, name)
+		klog.V(2).Infof("%s %s/%s not found, skipping deletion", resourceType, namespace, name)
 		return nil
 	}
 


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65386
Cherry-pick: https://github.com/IBM/ibm-common-service-operator/pull/2315