### PR TITLE
Pick up PostgreSQL 14.15 image for Keycloak 

### DIFF
--- a/controllers/constant/cloudNativePostgresql.go
+++ b/controllers/constant/cloudNativePostgresql.go
@@ -29,7 +29,7 @@ metadata:
 data:
   ibm-postgresql-16-operand-image: icr.io/cpopen/edb/postgresql:16.4@sha256:d87a804d9bb7558d124bd83a83c261a074c26bccc3fe6ef095cdbe22be29a456
   ibm-postgresql-15-operand-image: icr.io/cpopen/edb/postgresql:15.8@sha256:8f602b668e1174357332374094a93534a2ab132e954badcb82b331c2e04b65da
-  ibm-postgresql-14-operand-image: icr.io/cpopen/edb/postgresql:14.13@sha256:b857cfedbca28f2e17feb48b3809d29691be5eeb6d0838d8f80df402c5b018eb
+  ibm-postgresql-14-operand-image: icr.io/cpopen/edb/postgresql:14.15@sha256:e027ee5a9aaebd369196c119481a14eba961119a3c3b1748aac06936bcb3afe1
   ibm-postgresql-13-operand-image: icr.io/cpopen/edb/postgresql:13.16@sha256:9fc9cc5dd91c38797397a02736996857d0182e4858ee77aeeb21f855121c9347
   ibm-postgresql-12-operand-image: icr.io/cpopen/edb/postgresql:12.20@sha256:1a5ec719c2f7da6d98374cfa43a03f96a56195416ff0c7443ee255dc92d8a82b
   edb-postgres-license-provider-image: cp.icr.io/cp/cpd/edb-postgres-license-provider@sha256:8112cfa96daac82de5a4fdede8fcaecfc41908e7ee22686e0f8818c875784a00


### PR DESCRIPTION
**What this PR does / why we need it**:  
Pick up PostgreSQL 14.15 image for CP4I consuming the latest version EDB 1.22.8

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65734
