### PR TITLE
Decouple common service operator from OLM

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -97,6 +97,39 @@ type Resource struct {
 	Scope   string
 }
 
+func NewNonOLMBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
+	cpfsNs := util.GetCPFSNamespace(mgr.GetAPIReader())
+	servicesNs := util.GetServicesNamespace(mgr.GetAPIReader())
+	operatorNs, err := util.GetOperatorNamespace()
+	if err != nil {
+		return
+	}
+	csData := apiv3.CSData{
+		CPFSNs:                  cpfsNs,
+		ServicesNs:              servicesNs,
+		OperatorNs:              operatorNs,
+		CatalogSourceName:       "",
+		CatalogSourceNs:         "",
+		ApprovalMode:            "",
+		WatchNamespaces:         util.GetWatchNamespace(),
+		OnPremMultiEnable:       strconv.FormatBool(util.CheckMultiInstances(mgr.GetAPIReader())),
+		ExcludedCatalog:         constant.ExcludedCatalog,
+		StatusMonitoredServices: constant.StatusMonitoredServices,
+	}
+
+	bs = &Bootstrap{
+		Client:               mgr.GetClient(),
+		Reader:               mgr.GetAPIReader(),
+		Config:               mgr.GetConfig(),
+		EventRecorder:        mgr.GetEventRecorderFor("ibm-common-service-operator"),
+		Manager:              deploy.NewDeployManager(mgr),
+		SaasEnable:           util.CheckSaas(mgr.GetAPIReader()),
+		MultiInstancesEnable: util.CheckMultiInstances(mgr.GetAPIReader()),
+		CSData:               csData,
+	}
+	return
+}
+
 // NewBootstrap is the way to create a NewBootstrap struct
 func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 	cpfsNs := util.GetCPFSNamespace(mgr.GetAPIReader())

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -63,6 +63,11 @@ const (
 
 func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 
+	if os.Getenv("NO_OLM") == "true" {
+		klog.Infof("Reconciling CommonService: %s in non OLM environment", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
 	klog.Infof("Reconciling CommonService: %s", req.NamespacedName)
 
 	// Fetch the CommonService instance

--- a/main.go
+++ b/main.go
@@ -167,8 +167,6 @@ func main() {
 			}
 
 			klog.Infof("Start go routines")
-			// Update CS CR Status
-			go goroutines.UpdateCsCrStatus(bs)
 			// Create CS CR
 			go goroutines.WaitToCreateCsCR(bs)
 			// Delete Keycloak Cert

--- a/main.go
+++ b/main.go
@@ -45,14 +45,11 @@ import (
 	certmanagerv1 "github.com/ibm/ibm-cert-manager-operator/apis/cert-manager/v1"
 
 	operatorv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
-	"github.com/IBM/ibm-common-service-operator/v4/controllers"
 	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
 	certmanagerv1controllers "github.com/IBM/ibm-common-service-operator/v4/controllers/cert-manager"
 	util "github.com/IBM/ibm-common-service-operator/v4/controllers/common"
 	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
 	"github.com/IBM/ibm-common-service-operator/v4/controllers/goroutines"
-	commonservicewebhook "github.com/IBM/ibm-common-service-operator/v4/controllers/webhooks/commonservice"
-	operandrequestwebhook "github.com/IBM/ibm-common-service-operator/v4/controllers/webhooks/operandrequest"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -155,15 +152,15 @@ func main() {
 			os.Exit(1)
 		}
 
-		klog.Infof("Setup commonservice manager")
-		if err = (&controllers.CommonServiceReconciler{
-			Bootstrap: bs,
-			Scheme:    mgr.GetScheme(),
-			Recorder:  mgr.GetEventRecorderFor("commonservice-controller"),
-		}).SetupWithManager(mgr); err != nil {
-			klog.Errorf("Unable to create controller CommonService: %v", err)
-			os.Exit(1)
-		}
+		// klog.Infof("Setup commonservice manager")
+		// if err = (&controllers.CommonServiceReconciler{
+		// 	Bootstrap: bs,
+		// 	Scheme:    mgr.GetScheme(),
+		// 	Recorder:  mgr.GetEventRecorderFor("commonservice-controller"),
+		// }).SetupWithManager(mgr); err != nil {
+		// 	klog.Errorf("Unable to create controller CommonService: %v", err)
+		// 	os.Exit(1)
+		// }
 
 		klog.Infof("Start go routines")
 		// Update CS CR Status
@@ -210,26 +207,26 @@ func main() {
 		klog.Infof("Common Service Operator in the namespace %s takes charge of resource management", cpfsNs)
 	}
 
-	// Start up the webhook server
-	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
-		if err = (&commonservicewebhook.Defaulter{
-			Client:    mgr.GetClient(),
-			Reader:    mgr.GetAPIReader(),
-			IsDormant: operatorNs != cpfsNs,
-		}).SetupWebhookWithManager(mgr); err != nil {
-			klog.Errorf("Unable to create CommonService webhook: %v", err)
-			os.Exit(1)
-		}
+	// // Start up the webhook server
+	// if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+	// 	if err = (&commonservicewebhook.Defaulter{
+	// 		Client:    mgr.GetClient(),
+	// 		Reader:    mgr.GetAPIReader(),
+	// 		IsDormant: operatorNs != cpfsNs,
+	// 	}).SetupWebhookWithManager(mgr); err != nil {
+	// 		klog.Errorf("Unable to create CommonService webhook: %v", err)
+	// 		os.Exit(1)
+	// 	}
 
-		if err = (&operandrequestwebhook.Defaulter{
-			Client:    mgr.GetClient(),
-			Reader:    mgr.GetAPIReader(),
-			IsDormant: operatorNs != cpfsNs,
-		}).SetupWebhookWithManager(mgr); err != nil {
-			klog.Errorf("Unable to create OperandRequest webhook: %v", err)
-			os.Exit(1)
-		}
-	}
+	// 	if err = (&operandrequestwebhook.Defaulter{
+	// 		Client:    mgr.GetClient(),
+	// 		Reader:    mgr.GetAPIReader(),
+	// 		IsDormant: operatorNs != cpfsNs,
+	// 	}).SetupWebhookWithManager(mgr); err != nil {
+	// 		klog.Errorf("Unable to create OperandRequest webhook: %v", err)
+	// 		os.Exit(1)
+	// 	}
+	// }
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		klog.Errorf("unable to set up health check: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
The common-service-operator makes use of some OLM APIs, which need to be de-coupled so that cs-operator can be installed and work in cluster without OLM.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65720
