### PR TITLE
Skip no-op operators when retrieving operator status

### DIFF
--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2138,7 +2138,7 @@ func (b *Bootstrap) CheckSubOperatorStatus(instance *apiv3.CommonService) (bool,
 
 func (b *Bootstrap) GetOperatorInfo(optList []odlm.Operator, optName string) (*odlm.Operator, error) {
 	for _, opt := range optList {
-		if opt.Name == optName {
+		if opt.Name == optName && opt.InstallMode != "no-op" { // If the operator is no-op mode, skip it
 			return &opt, nil
 		}
 	}


### PR DESCRIPTION
CommonService Operator should skip checking `no-op` operator status since `no-op` operator will no longer be deployed by ODLM. If CommonService Operator is trying to check `no-op` operator's status, its status will never go into `Ready`.
