### PR TITLE
Add shared_buffers to comparable keys and normalize resource quantity formats

### DIFF
--- a/controllers/operandconfig.go
+++ b/controllers/operandconfig.go
@@ -257,6 +257,7 @@ func mergeChangedMap(key string, defaultMap interface{}, changedMap interface{},
 					"fips_enabled":    true,
 					"instances":       true,
 					"max_connections": true,
+					"shared_buffers":  true,
 				}
 				if _, ok := comparableKeys[key]; ok {
 					if directAssign {


### PR DESCRIPTION
**What this PR does / why we need it**:
The resource quantities of `shared_buffers` like `96MB`, `1GB` are not the standard resource quantity formats in Kubernetes like `96M`, `1G`.

When Common Service Operator is doing the resource comparison across multiple CommonService CRs, it returns error for `96MB`
```
quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```

The PR is to normalize the resource quantity before value comparison by converting `96MB` to `96M`.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66050

### Test
1. Install latest dev build
2. Patch CSV with image `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:dev` and change `ImagePullPolicy` to `Always`
3. Create a new CommonService CR and set `.spec.size: large`
4. Create OperandRequest to request `ibm-im-operator`
5. Wait for `common-service-db-1` pod to be ready
6. Opening a remote shell to `common-service-db-1` containers
    ```console
    ➜  ~ oc -n cs-data rsh common-service-db-1
    Defaulted container "postgres" out of: postgres, bootstrap-controller (init)
    sh-5.1$ 
    ```
7. Verified the the value of `shared_buffers` is correct
    ```console
    sh-5.1$ cat /var/lib/postgresql/data/pgdata/custom.conf | grep shared_buffers
    shared_buffers = '150MB'
    sh-5.1$
    ```
