### PR TITLE
add full DNS name to mongo certificate

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -53,31 +53,30 @@ function main() {
     save_log "cp3pt0-deployment/logs" "preload_data_log" "$DEBUG"
     trap cleanup_log EXIT
     prereq
-    patch_cert
     # if [[ $CLEANUP == "false" ]]; then
-    #   if [[ $RERUN == "true" ]]; then
-    #     info "Rerun specified..."
-    #     deletemongocopy
-    #   fi
-    #   # run backup preload
-    #   backup_preload_mongo
-    #   # copy im credentials
-    #   copy_resource "secret" "platform-auth-idp-credentials"
-    #   copy_resource "secret" "platform-auth-ldaps-ca-cert"
-    #   copy_resource "secret" "platform-oidc-credentials"
-    #   copy_resource "secret" "oauth-client-secret"
-    #   copy_resource "configmap" "ibm-cpp-config"
-    #   copy_resource "configmap" "common-web-ui-config"
-    #   copy_resource "configmap" "platform-auth-idp"
-    #   copy_resource "commonservice" "common-service" "preload-common-service-from-$FROM_NAMESPACE"
-    #   copy_resource "secret" "icp-mongodb-client-cert"
-    #   copy_resource "secret" "mongodb-root-ca-cert"
-    #   copy_resource "secret" "icp-mongodb-admin"
-    #   # any extra config
-    # else
-    #   info "Cleanup selected. Cleaning MongoDB in services namespace $TO_NAMESPACE"
-    #   deletemongocopy
-    # fi
+      if [[ $RERUN == "true" ]]; then
+        info "Rerun specified..."
+        deletemongocopy
+      fi
+      # run backup preload
+      backup_preload_mongo
+      # copy im credentials
+      copy_resource "secret" "platform-auth-idp-credentials"
+      copy_resource "secret" "platform-auth-ldaps-ca-cert"
+      copy_resource "secret" "platform-oidc-credentials"
+      copy_resource "secret" "oauth-client-secret"
+      copy_resource "configmap" "ibm-cpp-config"
+      copy_resource "configmap" "common-web-ui-config"
+      copy_resource "configmap" "platform-auth-idp"
+      copy_resource "commonservice" "common-service" "preload-common-service-from-$FROM_NAMESPACE"
+      copy_resource "secret" "icp-mongodb-client-cert"
+      copy_resource "secret" "mongodb-root-ca-cert"
+      copy_resource "secret" "icp-mongodb-admin"
+      # any extra config
+    else
+      info "Cleanup selected. Cleaning MongoDB in services namespace $TO_NAMESPACE"
+      deletemongocopy
+    fi
 }
 
 function parse_arguments() {
@@ -248,6 +247,7 @@ function check_copied_resource() {
 #
 function backup_preload_mongo() {
   pre_req_bpm
+  patch_cert
   cleanup
   deploymongocopy
   createdumppvc

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -292,7 +292,7 @@ function patch_cert() {
     if [[ $dns_exist == "fail" ]]; then
         info "Updating icp-mongodb-client-cert certificate"
         original_tls_data=$(${OC} get secret -n $FROM_NAMESPACE --no-headers --ignore-not-found icp-mongodb-client-cert -o jsonpath={.data.'tls\.crt'})
-        ${OC} patch certificate icp-mongodb-client-cert -n $FROM_NAMESPACE --type="json" -p '[{"op": "add", "path":"/spec/dnsNames/1", "value":"mongodb.'"${FROM_NAMESPACE}"'.svc.cluster.local"}]' #2> /dev/null
+        ${OC} patch certificates.v1.cert-manager.io icp-mongodb-client-cert -n $FROM_NAMESPACE --type="json" -p '[{"op": "add", "path":"/spec/dnsNames/0", "value":"mongodb.'"${FROM_NAMESPACE}"'.svc.cluster.local"}]'
 
         # wait for cert-manager renew this certificate secret
         retries=60

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -286,7 +286,7 @@ function pre_req_bpm() {
 function patch_cert() {
     info "Adding full DNS name into icp-mongodb-client-cert certificate in $FROM_NAMESPACE"
 
-    full_dnsname=$(${OC} get certificate icp-mongodb-client-cert -n $FROM_NAMESPACE -o=jsonpath='{.spec.dnsNames}') 
+    full_dnsname=$(${OC} get certificates.v1.cert-manager.io icp-mongodb-client-cert -n $FROM_NAMESPACE -o=jsonpath='{.spec.dnsNames}') 
     dns_exist=$(echo $full_dnsname | grep "mongodb.$FROM_NAMESPACE.svc.cluster.local" > /dev/null || echo fail)
 
     if [[ $dns_exist == "fail" ]]; then

--- a/preload_data.sh
+++ b/preload_data.sh
@@ -53,7 +53,7 @@ function main() {
     save_log "cp3pt0-deployment/logs" "preload_data_log" "$DEBUG"
     trap cleanup_log EXIT
     prereq
-    # if [[ $CLEANUP == "false" ]]; then
+    if [[ $CLEANUP == "false" ]]; then
       if [[ $RERUN == "true" ]]; then
         info "Rerun specified..."
         deletemongocopy


### PR DESCRIPTION
**What this PR does / why we need it**:
 Update the Certificate icp-mongodb-client-cert in original namespace to include the DNS name `mongodb.<original-ns>.svc.cluster.local`
**Which issue(s) this PR fixes**:
Fixes #  https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65642

