### PR TITLE
Generate EDB config template for all EDB service versions using

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -46,7 +46,7 @@ type CSData struct {
 	CloudPakThemesVersion   string
 	ExcludedCatalog         string
 	StatusMonitoredServices string
-	ServiceNames            []string
+	ServiceNames            map[string][]string
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -46,6 +46,7 @@ type CSData struct {
 	CloudPakThemesVersion   string
 	ExcludedCatalog         string
 	StatusMonitoredServices string
+	ServiceNames            []string
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/controllers/bootstrap/init.go
+++ b/controllers/bootstrap/init.go
@@ -126,6 +126,7 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		OnPremMultiEnable:       strconv.FormatBool(util.CheckMultiInstances(mgr.GetAPIReader())),
 		ExcludedCatalog:         constant.ExcludedCatalog,
 		StatusMonitoredServices: constant.StatusMonitoredServices,
+		ServiceNames:            constant.ServiceNames,
 	}
 
 	bs = &Bootstrap{
@@ -771,6 +772,7 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
 		constant.IMOpCon,
 		constant.IdpConfigUIOpCon,
 		constant.PlatformUIOpCon,
+		constant.EDBOpCon,
 		constant.KeyCloakOpCon,
 		constant.CommonServicePGOpCon,
 	}

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -33,11 +33,14 @@ var (
 	CSV4SaasOperandConfig   string
 )
 
-// ServiceNames defines the list of EDB service names used in the OperandConfig template.
-var ServiceNames = []string{
-	"cloud-native-postgresql",
-	"cloud-native-postgresql-v1.22",
-	"cloud-native-postgresql-v1.25",
+// ServiceNames defines the list of service names used in the OperandConfig template.
+var ServiceNames = map[string][]string{
+	"PostgreSQL": {
+		"cloud-native-postgresql",
+		"cloud-native-postgresql-v1.22",
+		"cloud-native-postgresql-v1.25",
+	},
+	// Add more service categories as needed
 }
 
 const (
@@ -518,7 +521,7 @@ metadata:
     version: {{ .Version }}
 spec:
   services:
-  {{- range .ServiceNames }}
+  {{- range .ServiceNames.PostgreSQL }}
   - name: {{ . }}
     resources:
       - apiVersion: batch/v1

--- a/controllers/constant/odlm.go
+++ b/controllers/constant/odlm.go
@@ -33,6 +33,13 @@ var (
 	CSV4SaasOperandConfig   string
 )
 
+// ServiceNames defines the list of EDB service names used in the OperandConfig template.
+var ServiceNames = []string{
+	"cloud-native-postgresql",
+	"cloud-native-postgresql-v1.22",
+	"cloud-native-postgresql-v1.25",
+}
+
 const (
 	ExcludedCatalog         = "certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog"
 	StatusMonitoredServices = "ibm-idp-config-ui-operator,ibm-mongodb-operator,ibm-im-operator"
@@ -498,6 +505,164 @@ spec:
       operandBindInfo: {}
 `
 )
+
+const EDBOpCon = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+spec:
+  services:
+  {{- range .ServiceNames }}
+  - name: {{ . }}
+    resources:
+      - apiVersion: batch/v1
+        kind: Job
+        name: create-postgres-license-config
+        namespace: "{{ $.OperatorNs }}"
+        labels:
+          operator.ibm.com/opreq-control: 'true'
+        data:
+          spec:
+            activeDeadlineSeconds: 600
+            backoffLimit: 5
+            template:
+              metadata:
+                annotations:
+                  productID: 068a62892a1e4db39641342e592daa25
+                  productMetric: FREE
+                  productName: IBM Cloud Platform Common Services
+              spec:
+                imagePullSecrets:
+                  - name: ibm-entitlement-key
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      nodeSelectorTerms:
+                      - matchExpressions:
+                        - key: kubernetes.io/arch
+                          operator: In
+                          values:
+                          - amd64
+                          - ppc64le
+                          - s390x
+                initContainers:
+                - command:
+                  - bash
+                  - -c
+                  - |
+                    cat << EOF | kubectl apply -f -
+                    apiVersion: v1
+                    kind: Secret
+                    type: Opaque
+                    metadata:
+                      name: postgresql-operator-controller-manager-config
+                    data:
+                      EDB_LICENSE_KEY: $(base64 /license_keys/edb/EDB_LICENSE_KEY | tr -d '\n')
+                    EOF
+                  image:
+                    templatingValueFrom:
+                      default:
+                        required: true
+                        configMapKeyRef:
+                          name: cloud-native-postgresql-image-list
+                          key: edb-postgres-license-provider-image
+                          namespace: {{ $.OperatorNs }}
+                  name: edb-license
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 512Mi
+                    requests:
+                      cpu: 100m
+                      memory: 50Mi
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    privileged: false
+                    readOnlyRootFilesystem: false
+                containers:
+                - command:
+                  - bash
+                  - '-c'
+                  args:
+                  - |
+                    kubectl delete pods -l app.kubernetes.io/name=cloud-native-postgresql
+                    kubectl annotate secret postgresql-operator-controller-manager-config ibm-license-key-applied="EDB Database with IBM License Key"
+                  image:
+                    templatingValueFrom:
+                      default:
+                        required: true
+                        configMapKeyRef:
+                          name: cloud-native-postgresql-image-list
+                          key: edb-postgres-license-provider-image
+                          namespace: {{ $.OperatorNs }}
+                  name: restart-edb-pod
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 512Mi
+                    requests:
+                      cpu: 100m
+                      memory: 50Mi
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    capabilities:
+                      drop:
+                      - ALL
+                    privileged: false
+                    readOnlyRootFilesystem: false
+                hostIPC: false
+                hostNetwork: false
+                hostPID: false
+                restartPolicy: OnFailure
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: edb-license-sa
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: edb-license-sa
+        namespace: "{{ $.OperatorNs }}"
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: edb-license-role
+        namespace: "{{ $.OperatorNs }}"
+        data:
+          rules:
+          - apiGroups:
+            - ""
+            resources:
+            - pods
+            - secrets
+            verbs:
+            - create
+            - update
+            - patch
+            - get
+            - list
+            - delete
+            - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: edb-license-rolebinding
+        namespace: "{{ $.OperatorNs }}"
+        data:
+          subjects:
+          - kind: ServiceAccount
+            name: edb-license-sa
+          roleRef:
+            kind: Role
+            name: edb-license-role
+            apiGroup: rbac.authorization.k8s.io
+  {{- end }}
+`
 
 const (
 	KeyCloakOpCon = `
@@ -1703,6 +1868,16 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
+  - channel: stable-v1.25
+    fallbackChannels:
+      - stable
+      - stable-v1.22
+    name: cloud-native-postgresql-v1.25
+    namespace: "{{ .CPFSNs }}"
+    packageName: cloud-native-postgresql
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    operatorConfig: cloud-native-postgresql-operator-config
   - channel: alpha
     name: ibm-user-data-services-operator
     namespace: "{{ .CPFSNs }}"
@@ -1907,290 +2082,6 @@ spec:
     spec:
       operandBindInfo: {}
       operandRequest: {}
-  - name: cloud-native-postgresql
-    resources:
-      - apiVersion: batch/v1
-        kind: Job
-        name: create-postgres-license-config
-        namespace: "{{ .OperatorNs }}"
-        labels:
-          operator.ibm.com/opreq-control: 'true'
-        data:
-          spec:
-            activeDeadlineSeconds: 600
-            backoffLimit: 5
-            template:
-              metadata:
-                annotations:
-                  productID: 068a62892a1e4db39641342e592daa25
-                  productMetric: FREE
-                  productName: IBM Cloud Platform Common Services
-              spec:
-                imagePullSecrets:
-                  - name: ibm-entitlement-key
-                affinity:
-                  nodeAffinity:
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      nodeSelectorTerms:
-                      - matchExpressions:
-                        - key: kubernetes.io/arch
-                          operator: In
-                          values:
-                          - amd64
-                          - ppc64le
-                          - s390x
-                initContainers:
-                - command:
-                  - bash
-                  - -c
-                  - |
-                    cat << EOF | kubectl apply -f -
-                    apiVersion: v1
-                    kind: Secret
-                    type: Opaque
-                    metadata:
-                      name: postgresql-operator-controller-manager-config
-                    data:
-                      EDB_LICENSE_KEY: $(base64 /license_keys/edb/EDB_LICENSE_KEY | tr -d '\n')
-                    EOF
-                  image:
-                    templatingValueFrom:
-                      default:
-                        required: true
-                        configMapKeyRef:
-                          name: cloud-native-postgresql-image-list
-                          key: edb-postgres-license-provider-image
-                          namespace: {{ .OperatorNs }}
-                  name: edb-license
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
-                    requests:
-                      cpu: 100m
-                      memory: 50Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                      - ALL
-                    privileged: false
-                    readOnlyRootFilesystem: false
-                containers:
-                - command:
-                  - bash
-                  - '-c'
-                  args:
-                  - |
-                    kubectl delete pods -l app.kubernetes.io/name=cloud-native-postgresql
-                    kubectl annotate secret postgresql-operator-controller-manager-config ibm-license-key-applied="EDB Database with IBM License Key"
-                  image:
-                    templatingValueFrom:
-                      default:
-                        required: true
-                        configMapKeyRef:
-                          name: cloud-native-postgresql-image-list
-                          key: edb-postgres-license-provider-image
-                          namespace: {{ .OperatorNs }}
-                  name: restart-edb-pod
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
-                    requests:
-                      cpu: 100m
-                      memory: 50Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                      - ALL
-                    privileged: false
-                    readOnlyRootFilesystem: false
-                hostIPC: false
-                hostNetwork: false
-                hostPID: false
-                restartPolicy: OnFailure
-                securityContext:
-                  runAsNonRoot: true
-                serviceAccountName: edb-license-sa
-      - apiVersion: v1
-        kind: ServiceAccount
-        name: edb-license-sa
-        namespace: "{{ .OperatorNs }}"
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        name: edb-license-role
-        namespace: "{{ .OperatorNs }}"
-        data:
-          rules:
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - secrets
-            verbs:
-            - create
-            - update
-            - patch
-            - get
-            - list
-            - delete
-            - watch
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        name: edb-license-rolebinding
-        namespace: "{{ .OperatorNs }}"
-        data:
-          subjects:
-          - kind: ServiceAccount
-            name: edb-license-sa
-          roleRef:
-            kind: Role
-            name: edb-license-role
-            apiGroup: rbac.authorization.k8s.io
-  - name: cloud-native-postgresql-v1.22
-    resources:
-      - apiVersion: batch/v1
-        kind: Job
-        name: create-postgres-license-config
-        namespace: "{{ .OperatorNs }}"
-        labels:
-          operator.ibm.com/opreq-control: 'true'
-        data:
-          spec:
-            activeDeadlineSeconds: 600
-            backoffLimit: 5
-            template:
-              metadata:
-                annotations:
-                  productID: 068a62892a1e4db39641342e592daa25
-                  productMetric: FREE
-                  productName: IBM Cloud Platform Common Services
-              spec:
-                imagePullSecrets:
-                  - name: ibm-entitlement-key
-                affinity:
-                  nodeAffinity:
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      nodeSelectorTerms:
-                      - matchExpressions:
-                        - key: kubernetes.io/arch
-                          operator: In
-                          values:
-                          - amd64
-                          - ppc64le
-                          - s390x
-                initContainers:
-                - command:
-                  - bash
-                  - -c
-                  - |
-                    cat << EOF | kubectl apply -f -
-                    apiVersion: v1
-                    kind: Secret
-                    type: Opaque
-                    metadata:
-                      name: postgresql-operator-controller-manager-config
-                    data:
-                      EDB_LICENSE_KEY: $(base64 /license_keys/edb/EDB_LICENSE_KEY | tr -d '\n')
-                    EOF
-                  image:
-                    templatingValueFrom:
-                      default:
-                        required: true
-                        configMapKeyRef:
-                          name: cloud-native-postgresql-image-list
-                          key: edb-postgres-license-provider-image
-                          namespace: {{ .OperatorNs }}
-                  name: edb-license
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
-                    requests:
-                      cpu: 100m
-                      memory: 50Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                      - ALL
-                    privileged: false
-                    readOnlyRootFilesystem: false
-                containers:
-                - command:
-                  - bash
-                  - '-c'
-                  args:
-                  - |
-                    kubectl delete pods -l app.kubernetes.io/name=cloud-native-postgresql
-                    kubectl annotate secret postgresql-operator-controller-manager-config ibm-license-key-applied="EDB Database with IBM License Key"
-                  image:
-                    templatingValueFrom:
-                      default:
-                        required: true
-                        configMapKeyRef:
-                          name: cloud-native-postgresql-image-list
-                          key: edb-postgres-license-provider-image
-                          namespace: {{ .OperatorNs }}
-                  name: restart-edb-pod
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
-                    requests:
-                      cpu: 100m
-                      memory: 50Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                      - ALL
-                    privileged: false
-                    readOnlyRootFilesystem: false
-                hostIPC: false
-                hostNetwork: false
-                hostPID: false
-                restartPolicy: OnFailure
-                securityContext:
-                  runAsNonRoot: true
-                serviceAccountName: edb-license-sa
-      - apiVersion: v1
-        kind: ServiceAccount
-        name: edb-license-sa
-        namespace: "{{ .OperatorNs }}"
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        name: edb-license-role
-        namespace: "{{ .OperatorNs }}"
-        data:
-          rules:
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - secrets
-            verbs:
-            - create
-            - update
-            - patch
-            - get
-            - list
-            - delete
-            - watch
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        name: edb-license-rolebinding
-        namespace: "{{ .OperatorNs }}"
-        data:
-          subjects:
-          - kind: ServiceAccount
-            name: edb-license-sa
-          roleRef:
-            kind: Role
-            name: edb-license-role
-            apiGroup: rbac.authorization.k8s.io
   - name: ibm-bts-operator
     spec:
       operandRequest:


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce `ServiceNames` as a slice of strings in CSData to include all the EDB version (1.18, 1.22 and 1.25). This allows for better maintainability and flexibility when adding or modifying EDB configs in the future.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65976

**How to test**:
1. Test image: `quay.io/yuchen_shen/cs_operator:edb`
2. Check `operandRegistry` and `operandConfig` created with correct `cloud-native-postgresql-v1.25` entry.