### PR TITLE
refactor cs-operator to enable common-service controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ else
 ARTIFACTORYA_REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 endif
 
-REGISTRY ?= "quay.io/yuchen_li1"
+REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= common-service-operator

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ else
 ARTIFACTORYA_REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 endif
 
-REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
+REGISTRY ?= "quay.io/yuchen_li1"
 
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= common-service-operator

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -257,6 +257,7 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 	}
 
 	if os.Getenv("NO_OLM") != "true" {
+		// skip deploy ODLM in no-olm
 		klog.Info("Installing ODLM Operator")
 		if err := b.renderTemplate(constant.ODLMSubscription, b.CSData); err != nil {
 			return err

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -269,8 +269,9 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 		} else if isWaiting {
 			forceUpdateODLMCRs = true
 		}
+	} else {
+		forceUpdateODLMCRs = true
 	}
-	forceUpdateODLMCRs = true
 
 	// wait ODLM OperandRegistry and OperandConfig CRD
 	if err := b.waitResourceReady(constant.OpregAPIGroupVersion, constant.OpregKind); err != nil {

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -97,39 +98,6 @@ type Resource struct {
 	Scope   string
 }
 
-func NewNonOLMBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
-	cpfsNs := util.GetCPFSNamespace(mgr.GetAPIReader())
-	servicesNs := util.GetServicesNamespace(mgr.GetAPIReader())
-	operatorNs, err := util.GetOperatorNamespace()
-	if err != nil {
-		return
-	}
-	csData := apiv3.CSData{
-		CPFSNs:                  cpfsNs,
-		ServicesNs:              servicesNs,
-		OperatorNs:              operatorNs,
-		CatalogSourceName:       "",
-		CatalogSourceNs:         "",
-		ApprovalMode:            "",
-		WatchNamespaces:         util.GetWatchNamespace(),
-		OnPremMultiEnable:       strconv.FormatBool(util.CheckMultiInstances(mgr.GetAPIReader())),
-		ExcludedCatalog:         constant.ExcludedCatalog,
-		StatusMonitoredServices: constant.StatusMonitoredServices,
-	}
-
-	bs = &Bootstrap{
-		Client:               mgr.GetClient(),
-		Reader:               mgr.GetAPIReader(),
-		Config:               mgr.GetConfig(),
-		EventRecorder:        mgr.GetEventRecorderFor("ibm-common-service-operator"),
-		Manager:              deploy.NewDeployManager(mgr),
-		SaasEnable:           util.CheckSaas(mgr.GetAPIReader()),
-		MultiInstancesEnable: util.CheckMultiInstances(mgr.GetAPIReader()),
-		CSData:               csData,
-	}
-	return
-}
-
 // NewBootstrap is the way to create a NewBootstrap struct
 func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 	cpfsNs := util.GetCPFSNamespace(mgr.GetAPIReader())
@@ -140,10 +108,13 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 	}
 
 	catalogSourceName, catalogSourceNs := util.GetCatalogSource(constant.IBMCSPackage, operatorNs, mgr.GetAPIReader())
