### PR TITLE
scale down mongodb operator 

### DIFF
--- a/preload_data.sh
+++ b/preload_data.sh
@@ -714,7 +714,7 @@ EOF
     done
 
     # Scale up ibm-mongodb-operator
-    ${OC} scale deployment -n ${FROM_NAMESPACE} ibm-mongodb-operator --replicas=${deployments}
+    # ${OC} scale deployment -n ${FROM_NAMESPACE} ibm-mongodb-operator --replicas=${deployments}
 
 
     success "DNS name in namespace: $FROM_NAMESPACE updated" 


### PR DESCRIPTION
**What this PR does / why we need it**:
preload_data script will scale down mongodb operator and never scale it up.
In this case, mongodb operartor will not revert the changes in icp-mongodb-init configmap
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65937
