### PR TITLE
create olm -> no olm migration chart in master branch

### DIFF
--- a/bedrock-migration/.helmignore
+++ b/bedrock-migration/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/bedrock-migration/Chart.yaml
+++ b/bedrock-migration/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: bedrock-migration
+description: A Helm chart for migrating Bedrock from OLM to No OLM
+type: application
+version: 4.12.0
+appVersion: "4.12.0"

--- a/bedrock-migration/templates/adopt-cs-cr.yaml
+++ b/bedrock-migration/templates/adopt-cs-cr.yaml
@@ -1,0 +1,7 @@
+#not sure this is necessary
+apiVersion: operator.ibm.com/v3
+kind: CommonService
+metadata:
+  name: common-service
+  namespace: {{ .Values.global.operatorNamespace }}
+spec:

--- a/bedrock-migration/templates/adopt-nss-cr.yaml
+++ b/bedrock-migration/templates/adopt-nss-cr.yaml
@@ -1,0 +1,7 @@
+#not sure this is necessary
+apiVersion: operator.ibm.com/v1
+kind: NamespaceScope
+metadata:
+  name: common-service
+  namespace: {{ .Values.global.operatorNamespace }}
+spec:

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: bedrock-migration-job-{{ .Release.appVersion }}
+  name: bedrock-migration-job-{{ .Chart.AppVersion }}
   namespace: {{ .Values.global.operatorNamespace }}
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: bedrock-migration-job-{{ .Chart.AppVersion }}
+  name: bedrock-migration-job
   namespace: {{ .Values.global.operatorNamespace }}
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -19,6 +19,7 @@ spec:
           - bash
           - -c
           - |
+            echo "Starting cleanup for OLM -> No OLM migration..."
             operatorNamespace={{ .Values.global.operatorNamespace }}
             servicesNamespace={{ .Values.global.instanceNamespace }}
             namespaces=$(oc get cm namespace-scope -n $operatorNamespace -o jsonpath="{.data.namespaces}")
@@ -34,12 +35,14 @@ spec:
             odlmSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='ibm-odlm')].metadata.name}")
             odlmCSV=$(oc get --ignore-not-found sub $odlmSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
             odlmVersion=$(oc get --ignore-not-found csv $odlmCSV -n $operatorNamespace -o jsonpath='{.spec.version}')
-
+            
+            echo "Deleting CS, NSS, and ODLM CSVs and Subscriptions..."
             oc delete --ignore-not-found csv $csCSV -n $operatorNamespace && oc delete --ignore-not-found sub $csSub -n $operatorNamespace
             oc delete --ignore-not-found csv $nssCSV -n $operatorNamespace && oc delete --ignore-not-found sub $nssSub -n $operatorNamespace
             oc delete --ignore-not-found csv $odlmCSV -n $operatorNamespace && oc delete --ignore-not-found sub $odlmSub -n $operatorNamespace
             
             {{- if .Values.imEnabled }}
+            echo "Deleting IAM, Common UI, and EDB resources in operator namespace $operatorNamespace..."
             iamSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='ibm-iam-operator')].metadata.name}")
             iamCSV=$(oc get --ignore-not-found sub $iamSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
             uiSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='ibm-commonui-operator-app')].metadata.name}")
@@ -56,7 +59,9 @@ spec:
             {{- end }}
 
             #loop for removing roles from services and tethered namespace
