### PR TITLE
Adding OLM required metadata (#2339)

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -34,6 +34,13 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.31.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/ibm-common-service-operator
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     support: IBM
   labels:
     operatorframework.io/arch.amd64: supported

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -19,6 +19,13 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/IBM/ibm-common-service-operator
     support: IBM
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "true"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported


### PR DESCRIPTION
cherry-pick: https://github.com/IBM/ibm-common-service-operator/pull/2339

Adding OLM required metadataas defined in https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#con-operator-requirements_openshift-sw-cert-policy-products-managed and required by RH Certification

**What this PR does / why we need it**:
OLM has introduced several required annotations which operator bundle is missing.