### PR TITLE
Support shared buffer values for common service db cluster

### DIFF
--- a/controllers/rules/rules.go
+++ b/controllers/rules/rules.go
@@ -93,7 +93,8 @@ const ConfigurationRules = `
             memory: LARGEST_VALUE    
         postgresql:
           parameters:
-            max_connections: LARGEST_VALUE     
+            max_connections: LARGEST_VALUE
+            shared_buffers: LARGEST_VALUE
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_amd64.go
+++ b/controllers/size/large_amd64.go
@@ -88,6 +88,7 @@ const Large = `
         postgresql:
           parameters:
             max_connections: "1100"
+            shared_buffers: 150MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_ppc64le.go
+++ b/controllers/size/large_ppc64le.go
@@ -88,6 +88,7 @@ const Large = `
         postgresql:
           parameters:
             max_connections: "1100"
+            shared_buffers: 150MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/large_s390x.go
+++ b/controllers/size/large_s390x.go
@@ -88,6 +88,7 @@ const Large = `
         postgresql:
           parameters:
             max_connections: "1100"
+            shared_buffers: 150MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/medium_amd64.go
+++ b/controllers/size/medium_amd64.go
@@ -88,6 +88,7 @@ const Medium = `
         postgresql:
           parameters:
             max_connections: "750"
+            shared_buffers: 96MB
 - name: ibm-im-mongodb-operator-v4.0
   spec:
     mongoDB:

--- a/controllers/size/medium_ppc64le.go
+++ b/controllers/size/medium_ppc64le.go
@@ -88,6 +88,7 @@ const Medium = `
         postgresql:
           parameters:
             max_connections: "750"
+            shared_buffers: 96MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/medium_s390x.go
+++ b/controllers/size/medium_s390x.go
@@ -88,6 +88,7 @@ const Medium = `
         postgresql:
           parameters:
             max_connections: "750"
+            shared_buffers: 96MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_amd64.go
+++ b/controllers/size/small_amd64.go
@@ -88,6 +88,7 @@ const Small = `
         postgresql:
           parameters:
             max_connections: "600"
+            shared_buffers: 64MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_ppc64le.go
+++ b/controllers/size/small_ppc64le.go
@@ -88,6 +88,7 @@ const Small = `
         postgresql:
           parameters:
             max_connections: "600"
+            shared_buffers: 64MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/small_s390x.go
+++ b/controllers/size/small_s390x.go
@@ -88,6 +88,7 @@ const Small = `
         postgresql:
           parameters:
             max_connections: "600"
+            shared_buffers: 64MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_amd64.go
+++ b/controllers/size/starterset_amd64.go
@@ -88,6 +88,7 @@ const StarterSet = `
         postgresql:
           parameters:
             max_connections: "400"
+            shared_buffers: 64MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_ppc64le.go
+++ b/controllers/size/starterset_ppc64le.go
@@ -88,6 +88,7 @@ const StarterSet = `
         postgresql:
           parameters:
             max_connections: "400"
+            shared_buffers: 64MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:

--- a/controllers/size/starterset_s390x.go
+++ b/controllers/size/starterset_s390x.go
@@ -90,6 +90,7 @@ const StarterSet = `
         postgresql:
           parameters:
             max_connections: "400"
+            shared_buffers: 64MB
 - name: ibm-im-mongodb-operator
   spec:
     mongoDB:


### PR DESCRIPTION
**What this PR does / why we need it**:
Support different default shared_buffers values for common-service-db cluster by sizing configuration
Cherry-pick: https://github.com/IBM/ibm-common-service-operator/pull/2403

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65422