-	if catalogSourceName == "" || catalogSourceNs == "" {
-		err = fmt.Errorf("failed to get catalogsource")
-		return
+	if os.Getenv("NO_OLM") != "true" {
+		if catalogSourceName == "" || catalogSourceNs == "" {
+			err = fmt.Errorf("failed to get catalogsource")
+			return
+		}
 	}
+
 	approvalMode, err := util.GetApprovalModeinNs(mgr.GetAPIReader(), operatorNs)
 	if err != nil {
 		return
@@ -196,13 +167,18 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 
 // InitResources initialize resources at the bootstrap of operator
 func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLMCRs bool) error {
-	installPlanApproval := instance.Spec.InstallPlanApproval
 
-	if installPlanApproval != "" {
-		if installPlanApproval != olmv1alpha1.ApprovalAutomatic && installPlanApproval != olmv1alpha1.ApprovalManual {
-			return fmt.Errorf("invalid value for installPlanApproval %v", installPlanApproval)
+	installPlanApproval := instance.Spec.InstallPlanApproval
+	if os.Getenv("NO_OLM") != "true" {
+		if installPlanApproval != "" {
+			if installPlanApproval != olmv1alpha1.ApprovalAutomatic && installPlanApproval != olmv1alpha1.ApprovalManual {
+				return fmt.Errorf("invalid value for installPlanApproval %v", installPlanApproval)
+			}
+			b.CSData.ApprovalMode = string(installPlanApproval)
 		}
-		b.CSData.ApprovalMode = string(installPlanApproval)
+	} else {
+		// set installPlanApproval to empty in non olm environment
+		installPlanApproval = ""
 	}
 
 	// Clean v3 Namespace Scope Operator and CRs in the servicesNamespace
@@ -280,16 +256,18 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 		}
 	}
 
-	klog.Info("Installing ODLM Operator")
-	if err := b.renderTemplate(constant.ODLMSubscription, b.CSData); err != nil {
-		return err
-	}
+	if os.Getenv("NO_OLM") != "true" {
+		klog.Info("Installing ODLM Operator")
+		if err := b.renderTemplate(constant.ODLMSubscription, b.CSData); err != nil {
+			return err
+		}
 
-	klog.Info("Waiting for ODLM Operator to be ready")
-	if isWaiting, err := b.waitOperatorCSV(constant.IBMODLMPackage, "ibm-odlm", b.CSData.CPFSNs); err != nil {
-		return err
-	} else if isWaiting {
-		forceUpdateODLMCRs = true
+		klog.Info("Waiting for ODLM Operator to be ready")
+		if isWaiting, err := b.waitOperatorCSV(constant.IBMODLMPackage, "ibm-odlm", b.CSData.CPFSNs); err != nil {
+			return err
+		} else if isWaiting {
+			forceUpdateODLMCRs = true
+		}
 	}
 
 	// wait ODLM OperandRegistry and OperandConfig CRD
@@ -532,6 +510,10 @@ func (b *Bootstrap) DeleteFromYaml(objectTemplate string, data interface{}) erro
 
 // GetSubscription returns the subscription instance of "name" from "namespace" namespace
 func (b *Bootstrap) GetSubscription(ctx context.Context, name, namespace string) (*unstructured.Unstructured, error) {
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("skip get subscription in no olm environment")
+		return nil, nil
+	}
 	klog.Infof("Fetch Subscription: %v/%v", namespace, name)
 	sub := &unstructured.Unstructured{}
 	sub.SetGroupVersionKind(olmv1alpha1.SchemeGroupVersion.WithKind("subscription"))
@@ -549,6 +531,10 @@ func (b *Bootstrap) GetSubscription(ctx context.Context, name, namespace string)
 
 // GetSubscription returns the subscription instances from a  namespace
 func (b *Bootstrap) ListSubscriptions(ctx context.Context, namespace string, listOptions client.ListOptions) (*unstructured.UnstructuredList, error) {
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("skip list subscription in no olm environment")
+		return nil, nil
+	}
 	klog.Infof("List Subscriptions in namespace %v", namespace)
 	subs := &unstructured.UnstructuredList{}
 	subs.SetGroupVersionKind(olmv1alpha1.SchemeGroupVersion.WithKind("SubscriptionList"))
@@ -657,6 +643,11 @@ func (b *Bootstrap) ListIssuer(ctx context.Context, opts ...client.ListOption) *
 }
 
 func (b *Bootstrap) CheckOperatorCatalog(ns string) error {
+
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("skip ckeck catalog in no olm environment")
+		return nil
+	}
 
 	err := utilwait.PollImmediate(time.Second*10, time.Minute*3, func() (done bool, err error) {
 		subList := &olmv1alpha1.SubscriptionList{}
@@ -1116,6 +1107,11 @@ func (b *Bootstrap) GetObjs(objectTemplate string, data interface{}, alwaysUpdat
 // need this function because common service operator is not in operandRegistry
 func (b *Bootstrap) UpdateCsOpApproval() error {
 	var commonserviceNS string
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("skip update common-service operator approval mode in no olm environment")
+		return nil
+	}
+
 	operatorNs, err := util.GetOperatorNamespace()
 	if err != nil {
 		klog.Errorf("Getting operator namespace failed: %v", err)
@@ -1173,6 +1169,11 @@ func (b *Bootstrap) UpdateCsOpApproval() error {
 }
 
 func (b *Bootstrap) updateApprovalMode() error {
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("skip update ApprovalMode in no olm environment")
+		return nil
+	}
+
 	opreg := &odlm.OperandRegistry{}
 	opregKey := types.NamespacedName{
 		Name:      "common-service",
@@ -1430,6 +1431,11 @@ func (b *Bootstrap) DeployCertManagerCR() error {
 // CleanNamespaceScopeResources will delete the v3 NamesapceScopes resources and namespace scope operator
 // NamespaceScope resources include common-service, nss-managedby-odlm, nss-odlm-scope, and odlm-scope-managedby-odlm
 func (b *Bootstrap) CleanNamespaceScopeResources() error {
+
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("skip cleanup namespace scope resources in no olm environment")
+		return nil
+	}
 
 	// get namespace-scope ConfigMap in operatorNamespace
 	nssCmNs, err := util.GetNssCmNs(b.Reader, b.CSData.OperatorNs)
@@ -2137,6 +2143,10 @@ func (b *Bootstrap) waitOperatorCSV(subName, packageManifest, operatorNs string)
 }
 
 func (b *Bootstrap) checkOperatorCSV(subName, packageManifest, operatorNs string) (bool, error) {
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("skip checking operator CSV in no olm environment")
+		return false, nil
+	}
 	// Get the subscription by name and namespace
 	sub := &olmv1alpha1.Subscription{}
 	if err := b.Reader.Get(context.TODO(), types.NamespacedName{Name: subName, Namespace: operatorNs}, sub); err != nil {

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -270,6 +270,7 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 			forceUpdateODLMCRs = true
 		}
 	}
+	forceUpdateODLMCRs = true
 
 	// wait ODLM OperandRegistry and OperandConfig CRD
 	if err := b.waitResourceReady(constant.OpregAPIGroupVersion, constant.OpregKind); err != nil {

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -494,7 +494,13 @@ func GetControlNs(r client.Reader) (controlNs string) {
 	return
 }
 
+// could have issue
 func GetApprovalModeinNs(r client.Reader, ns string) (approvalMode string, err error) {
+	// set approval mode to empty in non-olm environment
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("set approval mode to empty in no olm environment")
+		return "", nil
+	}
 	approvalMode = string(olmv1alpha1.ApprovalAutomatic)
 	subList := &olmv1alpha1.SubscriptionList{}
 	if err := r.List(context.TODO(), subList, &client.ListOptions{Namespace: ns}); err != nil {
@@ -511,6 +517,10 @@ func GetApprovalModeinNs(r client.Reader, ns string) (approvalMode string, err e
 
 // GetCatalogSource gets CatalogSource will be used by operators
 func GetCatalogSource(packageName, ns string, r client.Reader) (CatalogSourceName, CatalogSourceNS string) {
+	if os.Getenv("NO_OLM") != "true" {
+		klog.V(2).Infof("set catalogsource name and namespace to empty in no olm environment")
+		return "", ""
+	}
 	subList := &olmv1alpha1.SubscriptionList{}
 	if err := r.List(context.TODO(), subList, &client.ListOptions{Namespace: ns}); err != nil {
 		klog.Info(err)

--- a/controllers/common/util.go
+++ b/controllers/common/util.go
@@ -517,7 +517,7 @@ func GetApprovalModeinNs(r client.Reader, ns string) (approvalMode string, err e
 
 // GetCatalogSource gets CatalogSource will be used by operators
 func GetCatalogSource(packageName, ns string, r client.Reader) (CatalogSourceName, CatalogSourceNS string) {
-	if os.Getenv("NO_OLM") != "true" {
+	if os.Getenv("NO_OLM") == "true" {
 		klog.V(2).Infof("set catalogsource name and namespace to empty in no olm environment")
 		return "", ""
 	}

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -267,6 +267,12 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		instance.SetErrorCondition(constant.MasterCR, apiv3.ConditionTypeError, corev1.ConditionTrue, apiv3.ConditionReasonError, statusErr.Error())
 		instance.Status.Phase = CRFailed
 	}
+
+	if statusErr = r.Client.Status().Update(ctx, instance); statusErr != nil {
+		klog.Errorf("Fail to update %s/%s: %v", instance.Namespace, instance.Name, err)
+		return ctrl.Result{}, statusErr
+	}
+
 	var isEqual bool
 	if isEqual, statusErr = r.updateOperandConfig(ctx, newConfigs, serviceControllerMapping); statusErr != nil {
 		if statusErr := r.updatePhase(ctx, instance, CRFailed); statusErr != nil {

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -267,12 +267,6 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		instance.SetErrorCondition(constant.MasterCR, apiv3.ConditionTypeError, corev1.ConditionTrue, apiv3.ConditionReasonError, statusErr.Error())
 		instance.Status.Phase = CRFailed
 	}
-
-	if statusErr = r.Client.Status().Update(ctx, instance); statusErr != nil {
-		klog.Errorf("Fail to update %s/%s: %v", instance.Namespace, instance.Name, statusErr)
-		return ctrl.Result{}, statusErr
-	}
-
 	var isEqual bool
 	if isEqual, statusErr = r.updateOperandConfig(ctx, newConfigs, serviceControllerMapping); statusErr != nil {
 		if statusErr := r.updatePhase(ctx, instance, CRFailed); statusErr != nil {

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -94,7 +94,7 @@ func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	if !instance.Spec.License.Accept {
 		klog.Error("Accept license by changing .spec.license.accept to true in the CommonService CR. Operator will not proceed until then")
 	}
-  
+
 	// If the CommonService CR is not paused, continue to reconcile
 	if !r.reconcilePauseRequest(instance) {
 		if r.checkNamespace(req.NamespacedName.String()) {

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -95,52 +95,6 @@ func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		klog.Error("Accept license by changing .spec.license.accept to true in the CommonService CR. Operator will not proceed until then")
 	}
 
-	if os.Getenv("NO_OLM") == "true" {
-		klog.Infof("Reconciling CommonService: %s in non OLM environment", req.NamespacedName)
-
-		// create ibm-cpp-config configmap
-		if err := configurationcollector.CreateUpdateConfig(r.Bootstrap); err != nil {
-			klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
-			return ctrl.Result{}, err
-		}
-
-		// deploy Cert Manager CR
-		if err := r.Bootstrap.DeployCertManagerCR(); err != nil {
-			klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
-			return ctrl.Result{}, err
-		}
-
-		klog.Infof("Start to Create ODLM CR in the namespace %s", r.Bootstrap.CSData.OperatorNs)
-		// Check if ODLM OperandRegistry and OperandConfig are created
-		klog.Info("Checking if OperandRegistry and OperandConfig CRD already exist")
-		existOpreg, _ := r.Bootstrap.CheckCRD(constant.OpregAPIGroupVersion, constant.OpregKind)
-		existOpcon, _ := r.Bootstrap.CheckCRD(constant.OpregAPIGroupVersion, constant.OpconKind)
-		// Install/update Opreg and Opcon resources before installing ODLM if CRDs exist
-		if existOpreg && existOpcon {
-			klog.Info("Installing/Updating OperandRegistry")
-			if err := r.Bootstrap.InstallOrUpdateOpreg(true, ""); err != nil {
-				klog.Errorf("Fail to Installing/Updating OperandConfig: %v", err)
-				return ctrl.Result{}, err
-			}
-
-			klog.Info("Installing/Updating OperandConfig")
-			if err := r.Bootstrap.InstallOrUpdateOpcon(true); err != nil {
-				klog.Errorf("Fail to Installing/Updating OperandConfig: %v", err)
-				return ctrl.Result{}, err
-			}
-
-			// Temporary solution for EDB image ConfigMap reference
-			if err := r.Bootstrap.CreateEDBImageMaps(); err != nil {
-				klog.Errorf("Failed to create EDB Image ConfigMap: %v", err)
-				return ctrl.Result{}, err
-			}
-		} else {
-			klog.Error("ODLM CRD not ready, waiting for it to be ready")
-		}
-
-		return ctrl.Result{}, nil
-	}
-
 	// If the CommonService CR is not paused, continue to reconcile
 	if !r.reconcilePauseRequest(instance) {
 		if r.checkNamespace(req.NamespacedName.String()) {

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -263,13 +263,13 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 	instance.Status.Phase = CRUpdating
 	newConfigs, serviceControllerMapping, statusErr := r.getNewConfigs(cs)
 	if statusErr != nil {
-		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		instance.SetErrorCondition(constant.MasterCR, apiv3.ConditionTypeError, corev1.ConditionTrue, apiv3.ConditionReasonError, statusErr.Error())
 		instance.Status.Phase = CRFailed
 	}
 
 	if statusErr = r.Client.Status().Update(ctx, instance); statusErr != nil {
-		klog.Errorf("Fail to update %s/%s: %v", instance.Namespace, instance.Name, err)
+		klog.Errorf("Fail to update %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		return ctrl.Result{}, statusErr
 	}
 

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -114,6 +114,11 @@ const (
 	CSMappingConfig = "ibm-cs-ns-mapping-webhook-configuration"
 )
 
+// Bedrock Deployment names for No OLM
+var (
+	DeploymentsName = []string{"ibm-common-service-operator", "operand-deployment-lifecycle-manager", "ibm-namespace-scope-operator", "ibm-commonui-operator", "ibm-iam-operator"}
+)
+
 // CsOg is OperatorGroup constent for the common service operator
 const CsOperatorGroup = `
 apiVersion: operators.coreos.com/v1

--- a/controllers/deploy/manager.go
+++ b/controllers/deploy/manager.go
@@ -19,6 +19,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -165,6 +166,10 @@ func (d *Manager) GetDeployment() (*appsv1.Deployment, error) {
 
 // DeleteOperator delete operator's csv and subscription from specific namespace
 func (d *Manager) DeleteOperator(name, namespace string) error {
+	if os.Getenv("NO_OLM") == "true" {
+		klog.V(2).Infof("skip delete operator in no-olm environment")
+		return nil
+	}
 	// Get existing operator's subscription
 	subName := name
 	subNs := namespace

--- a/controllers/goroutines/no_olm_operator_status.go
+++ b/controllers/goroutines/no_olm_operator_status.go
@@ -46,30 +46,11 @@ func UpdateNoOLMCsCrStatus(bs *bootstrap.Bootstrap) {
 
 		var operatorSlice []apiv3.BedrockOperator
 
-		operatorsName := []string{}
-
-		// wait ODLM OperandRegistry CR resources
-		if err := bs.WaitResourceReady("operator.ibm.com/v1alpha1", "OperandRegistry"); err != nil {
-			klog.Error("Failed to wait for resource ready with kind: OperandRegistry, apiGroupVersion: operator.ibm.com/v1alpha1")
-			continue
-		}
-
-		opreg, err := bs.GetOperandRegistry(ctx_NoOLM, "common-service", bs.CSData.ServicesNs)
-		if err != nil || opreg == nil {
-			// klog.Warning("OperandRegistry common-service is not ready, retry in 5 seconds")
-			time.Sleep(5 * time.Second)
-			continue
-		}
-
-		for i := range opreg.Spec.Operators {
-			operatorsName = append(operatorsName, opreg.Spec.Operators[i].Name)
-		}
-
-		for _, name := range operatorsName {
+		for _, name := range constant.DeploymentsName {
 			var opt apiv3.BedrockOperator
 			var err error
 
-			opt, err = getNoOLMBedrockOperator(bs, name, bs.CSData.CPFSNs, instance)
+			opt, err = getNoOLMBedrockOperator(bs, name, bs.CSData.CPFSNs)
 
 			if err == nil {
 				operatorSlice = append(operatorSlice, opt)
@@ -98,7 +79,7 @@ func UpdateNoOLMCsCrStatus(bs *bootstrap.Bootstrap) {
 	}
 }
 
-func getNoOLMBedrockOperator(bs *bootstrap.Bootstrap, name, namespace string, reference *apiv3.CommonService) (apiv3.BedrockOperator, error) {
+func getNoOLMBedrockOperator(bs *bootstrap.Bootstrap, name, namespace string) (apiv3.BedrockOperator, error) {
 	var opt apiv3.BedrockOperator
 	opt.Name = name
 

--- a/controllers/goroutines/no_olm_operator_status.go
+++ b/controllers/goroutines/no_olm_operator_status.go
@@ -1,0 +1,120 @@
+//
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package goroutines
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/bootstrap"
+	"github.com/IBM/ibm-common-service-operator/v4/controllers/constant"
+)
+
+var ctx_NoOLM = context.Background()
+
+// UpdateCsCrStatus will update cs cr status according to each bedrock operator
+func UpdateNoOLMCsCrStatus(bs *bootstrap.Bootstrap) {
+	for {
+		instance := &apiv3.CommonService{}
+		if err := bs.Reader.Get(ctx_NoOLM, types.NamespacedName{Name: "common-service", Namespace: bs.CSData.OperatorNs}, instance); err != nil {
+			if !errors.IsNotFound(err) {
+				klog.Warningf("Faild to get CommonService CR %v/%v: %v", instance.GetNamespace(), instance.GetName(), err)
+			}
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		var operatorSlice []apiv3.BedrockOperator
+
+		operatorsName := []string{}
+
+		// wait ODLM OperandRegistry CR resources
+		if err := bs.WaitResourceReady("operator.ibm.com/v1alpha1", "OperandRegistry"); err != nil {
+			klog.Error("Failed to wait for resource ready with kind: OperandRegistry, apiGroupVersion: operator.ibm.com/v1alpha1")
+			continue
+		}
+
+		opreg, err := bs.GetOperandRegistry(ctx_NoOLM, "common-service", bs.CSData.ServicesNs)
+		if err != nil || opreg == nil {
+			// klog.Warning("OperandRegistry common-service is not ready, retry in 5 seconds")
+			time.Sleep(5 * time.Second)
+			continue
+		}
+
+		for i := range opreg.Spec.Operators {
+			operatorsName = append(operatorsName, opreg.Spec.Operators[i].Name)
+		}
+
+		for _, name := range operatorsName {
+			var opt apiv3.BedrockOperator
+			var err error
+
+			opt, err = getNoOLMBedrockOperator(bs, name, bs.CSData.CPFSNs, instance)
+
+			if err == nil {
+				operatorSlice = append(operatorSlice, opt)
+			} else if !errors.IsNotFound(err) {
+				klog.Errorf("Failed to check operator %s: %v", name, err)
+			}
+		}
+
+		// update status for each operators: BedrockOperators list
+		instance.Status.BedrockOperators = operatorSlice
+
+		// update operators overall status: OverallStatus
+		instance.Status.OverallStatus = "Succeeded"
+		for _, opt := range operatorSlice {
+			if opt.OperatorStatus != "Succeeded" {
+				instance.Status.OverallStatus = "NotReady"
+				break
+			}
+		}
+
+		if err := bs.Client.Status().Update(ctx_NoOLM, instance); err != nil {
+			klog.Warning(err)
+		}
+
+		time.Sleep(2 * time.Minute)
+	}
+}
+
+func getNoOLMBedrockOperator(bs *bootstrap.Bootstrap, name, namespace string, reference *apiv3.CommonService) (apiv3.BedrockOperator, error) {
+	var opt apiv3.BedrockOperator
+	opt.Name = name
+
+	// fetch subscription
+	deployment := &appsv1.Deployment{}
+	deploymentKey := types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}
+	if err := bs.Client.Get(ctx_NoOLM, deploymentKey, deployment); err != nil {
+		return opt, nil
+	}
+
+	if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {
+		opt.Troubleshooting = "Operator status is not healthy, please check " + constant.GeneralTroubleshooting + " for more information"
+	}
+
+	return opt, nil
+}

--- a/controllers/goroutines/no_olm_operator_status.go
+++ b/controllers/goroutines/no_olm_operator_status.go
@@ -90,7 +90,7 @@ func getNoOLMBedrockOperator(bs *bootstrap.Bootstrap, name, namespace string) (a
 		Namespace: namespace,
 	}
 	if err := bs.Client.Get(ctx_NoOLM, deploymentKey, deployment); err != nil {
-		return opt, nil
+		return opt, err
 	}
 
 	if deployment.Status.ReadyReplicas != *deployment.Spec.Replicas {

--- a/main.go
+++ b/main.go
@@ -142,131 +142,69 @@ func main() {
 	// If Common Service Operator Namespace is not in the same as .spec.operatorNamespace(cpfsNs) in default CS CR,
 	// this Common Service Operator is not in the operatorNamespace(cpfsNs) under this tenant, and goes dormant.
 	if operatorNs == cpfsNs {
+		// New bootstrap Object
+		bs, err := bootstrap.NewBootstrap(mgr)
+		if err != nil {
+			klog.Errorf("Bootstrap failed: %v", err)
+			os.Exit(1)
+		}
 
-		// Bootstrap for non-olm deploy
-		if os.Getenv("NO_OLM") == "true" {
-			bs, err := bootstrap.NewNonOLMBootstrap(mgr)
-			if err != nil {
-				klog.Errorf("Bootstrap failed: %v", err)
-				os.Exit(1)
-			}
+		if err := bs.CleanupWebhookResources(); err != nil {
+			klog.Errorf("Cleanup Webhook Resources failed: %v", err)
+			os.Exit(1)
+		}
 
-			if err := bs.CleanupWebhookResources(); err != nil {
-				klog.Errorf("Cleanup Webhook Resources failed: %v", err)
-				os.Exit(1)
-			}
+		klog.Infof("Setup commonservice manager")
+		if err = (&controllers.CommonServiceReconciler{
+			Bootstrap: bs,
+			Scheme:    mgr.GetScheme(),
+			Recorder:  mgr.GetEventRecorderFor("commonservice-controller"),
+		}).SetupWithManager(mgr); err != nil {
+			klog.Errorf("Unable to create controller CommonService: %v", err)
+			os.Exit(1)
+		}
 
-			klog.Infof("Setup commonservice manager")
-			if err = (&controllers.CommonServiceReconciler{
-				Bootstrap: bs,
-				Scheme:    mgr.GetScheme(),
-				Recorder:  mgr.GetEventRecorderFor("commonservice-controller"),
-			}).SetupWithManager(mgr); err != nil {
-				klog.Errorf("Unable to create controller CommonService: %v", err)
-				os.Exit(1)
-			}
-
-			klog.Infof("Start go routines")
-			// Create CS CR
-			go goroutines.WaitToCreateCsCR(bs)
-			// Delete Keycloak Cert
-			go goroutines.CleanupResources(bs)
-
-			// check if cert-manager CRD does not exist, then skip cert-manager related controllers initialization
-			exist, err := bs.CheckCRD(constant.CertManagerAPIGroupVersionV1, "Certificate")
-			if err != nil {
-				klog.Errorf("Failed to check if cert-manager CRD exists: %v", err)
-				os.Exit(1)
-			}
-			if !exist && err == nil {
-				klog.Infof("cert-manager CRD does not exist, skip cert-manager related controllers initialization")
-			} else if exist && err == nil {
-
-				if err = (&certmanagerv1controllers.CertificateRefreshReconciler{
-					Client: mgr.GetClient(),
-					Scheme: mgr.GetScheme(),
-				}).SetupWithManager(mgr); err != nil {
-					klog.Error(err, "unable to create controller", "controller", "CertificateRefresh")
-					os.Exit(1)
-				}
-				if err = (&certmanagerv1controllers.PodRefreshReconciler{
-					Client: mgr.GetClient(),
-					Scheme: mgr.GetScheme(),
-				}).SetupWithManager(mgr); err != nil {
-					klog.Error(err, "unable to create controller", "controller", "PodRefresh")
-					os.Exit(1)
-				}
-				if err = (&certmanagerv1controllers.V1AddLabelReconciler{
-					Client: mgr.GetClient(),
-					Scheme: mgr.GetScheme(),
-				}).SetupWithManager(mgr); err != nil {
-					klog.Error(err, "unable to create controller", "controller", "V1AddLabel")
-					os.Exit(1)
-				}
-			}
-		} else {
-
-			// New bootstrap Object
-			bs, err := bootstrap.NewBootstrap(mgr)
-			if err != nil {
-				klog.Errorf("Bootstrap failed: %v", err)
-				os.Exit(1)
-			}
-
-			if err := bs.CleanupWebhookResources(); err != nil {
-				klog.Errorf("Cleanup Webhook Resources failed: %v", err)
-				os.Exit(1)
-			}
-
-			klog.Infof("Setup commonservice manager")
-			if err = (&controllers.CommonServiceReconciler{
-				Bootstrap: bs,
-				Scheme:    mgr.GetScheme(),
-				Recorder:  mgr.GetEventRecorderFor("commonservice-controller"),
-			}).SetupWithManager(mgr); err != nil {
-				klog.Errorf("Unable to create controller CommonService: %v", err)
-				os.Exit(1)
-			}
-
-			klog.Infof("Start go routines")
+		klog.Infof("Start go routines")
+		if os.Getenv("NO_OLM") != "true" {
 			// Update CS CR Status
 			go goroutines.UpdateCsCrStatus(bs)
-			// Create CS CR
-			go goroutines.WaitToCreateCsCR(bs)
-			// Delete Keycloak Cert
-			go goroutines.CleanupResources(bs)
+		}
 
-			// check if cert-manager CRD does not exist, then skip cert-manager related controllers initialization
-			exist, err := bs.CheckCRD(constant.CertManagerAPIGroupVersionV1, "Certificate")
-			if err != nil {
-				klog.Errorf("Failed to check if cert-manager CRD exists: %v", err)
+		// Create CS CR
+		go goroutines.WaitToCreateCsCR(bs)
+		// Delete Keycloak Cert
+		go goroutines.CleanupResources(bs)
+
+		// check if cert-manager CRD does not exist, then skip cert-manager related controllers initialization
+		exist, err := bs.CheckCRD(constant.CertManagerAPIGroupVersionV1, "Certificate")
+		if err != nil {
+			klog.Errorf("Failed to check if cert-manager CRD exists: %v", err)
+			os.Exit(1)
+		}
+		if !exist && err == nil {
+			klog.Infof("cert-manager CRD does not exist, skip cert-manager related controllers initialization")
+		} else if exist && err == nil {
+
+			if err = (&certmanagerv1controllers.CertificateRefreshReconciler{
+				Client: mgr.GetClient(),
+				Scheme: mgr.GetScheme(),
+			}).SetupWithManager(mgr); err != nil {
+				klog.Error(err, "unable to create controller", "controller", "CertificateRefresh")
 				os.Exit(1)
 			}
-			if !exist && err == nil {
-				klog.Infof("cert-manager CRD does not exist, skip cert-manager related controllers initialization")
-			} else if exist && err == nil {
-
-				if err = (&certmanagerv1controllers.CertificateRefreshReconciler{
-					Client: mgr.GetClient(),
-					Scheme: mgr.GetScheme(),
-				}).SetupWithManager(mgr); err != nil {
-					klog.Error(err, "unable to create controller", "controller", "CertificateRefresh")
-					os.Exit(1)
-				}
-				if err = (&certmanagerv1controllers.PodRefreshReconciler{
-					Client: mgr.GetClient(),
-					Scheme: mgr.GetScheme(),
-				}).SetupWithManager(mgr); err != nil {
-					klog.Error(err, "unable to create controller", "controller", "PodRefresh")
-					os.Exit(1)
-				}
-				if err = (&certmanagerv1controllers.V1AddLabelReconciler{
-					Client: mgr.GetClient(),
-					Scheme: mgr.GetScheme(),
-				}).SetupWithManager(mgr); err != nil {
-					klog.Error(err, "unable to create controller", "controller", "V1AddLabel")
-					os.Exit(1)
-				}
+			if err = (&certmanagerv1controllers.PodRefreshReconciler{
+				Client: mgr.GetClient(),
+				Scheme: mgr.GetScheme(),
+			}).SetupWithManager(mgr); err != nil {
+				klog.Error(err, "unable to create controller", "controller", "PodRefresh")
+				os.Exit(1)
+			}
+			if err = (&certmanagerv1controllers.V1AddLabelReconciler{
+				Client: mgr.GetClient(),
+				Scheme: mgr.GetScheme(),
+			}).SetupWithManager(mgr); err != nil {
+				klog.Error(err, "unable to create controller", "controller", "V1AddLabel")
+				os.Exit(1)
 			}
 		}
 	} else {

--- a/main.go
+++ b/main.go
@@ -168,6 +168,9 @@ func main() {
 		if os.Getenv("NO_OLM") != "true" {
 			// Update CS CR Status
 			go goroutines.UpdateCsCrStatus(bs)
+		} else {
+			// Update CS CR Status
+			go goroutines.UpdateNoOLMCsCrStatus(bs)
 		}
 
 		// Create CS CR


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor cs-operator to de-couple it from OLM API
Enable common-service controller, so most of the key feature in cs-operators working in no olm environment, except:
1. webhooks (need to create webhook service and inject webhook-secret)
2. odlm and nss cleanup if it is upgrade from LTSR (need to cleanup sub and csv)
3. ~~operator status check (need to check deployment instead of sub and csv)~~

**Which issue(s) this PR fixes**:
Fixes #  https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65720

 