### PR TITLE
start go routines after cs controller manager setup

### DIFF
--- a/controllers/goroutines/cleanup_resources.go
+++ b/controllers/goroutines/cleanup_resources.go
@@ -137,8 +137,7 @@ func CleanupMongodbPreloadCm(bs *bootstrap.Bootstrap) {
 	}
 }
 
-func CleanupResources(ch chan *bootstrap.Bootstrap) {
-	bs := <-ch
+func CleanupResources(bs *bootstrap.Bootstrap) {
 	go CleanupKeycloakCert(bs)
 	go CleanupMongodbPreloadCm(bs)
 }

--- a/controllers/goroutines/operator_status.go
+++ b/controllers/goroutines/operator_status.go
@@ -35,9 +35,8 @@ import (
 var ctx = context.Background()
 
 // UpdateCsCrStatus will update cs cr status according to each bedrock operator
-func UpdateCsCrStatus(ch chan *bootstrap.Bootstrap) {
+func UpdateCsCrStatus(bs *bootstrap.Bootstrap) {
 	for {
-		bs := <-ch
 		instance := &apiv3.CommonService{}
 		if err := bs.Reader.Get(ctx, types.NamespacedName{Name: "common-service", Namespace: bs.CSData.OperatorNs}, instance); err != nil {
 			if !errors.IsNotFound(err) {

--- a/controllers/goroutines/waitToCreateCsCR.go
+++ b/controllers/goroutines/waitToCreateCsCR.go
@@ -28,9 +28,8 @@ import (
 )
 
 // WaitToCreateCsCR waits for the creation of the CommonService CR in the operator namespace.
-func WaitToCreateCsCR(ch chan *bootstrap.Bootstrap) {
+func WaitToCreateCsCR(bs *bootstrap.Bootstrap) {
 	for {
-		bs := <-ch
 		klog.Infof("Start to Create CommonService CR in the namespace %s", bs.CSData.OperatorNs)
 		if err := bs.CreateCsCR(); err != nil {
 			if strings.Contains(fmt.Sprint(err), "failed to call webhook") {

--- a/main.go
+++ b/main.go
@@ -154,13 +154,8 @@ func main() {
 			klog.Errorf("Cleanup Webhook Resources failed: %v", err)
 			os.Exit(1)
 		}
-		// Update CS CR Status
-		go goroutines.UpdateCsCrStatus(bs)
-		// Create CS CR
-		go goroutines.WaitToCreateCsCR(bs)
-		// Delete Keycloak Cert
-		go goroutines.CleanupResources(bs)
 
+		klog.Infof("Setup commonservice manager")
 		if err = (&controllers.CommonServiceReconciler{
 			Bootstrap: bs,
 			Scheme:    mgr.GetScheme(),
@@ -169,6 +164,14 @@ func main() {
 			klog.Errorf("Unable to create controller CommonService: %v", err)
 			os.Exit(1)
 		}
+
+		klog.Infof("Start go routines")
+		// Update CS CR Status
+		go goroutines.UpdateCsCrStatus(bs)
+		// Create CS CR
+		go goroutines.WaitToCreateCsCR(bs)
+		// Delete Keycloak Cert
+		go goroutines.CleanupResources(bs)
 
 		// check if cert-manager CRD does not exist, then skip cert-manager related controllers initialization
 		exist, err := bs.CheckCRD(constant.CertManagerAPIGroupVersionV1, "Certificate")


### PR DESCRIPTION
**What this PR does / why we need it**:
Given there are multiple receivers(multiple go routines) on a single channel `ch := make(chan *bootstrap.Bootstrap)` and we are only sending one data into the channel  `ch <- bs`, only a single random go routines will receive the data, and unblock the code. See [this article](https://stackoverflow.com/questions/31539804/multiple-receivers-on-a-single-channel-who-gets-the-data) for details

Thus, it is complicated to use the same single channel for multiple go routines. Instead we just start go routines after cs controller manager is set properly.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65568

### Test
After applying the dev build image `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:dev`, the CS operator will have following sequence
1. Set CS controller manager
2. Start go routines
    - Create default CS CR
    - There is no error message about `unknown caches`.
```logs
I1211 04:30:24.580267 1 main.go:131] Identifying Common Service Operator Role in the namespace cd-daily
I1211 04:30:24.610292 1 init.go:160] Single Deployment Status: false, MultiInstance Deployment status: true, SaaS Depolyment Status: false
I1211 04:30:31.118084 1 request.go:601] Waited for 1.046241127s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/db2ubnr.databases.ibm.com/v1alpha1?timeout=32s
I1211 04:30:40.975386 1 main.go:158] Setup commonservice manager
I1211 04:30:42.026625 1 request.go:601] Waited for 1.046418127s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/machine.openshift.io/v1?timeout=32s
I1211 04:30:46.427900 1 main.go:168] Start go routines
I1211 04:30:46.428201 1 waitToCreateCsCR.go:33] Start to Create CommonService CR in the namespace cd-daily
```