### PR TITLE
Create singleton recipe for License Service Reporter

### DIFF
--- a/velero/spectrum-fusion/license-service-reporter/application.yaml
+++ b/velero/spectrum-fusion/license-service-reporter/application.yaml
@@ -1,0 +1,11 @@
+apiVersion: application.isf.ibm.com/v1alpha1
+kind: Application
+metadata:
+  name: lsr-application
+  namespace: ibm-spectrum-fusion-ns
+spec:
+  enableDR: false
+  includedNamespaces:
+    - ibm-lsr
+    - openshift-marketplace    
+    - openshift-config

--- a/velero/spectrum-fusion/license-service-reporter/policy.yaml
+++ b/velero/spectrum-fusion/license-service-reporter/policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: data-protection.isf.ibm.com/v1alpha1
+kind: BackupPolicy
+metadata:
+  name: lsr-backup-policy
+spec:
+  backupStorageLocation: <storage_location>
+  provider: isf-backup-restore
+  retention:
+    number: 5
+    unit: days
+  schedule:
+    cron: '00 0  * * * '
+    timezone: America/New_York

--- a/velero/spectrum-fusion/license-service-reporter/policy_assignment.yaml
+++ b/velero/spectrum-fusion/license-service-reporter/policy_assignment.yaml
@@ -1,0 +1,13 @@
+apiVersion: data-protection.isf.ibm.com/v1alpha1
+kind: PolicyAssignment
+metadata:
+  name: lsr-policy-assignment
+  namespace: ibm-spectrum-fusion-ns
+spec:
+  application: lsr-application
+  backupPolicy: lsr-backup-policy
+  runNow: false
+  recipe:
+    apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+    name: lsr-recipe
+    namespace: ibm-spectrum-fusion-ns

--- a/velero/spectrum-fusion/license-service-reporter/recipe.yaml
+++ b/velero/spectrum-fusion/license-service-reporter/recipe.yaml
@@ -1,0 +1,179 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  name: lsr-recipe
+  namespace: ibm-spectrum-fusion-ns
+spec:
+  appType: license-service-reporter
+  groups:
+    - includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-parent
+      type: resource
+    - backupRef: license-service-reporter-parent
+      includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      name: license-service-reporter-crd
+      type: resource
+    - backupRef: license-service-reporter-parent
+      includeClusterResources: true
+      includedResourceTypes:
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      name: license-service-reporter-instances
+      type: resource
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: license-service-reporter-resources
+      type: resource
+    - backupRef: license-service-reporter-resources
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: lsr-pre-deploy
+      type: resource
+    - backupRef: license-service-reporter-resources
+      includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+      name: lsr-deployment
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-volume
+      type: volume
+    - includedResourceTypes:
+        - catalogsources.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=catalog
+      name: common-services-catalogs
+      type: resource
+    - includedNamespaces:
+        - openshift-config
+      includedResourceTypes:
+        - secrets
+      labelSelector: foundationservices.cloudpak.ibm.com=pull-secret
+      name: pull-secret
+      type: resource
+    - backupRef: pull-secret
+      includedNamespaces:
+        - openshift-config
+      includedResourceTypes:
+        - secrets
+      labelSelector: foundationservices.cloudpak.ibm.com=pull-secret
+      name: ow-pull-secret
+      restoreOverwriteResources: true
+      type: resource
+    - includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=namespace
+      name: common-services-namespace
+      type: resource
+    - includedResourceTypes:
+        - operatorgroups.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=operatorgroup
+      name: common-services-operatorgroups
+      type: resource
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-subscriptions
+      type: resource
+  hooks:
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: license-service-reporter-check
+      labelSelector: app.kubernetes.io/name=ibm-license-service-reporter
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: license-service-reporter-instance-check
+      labelSelector: app.kubernetes.io/instance=ibm-license-service-reporter
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-deployment
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-data
+      namespace: <lsr namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace> backup"]
+          container: lsr-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/lsr/br_lsr.sh <lsr namespace> restore"]
+          container: lsr-backup-job
+          name: restore
+          timeout: 2000
+      selectResource: pod
+      type: exec
+  workflows:
+    - failOn: any-error
+      name: backup
+      sequence:
+        # - hook: lsr-data/backup
+        # - group: lsr-volume
+        # - group: license-service-reporter-resources
+        - group: pull-secret
+        - group: common-services-namespace
+        - group: common-services-catalogs
+        - group: common-services-operatorgroups
+        - group: license-service-reporter-parent
+        - group: license-service-reporter-subscriptions
+    - failOn: any-error
+      name: restore
+      sequence:
+        - group: common-services-namespace
+        - group: pull-secret
+        - group: ow-pull-secret
+        - group: common-services-catalogs
+        - group: common-services-operatorgroups
+        - group: license-service-reporter-crd
+        - group: license-service-reporter-subscriptions
+        - hook: license-service-reporter-check/podReady
+        - group: license-service-reporter-instances
+        - hook: license-service-reporter-instance-check/podReady
+        # - group: lsr-pre-deploy
+        # - group: lsr-volume
+        # - group: lsr-deployment
+        # - hook: lsr-deployment/podReady
+        #- hook: lsr-data/restore
+
+    


### PR DESCRIPTION
**What this PR does**:  Create a new template for License Service Reporter and instance including set of Application, Assignment, PolicyAssignment and new streamlined Recipe

**Issue:** https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64751

**Test result:**
Backup and restore passed
<img width="640" alt="Screenshot 2024-12-03 at 12 46 50" src="https://github.com/user-attachments/assets/25385522-7d51-4895-92f7-991272fbcc39">
