### PR TITLE
update min rbac permissions for edb 1.25

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -1658,3 +1658,34 @@ rules:
       - secrets
     resourceNames:
       - postgresql-operator-controller-manager-1-22-7-service-cert
+  - verbs:
+      - get
+      - create
+      - delete
+      - list
+      - patch
+      - update
+      - watch
+    resources:
+      - databases
+      - publications
+      - subscriptions
+    apiGroups:
+      - postgresql.k8s.enterprisedb.io
+  - verbs:
+      - get
+      - patch
+      - update
+    resources:
+      - databases/status
+      - publications/status
+    apiGroups:
+      - postgresql.k8s.enterprisedb.io
+  - verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - imagecatalogs
+    apiGroups:
+      - postgresql.k8s.enterprisedb.io


### PR DESCRIPTION
**What this PR does / why we need it**: EDB 1.25 introduces new permissions that are not currently accounted for in the min rbac yaml causing some problems with deployments using nss min rbac

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66139

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action