### PR TITLE
More consistently check OIDC job readiness

### DIFF
--- a/velero/schedule/common-service-db/cs-db-br-script-cm.yaml
+++ b/velero/schedule/common-service-db/cs-db-br-script-cm.yaml
@@ -126,17 +126,17 @@ data:
         info "Waiting for job $job_name to complete in namespace $CSDB_NAMESPACE."
         job_exists=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers || echo fail)
         if [[ $job_exists != "fail" ]]; then
-            completed=$(oc get job $job_name -n $CSDB_NAMESPACE -o jsonpath='{status.succeeded}')
+            completed=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers | awk '{print $2}')
             retry_count=20
-            while [[ $completed != "1" ]] && [[ $retry_count > 0 ]]
+            while [[ ( $completed != "1/1" && $completed != "Complete" ) ]] && [[ $retry_count > 0 ]]
             do
                 info "Wait for job $job_name to complete. Try again in 15s."
                 sleep 15
-                completed=$(oc get job $job_name -n $CSDB_NAMESPACE -o jsonpath='{status.succeeded}')
+                completed=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers | awk '{print $2}')
                 retry_count=$((retry_count-1))
             done
 
-            if [[ $retry_count == 0 ]] && [[ $completed != "1" ]]; then
+            if [[ $retry_count == 0 ]] && [[ ( $completed != "1/1" && $completed != "Complete" ) ]]; then
                 error "Timed out waiting for job $job_name."
             else
                 info "Job $job_name completed."


### PR DESCRIPTION
**What this PR does / why we need it**: Its possible for the columns to be switched when trying to read job readiness. This can happen for pods as well. We need to check for either so we do not miss when it is not the one we expect in the column we expect it to be.

Seen when testing https://github.com/IBM/ibm-common-service-operator/pull/2321

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action