### PR TITLE
Enhance Keycloak 26 truststore file and sa certs import

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -47,6 +47,7 @@ type CSData struct {
 	ExcludedCatalog         string
 	StatusMonitoredServices string
 	ServiceNames            map[string][]string
+	UtilsImage              string
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:4.12.0
-    createdAt: "2025-03-18T20:20:54Z"
+    createdAt: "2025-03-18T21:27:31Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:4.12.0
-    createdAt: "2025-02-20T00:28:09Z"
+    createdAt: "2025-03-18T20:20:54Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -383,6 +383,8 @@ spec:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
                       - name: OPERATOR_NAME
                         value: ibm-common-service-operator
+                      - name: UTILS_IMAGE
+                        value: icr.io/cpopen/cpfs/cpfs-utils:latest
                     image: icr.io/cpopen/common-service-operator:4.12.0
                     imagePullPolicy: IfNotPresent
                     livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,6 +74,8 @@ spec:
               fieldPath: metadata.annotations['olm.targetNamespaces']
         - name: OPERATOR_NAME
           value: "ibm-common-service-operator"
+        - name: UTILS_IMAGE
+          value: icr.io/cpopen/cpfs/cpfs-utils:latest
         resources:
           limits:
             cpu: 500m

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -163,6 +163,7 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		ExcludedCatalog:         constant.ExcludedCatalog,
 		StatusMonitoredServices: constant.StatusMonitoredServices,
 		ServiceNames:            constant.ServiceNames,
+		UtilsImage:              util.GetUtilsImage(),
 	}
 
 	bs = &Bootstrap{

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -117,6 +117,7 @@ func NewNonOLMBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		ExcludedCatalog:         constant.ExcludedCatalog,
 		StatusMonitoredServices: constant.StatusMonitoredServices,
 		ServiceNames:            constant.ServiceNames,
+		UtilsImage:              util.GetUtilsImage(),
 	}
 
 	bs = &Bootstrap{

--- a/internal/controller/common/util.go
+++ b/internal/controller/common/util.go
@@ -279,6 +279,14 @@ func GetWatchNamespace() string {
 	return ns
 }
 
+func GetUtilsImage() string {
+	image, found := os.LookupEnv("UTILS_IMAGE")
+	if !found {
+		return ""
+	}
+	return image
+}
+
 // GetNSSCMSynchronization returns whether NSS ConfigMap shchronization with OperatorGroup is enabled
 func GetNSSCMSynchronization() bool {
 	isEnable, found := os.LookupEnv("NSSCM_SYNC_MODE")

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1042,6 +1042,93 @@ spec:
         kind: ConfigMap
         name: cs-keycloak-user-profile
       - apiVersion: v1
+        kind: ServiceAccount
+        name: convert-secret-sa
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: convert-secret-role
+        data:
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - secrets
+            - configmaps
+            verbs:
+            - create
+            - update
+            - patch
+            - get
+            - list
+            - delete
+            - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: convert-secret-rolebinding
+        data:
+          subjects:
+          - kind: ServiceAccount
+            name: convert-secret-sa
+          roleRef:
+            kind: Role
+            name: convert-secret-role
+            apiGroup: rbac.authorization.k8s.io
+      - apiVersion: batch/v1
+        kind: Job
+        force: true
+        name: convert-secret-job
+        data:
+          spec:
+            template:
+              spec:
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: kubernetes.io/arch
+                          operator: In
+                          values:
+                          - amd64
+                          - ppc64le
+                          - s390x
+                restartPolicy: OnFailure
+                serviceAccountName: convert-secret-sa
+                containers:
+                - name: convert-secret-job
+                  image: icr.io/cpopen/cpfs/cpfs-utils:latest
+                  command:
+                    - /bin/sh
+                    - -c
+                    - |              
+                      # Check if the secret already exists
+                      if oc get secret cs-keycloak-ca-certs -n {{ .OperatorNs }} >/dev/null 2>&1; then
+                        echo "Secretcs-keycloak-ca-certs already exists. Skipping conversion."
+                        exit 0
+                      fi
+                      
+                      # Check if ConfigMap exists
+                      if ! oc get configmap cs-keycloak-ca-certs -n {{ .OperatorNs }} >/dev/null 2>&1; then
+                        echo "ConfigMap cs-keycloak-ca-certs not found. Nothing to conversion."
+                        exit 0
+                      fi
+                      
+                      # Extract certificate file names from ConfigMap
+                      CERT_FILES=$(oc get configmap cs-keycloak-ca-certs -n {{ .OperatorNs }} -o yaml | yq e '.data | keys | .[]' -)              
+                      
+                      # Create a temporary directory
+                      mkdir -p /tmp/certs
+                      # Extract certificates from ConfigMap and save them as files
+                      for CERT in $CERT_FILES; do
+                        oc get configmap cs-keycloak-ca-certs -n {{ .OperatorNs }} -o yaml | yq e ".data[\"$CERT\"]"> /tmp/certs/$CERT
+                      done
+                      
+                      # Create Secret from extracted certificates
+                      oc create secret generic cs-keycloak-ca-certs -n {{ .OperatorNs }} \
+                        $(for CERT in $CERT_FILES; do echo --from-file=/tmp/certs/$CERT; done)
+                      
+                      echo "Conversion complete. Secret created: cs-keycloak-ca-certs"
+      - apiVersion: v1
         annotations:
           service.beta.openshift.io/serving-cert-secret-name: cpfs-opcon-cs-keycloak-tls-secret
         labels:

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -831,19 +831,9 @@ spec:
         namespace: "{{ $.OperatorNs }}"
         data:
           rules:
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - secrets
-            verbs:
-            - create
-            - update
-            - patch
-            - get
-            - list
-            - delete
-            - watch
+          - apiGroups: [""]
+            resources: ["pods", "secrets"]
+            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"]
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         name: edb-license-rolebinding
@@ -1049,19 +1039,9 @@ spec:
         name: convert-secret-role
         data:
           rules:
-          - apiGroups:
-            - ""
-            resources:
-            - secrets
-            - configmaps
-            verbs:
-            - create
-            - update
-            - patch
-            - get
-            - list
-            - delete
-            - watch
+          - apiGroups: [""]
+            resources: ["configmaps", "secrets"]
+            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"]
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         name: convert-secret-rolebinding
@@ -1625,19 +1605,9 @@ spec:
         namespace: "{{ .OperatorNs }}"
         data:
           rules:
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - secrets
-            verbs:
-            - create
-            - update
-            - patch
-            - get
-            - list
-            - delete
-            - watch
+          - apiGroups: [""]
+            resources: ["pods", "secrets"]
+            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"] 
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         name: edb-license-rolebinding

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1082,29 +1082,29 @@ spec:
                     - -c
                     - |              
                       # Check if the secret already exists
-                      if oc get secret cs-keycloak-ca-certs -n {{ .OperatorNs }} >/dev/null 2>&1; then
-                        echo "Secretcs-keycloak-ca-certs already exists. Skipping conversion."
+                      if oc get secret cs-keycloak-ca-certs >/dev/null 2>&1; then
+                        echo "Secret cs-keycloak-ca-certs already exists. Skipping conversion."
                         exit 0
                       fi
                       
                       # Check if ConfigMap exists
-                      if ! oc get configmap cs-keycloak-ca-certs -n {{ .OperatorNs }} >/dev/null 2>&1; then
+                      if ! oc get configmap cs-keycloak-ca-certs >/dev/null 2>&1; then
                         echo "ConfigMap cs-keycloak-ca-certs not found. Nothing to conversion."
                         exit 0
                       fi
                       
                       # Extract certificate file names from ConfigMap
-                      CERT_FILES=$(oc get configmap cs-keycloak-ca-certs -n {{ .OperatorNs }} -o yaml | yq e '.data | keys | .[]' -)              
+                      CERT_FILES=$(oc get configmap cs-keycloak-ca-certs -o yaml | yq e '.data | keys | .[]' -)              
                       
                       # Create a temporary directory
                       mkdir -p /tmp/certs
                       # Extract certificates from ConfigMap and save them as files
                       for CERT in $CERT_FILES; do
-                        oc get configmap cs-keycloak-ca-certs -n {{ .OperatorNs }} -o yaml | yq e ".data[\"$CERT\"]"> /tmp/certs/$CERT
+                        oc get configmap cs-keycloak-ca-certs -o yaml | yq e ".data[\"$CERT\"]"> /tmp/certs/$CERT
                       done
                       
                       # Create Secret from extracted certificates
-                      oc create secret generic cs-keycloak-ca-certs -n {{ .OperatorNs }} \
+                      oc create secret generic cs-keycloak-ca-certs \
                         $(for CERT in $CERT_FILES; do echo --from-file=/tmp/certs/$CERT; done)
                       
                       echo "Conversion complete. Secret created: cs-keycloak-ca-certs"
@@ -1218,6 +1218,11 @@ spec:
                         - amd64
                         - ppc64le
                         - s390x
+            truststores:
+              my-truststore:
+                secret:
+                  name: cs-keycloak-ca-certs
+                  optional: true
             proxy:
               headers: xforwarded
             features:
@@ -1391,6 +1396,15 @@ spec:
                   kind: CustomResourceDefinition
                 key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.truststores
                 operator: Exists
+          - path: .spec.truststores
+            operation: remove
+            matchExpressions:
+              - objectRef:
+                  name: keycloaks.k8s.keycloak.org
+                  apiVersion: apiextensions.k8s.io/v1
+                  kind: CustomResourceDefinition
+                key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.truststores
+                operator: DoesNotExist
       - apiVersion: v1
         kind: ConfigMap
         force: true

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1315,6 +1315,15 @@ spec:
                   kind: CustomResourceDefinition
                 key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.scheduling
                 operator: DoesNotExist
+          - path: .spec.unsupported.podTemplate.spec.containers[0].command
+            operation: remove
+            matchExpressions:
+              - objectRef:
+                  name: keycloaks.k8s.keycloak.org
+                  apiVersion: apiextensions.k8s.io/v1
+                  kind: CustomResourceDefinition
+                key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.truststores
+                operator: Exists
       - apiVersion: v1
         kind: ConfigMap
         force: true

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1107,16 +1107,16 @@ spec:
                 restartPolicy: OnFailure
                 serviceAccountName: convert-secret-sa
                 containers:
-                - name: convert-secret-job
-                  image: icr.io/cpopen/cpfs/cpfs-utils:latest
-                  command: ["/bin/sh", "/mnt/scripts/convert-secrets.sh"]
-                  volumeMounts
-                    - name: script-volume
-                      mountPath: /mnt/scripts
+                  - name: convert-secret-job
+                    image: {{ .UtilsImage }}
+                    command: ["/bin/sh", "/mnt/scripts/convert-secrets.sh"]
+                    volumeMounts:
+                      - name: script-volume
+                        mountPath: /mnt/scripts
                 volumes:
-                - name: script-volume
-                  configMap:
-                    name: convert-secrets
+                  - name: script-volume
+                    configMap:
+                      name: convert-secrets
       - apiVersion: v1
         annotations:
           service.beta.openshift.io/serving-cert-secret-name: cpfs-opcon-cs-keycloak-tls-secret


### PR DESCRIPTION
**What this PR does**: In Keycloak 24 and 26, it supports the truststore field directly defined in the spec field, allowing to specify the secret in it. Additionally, when running on a Kubernetes or OpenShift environment, well-known locations of trusted certificates, such as `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, are included automatically. 
Therefore, we can remove the import of kube service account certificates from the startup script.

Doc reference: https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html/operator_guide/advanced-configuration-#advanced-configuration-truststores

**Issue**: 
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65326#issuecomment-101278352
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65678

**How to test**:
Test Image: quay.io/yuchen_shen/cs_operator:truststore
1. delete the OperandConfig and apply the test image
2. install keycloak, the console could be accessed successfully.
