### PR TITLE
add on-error annotation for Velero hooks

### DIFF
--- a/velero/schedule/common-service-db/cs-db-backup-deployment.yaml
+++ b/velero/schedule/common-service-db/cs-db-backup-deployment.yaml
@@ -14,8 +14,10 @@ spec:
       annotations:
         backup.velero.io/backup-volumes: cs-db-backup
         pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /cs-db/cs-db-backup/database; /cs-db/br_cs-db.sh backup <cs-db namespace>"]'
+        pre.hook.backup.velero.io/on-error: Fail
         pre.hook.backup.velero.io/timeout: 300s
         post.hook.restore.velero.io/command: '["sh", "-c", "/cs-db/br_cs-db.sh restore <cs-db namespace>"]'
+        post.hook.restore.velero.io/on-error: Fail
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s
         post.hook.restore.velero.io/timeout: 720s

--- a/velero/schedule/keycloak/keycloak-backup-deployment.yaml
+++ b/velero/schedule/keycloak/keycloak-backup-deployment.yaml
@@ -12,9 +12,12 @@ spec:
       annotations:
         backup.velero.io/backup-volumes: keycloak-backup
         pre.hook.backup.velero.io/command: '["sh", "-c", "/keycloak/br_keycloak.sh backup <keycloak namespace>"]'
+        pre.hook.backup.velero.io/on-error: Fail
         pre.hook.backup.velero.io/timeout: 300s
         post.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /keycloak/keycloak-backup/database && rm -rf /keycloak/keycloak-backup/secrets"]'
+        post.hook.backup.velero.io/on-error: Fail
         post.hook.restore.velero.io/command: '["sh", "-c", "/keycloak/br_keycloak.sh restore <keycloak namespace>"]'
+        post.hook.restore.velero.io/on-error: Fail
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s
         post.hook.restore.velero.io/timeout: 720s

--- a/velero/schedule/license_service_reporter/lsr-backup-deployment.yaml
+++ b/velero/schedule/license_service_reporter/lsr-backup-deployment.yaml
@@ -14,8 +14,10 @@ spec:
       annotations:
         backup.velero.io/backup-volumes: lsr-backup
         pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace> backup"]'
+        pre.hook.backup.velero.io/on-error: Fail
         pre.hook.backup.velero.io/timeout: 300s
         post.hook.restore.velero.io/command: '["sh", "-c", "/lsr/br_lsr.sh <lsr namespace> restore"]'
+        post.hook.restore.velero.io/on-error: Fail
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s
         post.hook.restore.velero.io/timeout: 600s

--- a/velero/schedule/mongodb-backup-deployment.yaml
+++ b/velero/schedule/mongodb-backup-deployment.yaml
@@ -14,7 +14,9 @@ spec:
       annotations:
         backup.velero.io/backup-volumes: mongodump
         pre.hook.backup.velero.io/command: '["bash", "-c", "rm -rf /dump/dump/*; cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongodump --oplog --out /dump/dump --host mongodb:$MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem"]'
+        pre.hook.restore.velero.io/on-error: Fail
         post.hook.restore.velero.io/command: '["bash", "-c", "cat /cred/mongo-certs/tls.crt /cred/mongo-certs/tls.key > /work-dir/mongo.pem; cat /cred/cluster-ca/tls.crt /cred/cluster-ca/tls.key > /work-dir/ca.pem; mongorestore --db platform-db --host rs0/icp-mongodb-0.icp-mongodb.<mongo namespace>.svc.cluster.local,icp-mongodb-1.icp-mongodb.<mongo namespace>.svc.cluster.local,icp-mongodb-2.icp-mongodb.<mongo namespace>.svc.cluster.local --port $MONGODB_SERVICE_PORT --username $ADMIN_USER --password $ADMIN_PASSWORD --authenticationDatabase admin --ssl --sslCAFile /work-dir/ca.pem --sslPEMKeyFile /work-dir/mongo.pem /dump/dump/platform-db --drop"]'
+        post.hook.restore.velero.io/on-error: Fail
       name: mongodb-backup
       namespace: <mongo namespace>
       labels:

--- a/velero/schedule/zen-backup-deployment.yaml
+++ b/velero/schedule/zen-backup-deployment.yaml
@@ -14,8 +14,10 @@ spec:
       annotations:
         backup.velero.io/backup-volumes: zendump
         pre.hook.backup.velero.io/command: '["sh", "-c", "/zen4/zen4-br.sh <zenservice namespace> true"]'
+        pre.hook.backup.velero.io/on-error: Fail
         pre.hook.backup.velero.io/timeout: 300s
         post.hook.restore.velero.io/command: '["sh", "-c", "/zen4/zen4-br.sh <zenservice namespace> false"]'
+        post.hook.restore.velero.io/on-error: Fail
         post.hook.restore.velero.io/wait-timeout: 300s
         post.hook.restore.velero.io/exec-timeout: 300s
         post.hook.restore.velero.io/timeout: 600s

--- a/velero/schedule/zen5-backup-deployment.yaml
+++ b/velero/schedule/zen5-backup-deployment.yaml
@@ -14,8 +14,10 @@ spec:
       annotations:
         backup.velero.io/backup-volumes: zen5-backup
         pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace; /zen5/backup_zen5.sh <zenservice namespace>"]'
+        pre.hook.backup.velero.io/on-error: Fail
         pre.hook.backup.velero.io/timeout: 300s
         post.hook.restore.velero.io/command: '["sh", "-c", "/zen5/restore_zen5.sh <zenservice namespace> <zenservice name>"]'
+        post.hook.restore.velero.io/on-error: Fail
         post.hook.restore.velero.io/wait-timeout: 1000s
         post.hook.restore.velero.io/exec-timeout: 1000s
         post.hook.restore.velero.io/timeout: 1000s


### PR DESCRIPTION
**What this PR does / why we need it**:
Add on-error annotations for Velero hooks
If script specified in velero hooks failed, the status of restore CR should be fail as well.

**Which issue(s) this PR fixes**:
Enhancement for # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62663

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action