### PR TITLE
Add corresponding metadata to pass RH certification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-edge-docker-l
 
 ARG VCS_REF
 ARG VCS_URL
+ARG RELEASE_VERSION
 
 LABEL org.label-schema.vendor="IBM" \
   org.label-schema.name="ibm common service operator" \
@@ -34,7 +35,10 @@ LABEL org.label-schema.vendor="IBM" \
   org.label-schema.license="Licensed Materials - Property of IBM" \
   org.label-schema.schema-version="1.0" \
   name="common-service-operator" \
+  maintainer="IBM" \
   vendor="IBM" \
+  version=$RELEASE_VERSION \
+  release=$RELEASE_VERSION \
   description="Deploy ODLM and IBM Common Services" \
   summary="Deploy ODLM and IBM Common Services"
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
                 git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)
 RELEASE_VERSION ?= $(shell cat ./version/version.go | grep "Version =" | awk '{ print $$3}' | tr -d '"')
 PREVIOUS_VERSION := 3.23.0
-LATEST_VERSION ?= latest
+LATEST_VERSION ?= 4.11.0
 
 LOCAL_OS := $(shell uname)
 ifeq ($(LOCAL_OS),Linux)
@@ -81,7 +81,7 @@ OPERATOR_IMAGE_NAME ?= common-service-operator
 # Current Operator bundle image name
 BUNDLE_IMAGE_NAME ?= common-service-operator-bundle
 # Current Operator image with registry
-IMG ?= icr.io/cpopen/common-service-operator:4.11.0
+IMG ?= icr.io/cpopen/common-service-operator:$(LATEST_VERSION)
 
 CHANNELS := v4.11
 DEFAULT_CHANNEL := v4.11

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ YQ_VERSION=v4.27.3
 KUSTOMIZE_VERSION=v5.0.0
 OPERATOR_SDK_VERSION=v1.38.0
 CONTROLLER_TOOLS_VERSION ?= v0.14.0
+OPENSHIFT_VERSIONS ?= v4.12-v4.17
 
 CSV_PATH=bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
 
@@ -237,6 +238,8 @@ generate: controller-gen ## Generate code e.g. API etc.
 bundle-manifests: clis
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle \
 	-q --overwrite --version $(RELEASE_VERSION) $(BUNDLE_METADATA_OPTS)
+	echo "\n  # OpenShift annotations." >> bundle/metadata/annotations.yaml ;\
+	echo "  com.redhat.openshift.versions: $(OPENSHIFT_VERSIONS)" >> bundle/metadata/annotations.yaml ;\
 	$(OPERATOR_SDK) bundle validate ./bundle
 	$(YQ) eval -i '.metadata.annotations."olm.skipRange" = ">=3.3.0 <${RELEASE_VERSION}"' ${CSV_PATH}
 	$(YQ) eval -i '.spec.webhookdefinitions[0].deploymentName = "ibm-common-service-operator" | .spec.webhookdefinitions[1].deploymentName = "ibm-common-service-operator"' ${CSV_PATH}

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ deploy: manifests ## Deploy controller in the configured Kubernetes cluster in ~
 build-dev-image: cloudpak-theme.jar
 	@echo "Building the $(OPERATOR_IMAGE_NAME) docker dev image for $(LOCAL_ARCH)..."
 	@docker build -t $(REGISTRY)/$(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):dev \
-	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) \
+	--build-arg VCS_REF=$(VCS_REF) --build-arg VCS_URL=$(VCS_URL) --build-arg RELEASE_VERSION=$(RELEASE_VERSION) \
 	--build-arg GOARCH=$(LOCAL_ARCH) -f Dockerfile .
 	@docker push $(REGISTRY)/$(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):dev
 

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
       ]
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
-    containerImage: icr.io/cpopen/common-service-operator:latest
+    containerImage: icr.io/cpopen/common-service-operator:4.11.0
     createdAt: "2025-02-14T20:37:49Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2025-02-13T22:58:21Z"
+    createdAt: "2025-02-14T20:37:49Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -387,7 +387,7 @@ spec:
                         value: "false"
                       - name: OPERATOR_NAME
                         value: ibm-common-service-operator
-                    image: icr.io/cpopen/common-service-operator:latest
+                    image: icr.io/cpopen/common-service-operator:4.11.0
                     imagePullPolicy: IfNotPresent
                     livenessProbe:
                       failureThreshold: 10

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2025-02-13T21:51:07Z"
+    createdAt: "2025-02-13T22:58:21Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -13,3 +13,6 @@ annotations:
   # Annotations for testing.
   operators.operatorframework.io.test.mediatype.v1: scorecard+v1
   operators.operatorframework.io.test.config.v1: tests/scorecard/
+
+  # OpenShift annotations.
+  com.redhat.openshift.versions: v4.12-v4.17

--- a/common/scripts/next-csv.sh
+++ b/common/scripts/next-csv.sh
@@ -55,6 +55,7 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 
     # update cs operator channel in Makefile & bundle.Dockerfile & annotations.yaml
     sed -i "s/$CURRENT_CHANNEL/$NEW_CHANNEL/g" Makefile
+    sed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/g" Makefile
     echo "Updated the Makefile"
 
     sed -i "s/$CURRENT_CHANNEL/$NEW_CHANNEL/g" bundle.Dockerfile
@@ -91,6 +92,7 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 
     # update cs operator channel in Makefile & bundle.Dockerfile & annotations.yaml
     sed -i "" "s/$CURRENT_CHANNEL/$NEW_CHANNEL/g" Makefile
+    sed -i "" "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/g" Makefile
     echo "Updated the Makefile"
 
     sed -i "" "s/$CURRENT_CHANNEL/$NEW_CHANNEL/g" bundle.Dockerfile

--- a/common/scripts/next-csv.sh
+++ b/common/scripts/next-csv.sh
@@ -102,3 +102,5 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
 else
     echo "Not support on other operating systems"
 fi
+
+make generate-all

--- a/config/ibm-common-service-operator.yaml
+++ b/config/ibm-common-service-operator.yaml
@@ -731,7 +731,7 @@ spec:
           value: "false"
         - name: OPERATOR_NAME
           value: ibm-common-service-operator
-        image: icr.io/cpopen/common-service-operator:latest
+        image: icr.io/cpopen/common-service-operator:4.11.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 10

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -3,6 +3,6 @@ resources:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-- name: controller
+- name: icr.io/cpopen/common-service-operator
   newName: icr.io/cpopen/common-service-operator
-  newTag: latest
+  newTag: 4.11.0

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
-    containerImage: icr.io/cpopen/common-service-operator:latest
+    containerImage: icr.io/cpopen/common-service-operator:4.11.0
     createdAt: "2020-10-19T21:38:33Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy
       IBM foundational services.


### PR DESCRIPTION
**What this PR does / why we need it**:
#### Add labels in container image
- name: Image name ✅
- maintainer: Maintainer name 🔴
- vendor: Company name ✅
- version: Version of the image 🔴
- release: A number used to identify the specific build for this image 🔴
- summary: A short overview of the application or component in this image ✅
- description: A long description of the application or component in this image ✅

#### Add OCP version labels bundle metadata
- `com.redhat.openshift.versions: v4.12-v4.17`

#### Update the image reference with versioned tag
- `icr.io/cpopen/common-service-operator:4.11.0`

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65704

#### Test
following the instructions here run the pipeline certification against your own repo. https://ibm-analytics.slack.com/archives/C08CCB76L0J/p1739552810788419
Please let me know if you are not able to access the above link