### PR TITLE
suspend go routines until operator cache is ready

### DIFF
--- a/controllers/goroutines/cleanup_resources.go
+++ b/controllers/goroutines/cleanup_resources.go
@@ -137,7 +137,8 @@ func CleanupMongodbPreloadCm(bs *bootstrap.Bootstrap) {
 	}
 }
 
-func CleanupResources(bs *bootstrap.Bootstrap) {
+func CleanupResources(ch chan *bootstrap.Bootstrap) {
+	bs := <-ch
 	go CleanupKeycloakCert(bs)
 	go CleanupMongodbPreloadCm(bs)
 }

--- a/controllers/goroutines/operator_status.go
+++ b/controllers/goroutines/operator_status.go
@@ -36,10 +36,8 @@ var ctx = context.Background()
 
 // UpdateCsCrStatus will update cs cr status according to each bedrock operator
 func UpdateCsCrStatus(ch chan *bootstrap.Bootstrap) {
-	klog.Info("start update CSCR")
 	for {
 		bs := <-ch
-		klog.Info("Get bs from channel")
 		instance := &apiv3.CommonService{}
 		if err := bs.Reader.Get(ctx, types.NamespacedName{Name: "common-service", Namespace: bs.CSData.OperatorNs}, instance); err != nil {
 			if !errors.IsNotFound(err) {

--- a/controllers/goroutines/operator_status.go
+++ b/controllers/goroutines/operator_status.go
@@ -36,8 +36,10 @@ var ctx = context.Background()
 
 // UpdateCsCrStatus will update cs cr status according to each bedrock operator
 func UpdateCsCrStatus(ch chan *bootstrap.Bootstrap) {
+	klog.Info("start update CSCR")
 	for {
 		bs := <-ch
+		klog.Info("Get bs from channel")
 		instance := &apiv3.CommonService{}
 		if err := bs.Reader.Get(ctx, types.NamespacedName{Name: "common-service", Namespace: bs.CSData.OperatorNs}, instance); err != nil {
 			if !errors.IsNotFound(err) {

--- a/controllers/goroutines/operator_status.go
+++ b/controllers/goroutines/operator_status.go
@@ -35,8 +35,9 @@ import (
 var ctx = context.Background()
 
 // UpdateCsCrStatus will update cs cr status according to each bedrock operator
-func UpdateCsCrStatus(bs *bootstrap.Bootstrap) {
+func UpdateCsCrStatus(ch chan *bootstrap.Bootstrap) {
 	for {
+		bs := <-ch
 		instance := &apiv3.CommonService{}
 		if err := bs.Reader.Get(ctx, types.NamespacedName{Name: "common-service", Namespace: bs.CSData.OperatorNs}, instance); err != nil {
 			if !errors.IsNotFound(err) {

--- a/controllers/goroutines/waitToCreateCsCR.go
+++ b/controllers/goroutines/waitToCreateCsCR.go
@@ -28,8 +28,9 @@ import (
 )
 
 // WaitToCreateCsCR waits for the creation of the CommonService CR in the operator namespace.
-func WaitToCreateCsCR(bs *bootstrap.Bootstrap) {
+func WaitToCreateCsCR(ch chan *bootstrap.Bootstrap) {
 	for {
+		bs := <-ch
 		klog.Infof("Start to Create CommonService CR in the namespace %s", bs.CSData.OperatorNs)
 		if err := bs.CreateCsCR(); err != nil {
 			if strings.Contains(fmt.Sprint(err), "failed to call webhook") {

--- a/main.go
+++ b/main.go
@@ -164,6 +164,7 @@ func main() {
 		// Delete Keycloak Cert
 		go goroutines.CleanupResources(ch)
 
+		klog.Infof("Setup commonservice manager")
 		if err = (&controllers.CommonServiceReconciler{
 			Bootstrap: bs,
 			Scheme:    mgr.GetScheme(),
@@ -174,6 +175,7 @@ func main() {
 		}
 
 		// start go routines
+		klog.Infof("Start go routines")
 		ch <- bs
 
 		// check if cert-manager CRD does not exist, then skip cert-manager related controllers initialization
@@ -186,6 +188,7 @@ func main() {
 			klog.Infof("cert-manager CRD does not exist, skip cert-manager related controllers initialization")
 		} else if exist && err == nil {
 
+			klog.Infof("Set up certmanager Manager")
 			if err = (&certmanagerv1controllers.CertificateRefreshReconciler{
 				Client: mgr.GetClient(),
 				Scheme: mgr.GetScheme(),

--- a/main.go
+++ b/main.go
@@ -173,6 +173,9 @@ func main() {
 			os.Exit(1)
 		}
 
+		// start go routines
+		ch <- bs
+
 		// check if cert-manager CRD does not exist, then skip cert-manager related controllers initialization
 		exist, err := bs.CheckCRD(constant.CertManagerAPIGroupVersionV1, "Certificate")
 		if err != nil {
@@ -181,8 +184,6 @@ func main() {
 		}
 		if !exist && err == nil {
 			klog.Infof("cert-manager CRD does not exist, skip cert-manager related controllers initialization")
-			// start go routines
-			ch <- bs
 		} else if exist && err == nil {
 
 			if err = (&certmanagerv1controllers.CertificateRefreshReconciler{
@@ -206,8 +207,6 @@ func main() {
 				klog.Error(err, "unable to create controller", "controller", "V1AddLabel")
 				os.Exit(1)
 			}
-			// start go routines
-			ch <- bs
 		}
 	} else {
 		klog.Infof("Common Service Operator goes dormant in the namespace %s", operatorNs)

--- a/main.go
+++ b/main.go
@@ -181,6 +181,8 @@ func main() {
 		}
 		if !exist && err == nil {
 			klog.Infof("cert-manager CRD does not exist, skip cert-manager related controllers initialization")
+			// start go routines
+			ch <- bs
 		} else if exist && err == nil {
 
 			if err = (&certmanagerv1controllers.CertificateRefreshReconciler{


### PR DESCRIPTION
**What this PR does / why we need it**:
Go routines in ibm-common-service operator relies on operator [controller's cache](https://github.com/IBM/ibm-common-service-operator/blob/b947cd93e81eccefd769c64628de3c730fa1797a/main.go#L124) to be ready. It will be ready when [Manager is set up](https://github.com/IBM/ibm-common-service-operator/blob/b947cd93e81eccefd769c64628de3c730fa1797a/main.go#L253). So we need to suspend go routines until manager is setup
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58246