### PR TITLE
Removed EDB image list created by cs operator for non-olm case

### DIFF
--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -223,9 +224,12 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 	}
 
 	// Temporary solution for EDB image ConfigMap reference
-	if err := b.CreateEDBImageMaps(); err != nil {
-		klog.Errorf("Failed to create EDB Image ConfigMap: %v", err)
-		return err
+	if os.Getenv("NO_OLM") != "true" {
+		klog.Infof("It is not a non-OLM mode, create EDB Image ConfigMap")
+		if err := b.CreateEDBImageMaps(); err != nil {
+			klog.Errorf("Failed to create EDB Image ConfigMap: %v", err)
+			return err
+		}
 	}
 
 	// Create Keycloak themes ConfigMap

--- a/controllers/commonservice_controller.go
+++ b/controllers/commonservice_controller.go
@@ -130,10 +130,11 @@ func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 
 			// Temporary solution for EDB image ConfigMap reference
-			if err := r.Bootstrap.CreateEDBImageMaps(); err != nil {
-				klog.Errorf("Failed to create EDB Image ConfigMap: %v", err)
-				return ctrl.Result{}, err
-			}
+			klog.Infof("It is a non-OLM mode, skip creating EDB Image ConfigMap...")
+			// if err := r.Bootstrap.CreateEDBImageMaps(); err != nil {
+			// 	klog.Errorf("Failed to create EDB Image ConfigMap: %v", err)
+			// 	return ctrl.Result{}, err
+			// }
 		} else {
 			klog.Error("ODLM CRD not ready, waiting for it to be ready")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: EDB image list ConfigMap will be included in EDB helm charts,  and cs oeprator will not manager this ConfigMap in non-OLM case any more.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65815

 **How the test is done**:
Test image: quay.io/yuchen_shen/cs_operator:edb
1. Apply image in OLM-base operator, the ConfigMap `cloud-native-postgresql-image-list` is still created with log 
    ```
    I0211 03:03:41.575718 1 init.go:228] It is not a non-OLM mode, create EDB Image ConfigMap
    ```
2. Apply image in non-OLM deployment, ConfigMap will not shown up with log
    ```
    I0211 03:03:28.390738       1 commonservice_controller.go:133] It is a non-OLM mode, skip creating EDB Image ConfigMap...
    ```
