### PR TITLE
Fixed reference value for imageRegistryNamespaceOperator

### DIFF
--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -39,7 +39,7 @@ spec:
                       - s390x
       containers:         
         - name: ibm-common-service-operator
-          image: {{ .Values.global.imagePullPrefix}}/{{ .Values.imageRegistryNamespaceOperator}}/common-service-operator:4.12.0
+          image: {{ .Values.global.imagePullPrefix}}/{{ .Values.cpfs.imageRegistryNamespaceOperator}}/common-service-operator:4.12.0
           command: 
             - /manager
           env:             


### PR DESCRIPTION
**What this PR does / why we need it**:
Originally was .Values.imageRegistryNamespaceOperator which didn't reference imageRegistryNamespaceOperator value correctly. Added the correct referencing.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action