+            echo "Cleaning up roles and rolebindings in namespaces $namespaces..."
             for ns in ${namespaces//,/ }; do
+                echo "Processing namespace $ns..."
                 roles=""
                 #get cs operator roles
                 roles="${roles} $(oc get roles -n $ns | grep ibm-common-service-op | awk '{print $1}' | tr "\n" " ")"
@@ -81,6 +86,7 @@ spec:
 
                 oc delete role $roles -n $ns --ignore-not-found
                 oc delete rolebindings $roles -n $ns --ignore-not-found
+                echo "Namespace $ns complete."
             done
       restartPolicy: Never
       serviceAccount: bedrock-migration-job-sa

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -1,0 +1,88 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bedrock-migration-job-{{ .Release.appVersion }}
+  namespace: {{ .Values.global.operatorNamespace }}
+  annotations:
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    spec:
+      containers:
+      - name: bedrock-migration-job
+        #should we be using our own image or the cpd image? I vote our own
+        # image: '{{ .Values.global.imagePullPrefix }}/{{ .Values.global.migrationJobImgName }}@{{ .Values.global.migrationJobImgDigest }}'
+        image: icr.io/cpopen/cpfs/cpfs-utils:4.6.7
+        command:
+          - bash
+          - -c
+          - |
+            operatorNamespace={{ .Values.global.operatorNamespace }}
+            servicesNamespace={{ .Values.global.instanceNamespace }}
+            namespaces=$(oc get cm namespace-scope -n $operatorNamespace -o jsonpath="{.data.namespaces}")
+
+            nssSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='ibm-namespace-scope-operator')].metadata.name}")
+            nssCSV=$(oc get --ignore-not-found sub $nssSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
+            nssVersion=$(oc get --ignore-not-found csv $nssCSV -n $operatorNamespace -o jsonpath='{.spec.version}')
+
+            csSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='ibm-common-service-operator')].metadata.name}")
+            csCSV=$(oc get --ignore-not-found sub $csSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
+            csVersion=$(oc get --ignore-not-found csv $csCSV -n $operatorNamespace -o jsonpath='{.spec.version}')
+
+            odlmSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='ibm-odlm')].metadata.name}")
+            odlmCSV=$(oc get --ignore-not-found sub $odlmSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
+            odlmVersion=$(oc get --ignore-not-found csv $odlmCSV -n $operatorNamespace -o jsonpath='{.spec.version}')
+
+            oc delete --ignore-not-found csv $csCSV -n $operatorNamespace && oc delete --ignore-not-found sub $csSub -n $operatorNamespace
+            oc delete --ignore-not-found csv $nssCSV -n $operatorNamespace && oc delete --ignore-not-found sub $nssSub -n $operatorNamespace
+            oc delete --ignore-not-found csv $odlmCSV -n $operatorNamespace && oc delete --ignore-not-found sub $odlmSub -n $operatorNamespace
+            
+            {{- if .Values.imEnabled }}
+            iamSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='ibm-iam-operator')].metadata.name}")
+            iamCSV=$(oc get --ignore-not-found sub $iamSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
+            uiSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='ibm-commonui-operator-app')].metadata.name}")
+            uiCSV=$(oc get --ignore-not-found sub $uiSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
+            edbSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='cloud-native-postgresql')].metadata.name}")
+            edbCSV=$(oc get --ignore-not-found sub $edbSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
+            oc delete --ignore-not-found csv $iamCSV -n $operatorNamespace && oc delete --ignore-not-found sub $iamSub -n $operatorNamespace
+            oc delete --ignore-not-found csv $uiCSV -n $operatorNamespace && oc delete --ignore-not-found sub $uiSub -n $operatorNamespace
+            oc delete --ignore-not-found csv $edbCSV -n $operatorNamespace && oc delete --ignore-not-found sub $edbSub -n $operatorNamespace
+            oc delete --ignore-not-found sa postgresql-operator-manager edb-license-sa -n $operatorNamespace
+            oc delete --ignore-not-found sa ibm-iam-operand-restricted ibm-commonui-operand common-service-db -n $servicesNamespace
+            oc delete --ignore-not-found role edb-license-role -n $operatorNamespace
+            oc delete --ignore-not-found job create-postgres-license-config -n $operatorNamespace
+            {{- end }}
+
+            #loop for removing roles from services and tethered namespace
+            for ns in ${namespaces//,/ }; do
+                roles=""
+                #get cs operator roles
+                roles="${roles} $(oc get roles -n $ns | grep ibm-common-service-op | awk '{print $1}' | tr "\n" " ")"
+                #get odlm roles
+                roles="${roles} $(oc get roles -n $ns | grep operand-deployment-l | awk '{print $1}' | tr "\n" " ")"
+                {{- if .Values.imEnabled }}
+                #get iam roles
+                roles="${roles} $(oc get roles -n $ns | grep ibm-iam | awk '{print $1}' | tr "\n" " ")"
+                #get ui roles
+                roles="${roles} $(oc get roles -n $ns | grep ibm-commonui | awk '{print $1}' | tr "\n" " ")"
+                #get edb roles
+                roles="${roles} $(oc get roles -n $ns | grep postgresql-operator-controller-manager | awk '{print $1}' | tr "\n" " ")"
+                roles="${roles} $(oc get roles -n $ns | grep cloud-native-postgresql | awk '{print $1}' | tr "\n" " ")"
+                roles="${roles} $(oc get roles -n $ns | grep common-service-db | awk '{print $1}' | tr "\n" " ")"
+                if [[ $ns != $servicesNamespace ]]; then
+                    edbSA=$(oc get sa -n $ns --ignore-not-found | grep postgresql-operator-controller-manager | awk '{print $1}' | tr "\n" " ")
+                    oc delete sa $edbSA -n $ns --ignore-not-found
+                fi
+                {{- end }}
+                #get nss roles?
+                echo "${roles}"
+
+                oc delete role $roles -n $ns --ignore-not-found
+                oc delete rolebindings $roles -n $ns --ignore-not-found
+            done
+      restartPolicy: Never
+      serviceAccount: bedrock-migration-job-sa
+      imagePullSecrets:
+      - name: {{ .Values.global.imagePullSecret }}

--- a/bedrock-migration/templates/rbac.yaml
+++ b/bedrock-migration/templates/rbac.yaml
@@ -1,0 +1,164 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bedrock-migration-job-sa
+  namespace: {{ .Values.global.operatorNamespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bedrock-migration-job-role
+  namespace: {{ .Values.global.operatorNamespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+rules: 
+- apiGroups: 
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  - clusterserviceversions
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups: 
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups: 
+  - ""
+  resources:
+  - configmaps
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups: 
+  - "batch"
+  resources:
+  - jobs
+  verbs:
+  - list
+  - get
+  - delete
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bedrock-migration-job-rb
+  namespace: {{ .Values.global.operatorNamespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+subjects:
+  - kind: ServiceAccount
+    name: bedrock-migration-job-sa
+    namespace: {{ .Values.global.operatorNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bedrock-migration-job-role
+{{- if .Values.global.instanceNamespace }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bedrock-migration-job-role
+  namespace: {{ .Values.global.instanceNamespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+rules:
+- apiGroups: 
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups: 
+  - ""
+  resources:
+  - configmaps
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bedrock-migration-job-rb
+  namespace: {{ .Values.global.instanceNamespace }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+subjects:
+  - kind: ServiceAccount
+    name: bedrock-migration-job-sa
+    namespace: {{ .Values.global.operatorNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bedrock-migration-job-role
+{{- end }}
+{{- range $i := .Values.global.tetheredNamespaces }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bedrock-migration-job-role
+  namespace: {{ $i }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+rules:
+- apiGroups: 
+  - "rbac.authorization.k8s.io"
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - delete
+- apiGroups: 
+  - ""
+  resources:
+  - configmaps
+  - serviceaccounts
+  verbs:
+  - list
+  - get
+  - delete
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: bedrock-migration-job-rb
+  namespace: {{ $i }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1"
+subjects:
+  - kind: ServiceAccount
+    name: bedrock-migration-job-sa
+    namespace: {{ $.Values.global.operatorNamespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: bedrock-migration-job-role
+{{- end }}

--- a/bedrock-migration/values.yaml
+++ b/bedrock-migration/values.yaml
@@ -4,6 +4,6 @@ imEnabled: "true" #should this be a global value? Is there a better way to deter
 global:
   operatorNamespace: "cs-op"
   instanceNamespace: "cs-serv"
-  tetheredNamespaces: ["test"]
+  tetheredNamespaces: [""]
   imagePullPrefix: icr.io
   imagePullSecret: ibm-entitlement-key

--- a/bedrock-migration/values.yaml
+++ b/bedrock-migration/values.yaml
@@ -4,6 +4,6 @@ imEnabled: "true" #should this be a global value? Is there a better way to deter
 global:
   operatorNamespace: "cs-op"
   instanceNamespace: "cs-serv"
-  tetheredNamespaces: [""]
+  tetheredNamespace: [""]
   imagePullPrefix: icr.io
   imagePullSecret: ibm-entitlement-key

--- a/bedrock-migration/values.yaml
+++ b/bedrock-migration/values.yaml
@@ -1,0 +1,9 @@
+imEnabled: "true" #should this be a global value? Is there a better way to determine this?
+
+#stand-in global values for testing
+global:
+  operatorNamespace: "cs-op"
+  instanceNamespace: "cs-serv"
+  tetheredNamespaces: ["test"]
+  imagePullPrefix: icr.io
+  imagePullSecret: ibm-entitlement-key


### PR DESCRIPTION
**What this PR does / why we need it**:

Create migration job chart for migration from OLM install to no OLM install for bedrock components.

Job is based on CPD migration template found here https://github.ibm.com/Mengdie-Chu/non-olm-installer/tree/main/charts/cpd-platform-migration and essentially runs a script where the sub, csv, and rbac for installer and bedrock services are cleaned up so they can be replaced by a helm install. CRs like NSS and CS are included to "adopt" the existing ones without outright replacing them.

Cleans up services and tethered namespaces as well.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65830

**Special notes for your reviewer**:

1. How the test is done?

- Install CS, ODLM, NSS, IM, EDB, and UI via OLM (so as normal). Make sure to include cert manager in initial install.
- Once CPFS is ready, edit migration chart values.yaml to include correct values
- install the migration chart, include --take-ownership flag in helm install command
    - If using toplevel values file instead, make sure to still set the imEnabled value to true
- verify that subscriptions, csvs, roles, rolebindings, and service accounts are deleted from the install. Should be very few pods if any running in operator namespace. 
- Verify services namespace still has required operands running as expected
- install cluster and namespace scope helm charts, may need --take-ownership flag if using helm install command
- verify operators come ready as expected, verify can login to cp-console still

Alternate test could be to install cluster scoped charts before running migration to verify if there is a difference in the final install if the order changes

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
3. The PR will be automatically created in the target branch after merging this PR
4. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action