### PR TITLE
Remove truststore startup script for keycloak 24 and 26

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -47,6 +47,7 @@ type CSData struct {
 	ExcludedCatalog         string
 	StatusMonitoredServices string
 	ServiceNames            map[string][]string
+	UtilsImage              string
 }
 
 // +kubebuilder:pruning:PreserveUnknownFields

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles467.css
     containerImage: icr.io/cpopen/common-service-operator:latest
-    createdAt: "2025-03-06T19:45:25Z"
+    createdAt: "2025-03-05T20:28:45Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
@@ -375,6 +375,8 @@ spec:
                             fieldPath: metadata.annotations['olm.targetNamespaces']
                       - name: OPERATOR_NAME
                         value: ibm-common-service-operator
+                      - name: UTILS_IMAGE
+                        value: icr.io/cpopen/cpfs/cpfs-utils:latest
                     image: icr.io/cpopen/common-service-operator:latest
                     imagePullPolicy: IfNotPresent
                     livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -74,6 +74,8 @@ spec:
               fieldPath: metadata.annotations['olm.targetNamespaces']
         - name: OPERATOR_NAME
           value: "ibm-common-service-operator"
+        - name: UTILS_IMAGE
+          value: icr.io/cpopen/cpfs/cpfs-utils:latest
         resources:
           limits:
             cpu: 500m

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -127,6 +127,7 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		ExcludedCatalog:         constant.ExcludedCatalog,
 		StatusMonitoredServices: constant.StatusMonitoredServices,
 		ServiceNames:            constant.ServiceNames,
