### PR TITLE
add permissions to delete and patch nss cr

### DIFF
--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -32,7 +32,7 @@ spec:
               oc delete --ignore-not-found csv $nssCSV -n $operatorNamespace && oc delete --ignore-not-found subscription.operators.coreos.com $nssSub -n $operatorNamespace
               oc delete namespacescopes.operator.ibm.com common-service -n $operatorNamespace --ignore-not-found --timeout=10s
               if [ $? -ne 0 ]; then
-                  info "Failed to delete NSS CR, patching its finalizer to null..."
+                  echo "Failed to delete NSS CR, patching its finalizer to null..."
                   oc patch namespacescopes.operator.ibm.com common-service -n $operatorNamespace --type="json" -p '[{"op": "remove", "path":"/metadata/finalizers"}]'
               fi
             fi

--- a/bedrock-migration/templates/rbac.yaml
+++ b/bedrock-migration/templates/rbac.yaml
@@ -51,6 +51,15 @@ rules:
   - list
   - get
   - delete
+- apiGroups: 
+  - "operator.ibm.com"
+  resources:
+  - namespacescopes
+  verbs:
+  - list
+  - get
+  - delete
+  - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**: Part of the migration job is to verify the NSS CR is deleted when NSS is uninstalled. Currently, the job does not possess enough permissions to do so

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66194

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action