### PR TITLE
Enable dynamic backchannel and hostnamev configuration in OperandConfig

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1169,12 +1169,31 @@ spec:
             hostname:
               hostname:
                 templatingValueFrom:
-                  objectRef:
-                    apiVersion: route.openshift.io/v1
-                    kind: Route
-                    name: keycloak
-                    path: .spec.host
-                  required: true
+                  conditional:
+                    expression:
+                      greaterThan:
+                        left:
+                          objectRef:
+                            apiVersion: apps/v1
+                            kind: Deployment
+                            name: rhbk-operator
+                            path: .metadata.labels.olm\.owner
+                        right:
+                          literal: rhbk-operator.v26.0.0
+                    then:
+                      objectRef:
+                        apiVersion: route.openshift.io/v1
+                        kind: Route
+                        name: keycloak
+                        path: 'https://+.spec.host'
+                      required: true
+                    else:                        
+                        objectRef:
+                          apiVersion: route.openshift.io/v1
+                          kind: Route
+                          name: keycloak
+                          path: .spec.host
+                        required: true
             http:
               tlsSecret: cs-keycloak-tls-secret
             ingress:

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1188,12 +1188,30 @@ spec:
                         path: 'https://+.spec.host'
                       required: true
                     else:                        
+                      objectRef:
+                        apiVersion: route.openshift.io/v1
+                        kind: Route
+                        name: keycloak
+                        path: .spec.host
+                      required: true
+            additionalOptions:
+              templatingValueFrom:
+                conditional:
+                  expression:
+                    greaterThan:
+                      left:
                         objectRef:
-                          apiVersion: route.openshift.io/v1
-                          kind: Route
-                          name: keycloak
-                          path: .spec.host
-                        required: true
+                          apiVersion: apps/v1
+                          kind: Deployment
+                          name: rhbk-operator
+                          path: .metadata.labels.olm\.owner
+                      right:
+                        literal: rhbk-operator.v26.0.0
+                  then:
+                      array:
+                        - map:
+                            name: hostname-backchannel-dynamic
+                            value: 'true'
             http:
               tlsSecret: cs-keycloak-tls-secret
             ingress:


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable dynamic backchannel and hostnamev configuration in OperandConfig for keycloak 26+

**Which issue(s) this PR fixes**:
keycloak 26: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65922

**How to test**:
1. Test image: `quay.io/yuchen_shen/cs_operator:hostnamev2`
2. Install keycloak 26+
3. Apply ODLM image:  `quay.io/yuchen_shen/odlm:templating`
4. Check if kc 26 is working