+		UtilsImage:              util.GetUtilsImage(),
 	}
 
 	bs = &Bootstrap{

--- a/internal/controller/common/util.go
+++ b/internal/controller/common/util.go
@@ -278,6 +278,14 @@ func GetWatchNamespace() string {
 	return ns
 }
 
+func GetUtilsImage() string {
+	image, found := os.LookupEnv("UTILS_IMAGE")
+	if !found {
+		return ""
+	}
+	return image
+}
+
 // GetNSSCMSynchronization returns whether NSS ConfigMap shchronization with OperatorGroup is enabled
 func GetNSSCMSynchronization() bool {
 	isEnable, found := os.LookupEnv("NSSCM_SYNC_MODE")

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -917,11 +917,11 @@ spec:
                 serviceAccountName: convert-secret-sa
                 containers:
                   - name: convert-secret-job
-                    image: icr.io/cpopen/cpfs/cpfs-utils:latest
+                    image: {{ .UtilsImage }}
                     command: ["/bin/sh", "/mnt/scripts/convert-secrets.sh"]
                     volumeMounts:
-                    - name: script-volume
-                      mountPath: /mnt/scripts
+                      - name: script-volume
+                        mountPath: /mnt/scripts
                 volumes:
                   - name: script-volume
                     configMap:

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -639,19 +639,9 @@ spec:
         namespace: "{{ $.OperatorNs }}"
         data:
           rules:
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - secrets
-            verbs:
-            - create
-            - update
-            - patch
-            - get
-            - list
-            - delete
-            - watch
+          - apiGroups: [""]
+            resources: ["pods", "secrets"]
+            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"]
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         name: edb-license-rolebinding
@@ -857,19 +847,9 @@ spec:
         name: convert-secret-role
         data:
           rules:
-          - apiGroups:
-            - ""
-            resources:
-            - secrets
-            - configmaps
-            verbs:
-            - create
-            - update
-            - patch
-            - get
-            - list
-            - delete
-            - watch
+          - apiGroups: [""]
+            resources: ["secrets", "configmaps"]
+            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"]
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         name: convert-secret-rolebinding
@@ -1434,19 +1414,9 @@ spec:
         namespace: "{{ .OperatorNs }}"
         data:
           rules:
-          - apiGroups:
-            - ""
-            resources:
-            - pods
-            - secrets
-            verbs:
-            - create
-            - update
-            - patch
-            - get
-            - list
-            - delete
-            - watch
+          - apiGroups: [""]
+            resources: ["pods", "secrets"]
+            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"]
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         name: edb-license-rolebinding

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1123,6 +1123,15 @@ spec:
                   kind: CustomResourceDefinition
                 key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.scheduling
                 operator: DoesNotExist
+          - path: .spec.unsupported.podTemplate.spec.containers[0].command
+            operation: remove
+            matchExpressions:
+              - objectRef:
+                  name: keycloaks.k8s.keycloak.org
+                  apiVersion: apiextensions.k8s.io/v1
+                  kind: CustomResourceDefinition
+                key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.truststores
+                operator: Exists
       - apiVersion: v1
         kind: ConfigMap
         force: true

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -592,9 +592,7 @@ spec:
                     privileged: false
                     readOnlyRootFilesystem: false
                 containers:
-                - command:
-                  - bash
-                  - '-c'
+                - command: ["bash", "-c"]
                   args:
                   - |
                     kubectl delete pods -l app.kubernetes.io/name=cloud-native-postgresql
@@ -861,6 +859,41 @@ spec:
             kind: Role
             name: convert-secret-role
             apiGroup: rbac.authorization.k8s.io
+      - apiVersion: v1
+        kind: ConfigMap
+        name: convert-secrets
+        data:
+          data:
+            convert-secrets.sh: |
+              #!/usr/bin/env bash
+              # Check if the secret already exists
+              if oc get secret cs-keycloak-ca-certs >/dev/null 2>&1; then
+                echo "Secret cs-keycloak-ca-certs already exists. Skipping conversion."
+                exit 0
+              fi
+              
+              # Check if ConfigMap exists
+              if ! oc get configmap cs-keycloak-ca-certs >/dev/null 2>&1; then
+                echo "ConfigMap cs-keycloak-ca-certs not found. Nothing to conversion."
+                exit 0
+              fi
+              
+              # Extract certificate file names from ConfigMap
+              CERT_FILES=$(oc get configmap cs-keycloak-ca-certs -o yaml | yq e '.data | keys | .[]' -)              
+              
+              # Create a temporary directory
+              mkdir -p /tmp/certs
+
+              # Extract certificates from ConfigMap and save them as files
+              for CERT in $CERT_FILES; do
+                oc get configmap cs-keycloak-ca-certs -o yaml | yq e ".data[\"$CERT\"]"> /tmp/certs/$CERT
+              done
+              
+              # Create Secret from extracted certificates
+              oc create secret generic cs-keycloak-ca-certs \
+                $(for CERT in $CERT_FILES; do echo --from-file=/tmp/certs/$CERT; done)
+              
+              echo "Conversion complete. Secret created: cs-keycloak-ca-certs"
       - apiVersion: batch/v1
         kind: Job
         force: true
@@ -883,40 +916,16 @@ spec:
                 restartPolicy: OnFailure
                 serviceAccountName: convert-secret-sa
                 containers:
-                - name: convert-secret-job
-                  image: icr.io/cpopen/cpfs/cpfs-utils:latest
-                  command:
-                    - /bin/sh
-                    - -c
-                    - |              
-                      # Check if the secret already exists
-                      if oc get secret cs-keycloak-ca-certs >/dev/null 2>&1; then
-                        echo "Secret cs-keycloak-ca-certs already exists. Skipping conversion."
-                        exit 0
-                      fi
-                      
-                      # Check if ConfigMap exists
-                      if ! oc get configmap cs-keycloak-ca-certs >/dev/null 2>&1; then
-                        echo "ConfigMap cs-keycloak-ca-certs not found. Nothing to conversion."
-                        exit 0
-                      fi
-                      
-                      # Extract certificate file names from ConfigMap
-                      CERT_FILES=$(oc get configmap cs-keycloak-ca-certs -o yaml | yq e '.data | keys | .[]' -)              
-                      
-                      # Create a temporary directory
-                      mkdir -p /tmp/certs
-
-                      # Extract certificates from ConfigMap and save them as files
-                      for CERT in $CERT_FILES; do
-                        oc get configmap cs-keycloak-ca-certs -o yaml | yq e ".data[\"$CERT\"]"> /tmp/certs/$CERT
-                      done
-                      
-                      # Create Secret from extracted certificates
-                      oc create secret generic cs-keycloak-ca-certs \
-                        $(for CERT in $CERT_FILES; do echo --from-file=/tmp/certs/$CERT; done)
-                      
-                      echo "Conversion complete. Secret created: cs-keycloak-ca-certs"
+                  - name: convert-secret-job
+                    image: icr.io/cpopen/cpfs/cpfs-utils:latest
+                    command: ["/bin/sh", "/mnt/scripts/convert-secrets.sh"]
+                    volumeMounts:
+                    - name: script-volume
+                      mountPath: /mnt/scripts
+                volumes:
+                  - name: script-volume
+                    configMap:
+                      name: convert-secrets
       - apiVersion: v1
         annotations:
           service.beta.openshift.io/serving-cert-secret-name: cpfs-opcon-cs-keycloak-tls-secret
@@ -1111,9 +1120,7 @@ spec:
                         required: true
                 spec:
                   containers:
-                    - command:
-                        - /bin/sh
-                        - /mnt/startup/cs-keycloak-entrypoint.sh
+                    - command: ["/bin/sh", "/mnt/startup/cs-keycloak-entrypoint.sh"]
                       volumeMounts:
                         - mountPath: /mnt/truststore
                           name: truststore-volume
@@ -1381,9 +1388,7 @@ spec:
                     privileged: false
                     readOnlyRootFilesystem: false
                 containers:
-                - command:
-                  - bash
-                  - '-c'
+                - command: ["bash", "-c"]
                   args:
                   - |
                     kubectl delete pods -l app.kubernetes.io/name=cloud-native-postgresql

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -977,12 +977,49 @@ spec:
             hostname:
               hostname:
                 templatingValueFrom:
-                  objectRef:
-                    apiVersion: route.openshift.io/v1
-                    kind: Route
-                    name: keycloak
-                    path: .spec.host
-                  required: true
+                  conditional:
+                    expression:
+                      greaterThan:
+                        left:
+                          objectRef:
+                            apiVersion: apps/v1
+                            kind: Deployment
+                            name: rhbk-operator
+                            path: .metadata.labels.olm\.owner
+                        right:
+                          literal: rhbk-operator.v26.0.0
+                    then:
+                      objectRef:
+                        apiVersion: route.openshift.io/v1
+                        kind: Route
+                        name: keycloak
+                        path: 'https://+.spec.host'
+                      required: true
+                    else:                        
+                      objectRef:
+                        apiVersion: route.openshift.io/v1
+                        kind: Route
+                        name: keycloak
+                        path: .spec.host
+                      required: true
+            additionalOptions:
+              templatingValueFrom:
+                conditional:
+                  expression:
+                    greaterThan:
+                      left:
+                        objectRef:
+                          apiVersion: apps/v1
+                          kind: Deployment
+                          name: rhbk-operator
+                          path: .metadata.labels.olm\.owner
+                      right:
+                        literal: rhbk-operator.v26.0.0
+                  then:
+                      array:
+                        - map:
+                            name: hostname-backchannel-dynamic
+                            value: 'true'
             http:
               tlsSecret: cs-keycloak-tls-secret
             ingress:


### PR DESCRIPTION
### What this PR does / why we need it:
In Keycloak 24 and 26, it supports the truststore field directly defined in the spec field, allowing to specify the secret in it. Additionally, when running on a Kubernetes or OpenShift environment, well-known locations of trusted certificates, such as `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`, are included automatically.
Therefore, we can remove startup script which includes truststore setup and the import of kube service account certificates.

### Issue:
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65326#issuecomment-101278352
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65678

### How to test:
1. Test image: `quay.io/yuchen_shen/cs_operator:truststore`
2. Check the new created `common-service` OperandConfig with the new optionalFields, this mean, if it is new CRD with `.spec.truststore`, then we do not need to run the startup script
    ```
    - path: .spec.unsupported.podTemplate.spec.containers[0].command
            operation: remove
            matchExpressions:
              - objectRef:
                  name: keycloaks.k8s.keycloak.org
                  apiVersion: apiextensions.k8s.io/v1
                  kind: CustomResourceDefinition
                key: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.truststores
                operator: Exists
      ```
3. Install 24+ `keycloak-operator` and check keycloak cr there is no following command in containers
    ```
    - command:
        - /bin/sh
        - /mnt/startup/cs-keycloak-entrypoint.sh
    ```
4. Check the first few lines in `cs-keycloak-0`, it should start with 
    ```
    Changes detected in configuration. Updating the server image.
    Updating the configuration and installing your custom providers, if any. Please wait.
    ```
    no more: 
    ```
    Building the truststore file ...
    Importing default service account certificates ...
    ```
    Also, in terminal, `cd mnt/truststore` there is no more `keycloak-truststore.jks` existing.
5. Last check, if the keycloak route could open and login.
6. Compatibility with KeyCloak 22, delete 24 CRD and install 22, check above step, the result should be changed as above mentioned.

**Doc reference**: https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/26.0/html/operator_guide/advanced-configuration-#advanced-configuration-truststores

