### PR TITLE
Enable granting permission for token exchange

### DIFF
--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -947,6 +947,7 @@ spec:
             features:
               enabled:
                 - token-exchange
+                - admin-fine-grained-authz
             db:
               host: keycloak-edb-cluster-rw
               passwordSecret:


### PR DESCRIPTION
**What this PR does / why we need it**: 
If the clients that want to exchange tokens for a different client need to be authorized in the Admin Console, so a token-exchange fine grain permission `- admin-fine-grained-authz` was enabled by default in Keycloak CR

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65708

**How to backport this PR to other branch**:
1. After `- admin-fine-grained-authz` is enabled, the permission section in the client is shown up

_**Before adding into CR:**_

<img width="971" alt="Screenshot 2025-01-20 at 3 56 17 PM" src="https://github.com/user-attachments/assets/c43d5d78-13c1-4619-a3a3-cc6d8cd72c89" />

_**After**:_

<img width="965" alt="Screenshot 2025-01-20 at 4 05 47 PM" src="https://github.com/user-attachments/assets/6d50b1db-79dd-40e5-9a07-f21bf41d6969" />



**Doc reference:** 
https://www.keycloak.org/securing-apps/token-exchange#_internal-token-to-internal-token-exchange