### PR TITLE
cleanup cs-control

### DIFF
--- a/cp3pt0-deployment/common/cleanup_cp2_control.sh
+++ b/cp3pt0-deployment/common/cleanup_cp2_control.sh
@@ -32,9 +32,11 @@ function main() {
 
     # cleanup namespaceScope in Control namespace
     cleanup_NamespaceScope $CONTROL_NS
+    delete_operator "ibm-namespace-scope-operator" "$CONTROL_NS"
 
-    # cleanup webhookc
+    # cleanup webhook
     cleanup_webhook $CONTROL_NS ""
+    cleanup_webhook_service $CONTROL_NS
     
     # cleanup secretshare
     cleanup_secretshare $CONTROL_NS ""

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -1046,6 +1046,12 @@ function cleanup_webhook() {
 
 }
 
+function cleanup_webhook_service() {
+    local control_ns=$1
+    info "Deleting ibm-common-service-webhook-service"
+    ${OC} delete service ibm-common-service-webhook -n $control_ns --ignore-not-found
+}
+
 # Clean up secretshare deployment and CR in service_ns
 function cleanup_secretshare() {
     local control_ns=$1


### PR DESCRIPTION
**What this PR does / why we need it**:
cleanup Namespace scope operator and cs-webhook service

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65254
