### PR TITLE
Enhance Keycloak 26 pod scheduling and startup probe configurations

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -979,16 +979,6 @@ spec:
                     - command:
                         - /bin/sh
                         - /mnt/startup/cs-keycloak-entrypoint.sh
-                      name: keycloak
-                      startupProbe:
-                        failureThreshold: 20
-                        httpGet:
-                          path: /health/started
-                          port: 9000
-                          scheme: HTTPS
-                        initialDelaySeconds: 180
-                        periodSeconds: 20
-                        timeoutSeconds: 5
                       volumeMounts:
                         - mountPath: /mnt/truststore
                           name: truststore-volume

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -1020,6 +1020,17 @@ spec:
                     - name: user-profile-volume
                       configMap: 
                         name: cs-keycloak-user-profile
+                  affinity:
+                    nodeAffinity:
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        nodeSelectorTerms:
+                        - matchExpressions:
+                          - key: kubernetes.io/arch
+                            operator: In
+                            values:
+                            - amd64
+                            - ppc64le
+                            - s390x
         force: true
         kind: Keycloak
         name: cs-keycloak
@@ -1041,6 +1052,24 @@ spec:
                   apiVersion: apiextensions.k8s.io/v1
                   kind: CustomResourceDefinition
                 key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.resources
+                operator: DoesNotExist
+          - path: .spec.unsupported.podTemplate.spec.affinity
+            operation: remove
+            matchExpressions:
+              - objectRef:
+                  name: keycloaks.k8s.keycloak.org
+                  apiVersion: apiextensions.k8s.io/v1
+                  kind: CustomResourceDefinition
+                key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.scheduling
+                operator: Exists
+          - path: .spec.scheduling
+            operation: remove
+            matchExpressions:
+              - objectRef:
+                  name: keycloaks.k8s.keycloak.org
+                  apiVersion: apiextensions.k8s.io/v1
+                  kind: CustomResourceDefinition
+                key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.scheduling
                 operator: DoesNotExist
       - apiVersion: v1
         kind: ConfigMap

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -923,6 +923,18 @@ spec:
       - apiVersion: k8s.keycloak.org/v2alpha1
         data:
           spec:
+            scheduling:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - ppc64le
+                        - s390x
             proxy:
               headers: xforwarded
             features:
@@ -967,6 +979,16 @@ spec:
                     - command:
                         - /bin/sh
                         - /mnt/startup/cs-keycloak-entrypoint.sh
+                      name: keycloak
+                      startupProbe:
+                        failureThreshold: 20
+                        httpGet:
+                          path: /health/started
+                          port: 9000
+                          scheme: HTTPS
+                        initialDelaySeconds: 180
+                        periodSeconds: 20
+                        timeoutSeconds: 5
                       volumeMounts:
                         - mountPath: /mnt/truststore
                           name: truststore-volume
@@ -998,17 +1020,6 @@ spec:
                     - name: user-profile-volume
                       configMap: 
                         name: cs-keycloak-user-profile
-                  affinity:
-                    nodeAffinity:
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        nodeSelectorTerms:
-                        - matchExpressions:
-                          - key: kubernetes.io/arch
-                            operator: In
-                            values:
-                            - amd64
-                            - ppc64le
-                            - s390x
         force: true
         kind: Keycloak
         name: cs-keycloak


### PR DESCRIPTION
**What this PR changes**:

- Scheduling Enhancements:
   - Keycloak 26 CRD intrduced: 
      `.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.scheduling`
   - Added `spec.scheduling` with affinity spread constraints to ensured compatibility across node architectures
   - Keycloak 26 doc reference: https://www.keycloak.org/operator/advanced-configuration#_scheduling

- Startup and Readiness Probe Adjustments:

   -  Increased `initialDelaySeconds` for `startupProbe` to handle longer initialization times and avoid the error msg: 
      ```
      Startup probe failed: Get "https://10.254.19.137:9000/health/started": dial tcp 10.254.19.137:9000: connect: connection refused
       ```

**Which issue(s) this PR fixes**:
Fixes # 
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65326#issuecomment-101278516
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65677

**How to test**:
Test Image: quay.io/yuchen_shen/cs_operator:scheduling
