### PR TITLE
Remove non-OLM env from OLM bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,8 +254,11 @@ generate-all: yq kustomize operator-sdk generate manifests cloudpak-theme-versio
 
 .PHONY: deploy-dryrun
 deploy-dryrun: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image icr.io/cpopen/common-service-operator=${IMG}
+	cd config/manager && \
+	$(KUSTOMIZE) edit set image icr.io/cpopen/common-service-operator=${IMG} && \
+	$(KUSTOMIZE) edit add patch --path non-olm-env-patch.yaml 
 	$(KUSTOMIZE) build config/default --output config/ibm-common-service-operator.yaml
+	cd config/manager && $(KUSTOMIZE) edit remove patch --path non-olm-env-patch.yaml
 
 .PHONY: helm
 helm: deploy-dryrun kustohelmize

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:4.11.0
-    createdAt: "2025-02-14T20:37:49Z"
+    createdAt: "2025-02-20T00:28:09Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -381,10 +381,6 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
-                      - name: NO_OLM
-                        value: "true"
-                      - name: ENABLE_WEBHOOKS
-                        value: "false"
                       - name: OPERATOR_NAME
                         value: ibm-common-service-operator
                     image: icr.io/cpopen/common-service-operator:4.11.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,14 +70,8 @@ spec:
               fieldPath: metadata.namespace
         - name: WATCH_NAMESPACE
           valueFrom:
-            configMapKeyRef:
-              name: namespace-scope
-              key: namespaces
-              optional: true
-        - name: NO_OLM
-          value: 'true'
-        - name: ENABLE_WEBHOOKS
-          value: 'false'
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']
         - name: OPERATOR_NAME
           value: "ibm-common-service-operator"
         resources:

--- a/config/manager/non-olm-env-patch.yaml
+++ b/config/manager/non-olm-env-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ibm-common-service-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: ibm-common-service-operator
+        env:
+        - name: NO_OLM
+          value: "true"
+        - name: ENABLE_WEBHOOKS
+          value: "false"


### PR DESCRIPTION
**What this PR does / why we need it**:
When we run `make generate-all` to update the bundle for RH certification, the non-OLM env variables are accidentally added into the `bundle` folder from `config` folder.

Makefile is updated, so that `make generate-all` will not add non-OLM env variables into bundle folder.
Those non-OLM env variables will only be introduced when it is rendering the helm chart via `make helm`.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65966
