### PR TITLE
handle error returning

### DIFF
--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -282,11 +282,11 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Noeffect", fmt.Sprintf("No update, resource sizings in the OperandConfig %s/%s are larger than the profile from CommonService CR %s/%s", r.Bootstrap.CSData.OperatorNs, "common-service", instance.Namespace, instance.Name))
 	}
 
-	if err := r.Bootstrap.UpdateEDBUserManaged(); err != nil {
+	if statusErr = r.Bootstrap.UpdateEDBUserManaged(); statusErr != nil {
 		if statusErr := r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
 			klog.Error(statusErr)
 		}
-		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		return ctrl.Result{}, statusErr
 	}
 
@@ -324,9 +324,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		return ctrl.Result{}, statusErr
 	}
 
-	var optStatusReady bool
-	var optStatusErr error
-	if optStatusReady, optStatusErr = r.Bootstrap.CheckSubOperatorStatus(instance); optStatusErr != nil {
+	if optStatusReady, optStatusErr := r.Bootstrap.CheckSubOperatorStatus(instance); optStatusErr != nil {
 		klog.Errorf("Failed to check the status of the operators in the OperandRegistry: %v", optStatusErr)
 		return ctrl.Result{}, optStatusErr
 	} else if !optStatusReady {

--- a/internal/controller/no_olm_commonservice_controller.go
+++ b/internal/controller/no_olm_commonservice_controller.go
@@ -261,11 +261,11 @@ func (r *CommonServiceReconciler) ReconcileNoOLMMasterCR(ctx context.Context, in
 		r.Recorder.Event(instance, corev1.EventTypeNormal, "Noeffect", fmt.Sprintf("No update, resource sizings in the OperandConfig %s/%s are larger than the profile from CommonService CR %s/%s", r.Bootstrap.CSData.OperatorNs, "common-service", instance.Namespace, instance.Name))
 	}
 
-	if err := r.Bootstrap.UpdateEDBUserManaged(); err != nil {
+	if statusErr = r.Bootstrap.UpdateEDBUserManaged(); statusErr != nil {
 		if statusErr := r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
 			klog.Error(statusErr)
 		}
-		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		return ctrl.Result{}, statusErr
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a corner case that Cs operator is hitting [an error from line 289](https://github.com/IBM/ibm-common-service-operator/blob/1a36d1997101cdbc5414933994cf5c510fa95090/internal/controller/commonservice_controller.go#L289).

However, there is a discrepancy between [what err is returned from `err := r.Bootstrap.UpdateEDBUserManaged()`](https://github.com/IBM/ibm-common-service-operator/blob/1a36d1997101cdbc5414933994cf5c510fa95090/internal/controller/commonservice_controller.go#L285C5-L285C46) and [what error is returned for reconciliation](https://github.com/IBM/ibm-common-service-operator/blob/1a36d1997101cdbc5414933994cf5c510fa95090/internal/controller/commonservice_controller.go#L290). Thus, the error was not actually returned to trigger the re-queue on reconciliation.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66102

### Test
The change ensures that CS operator would always re-queue the reconciliation request until its CommonService CR reaching `Succeeded` phase.