### PR TITLE
Enhancement on EnsureLabels function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ else
 ARTIFACTORYA_REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 endif
 
-REGISTRY ?= "quay.io/yuchen_li1"
+REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= common-service-operator

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ else
 ARTIFACTORYA_REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 endif
 
-REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
+REGISTRY ?= "quay.io/yuchen_li1"
 
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= common-service-operator

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -453,6 +453,7 @@ spec:
                 - get
                 - list
                 - watch
+                - update
             - apiGroups:
                 - apps
               resources:

--- a/config/ibm-common-service-operator.yaml
+++ b/config/ibm-common-service-operator.yaml
@@ -388,6 +388,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - apps
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -114,6 +114,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - apps
   resources:

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -80,6 +80,7 @@ rules:
       - get
       - list
       - watch
+      - update
   - apiGroups: 
       - apps
     resources: 

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -1958,6 +1958,7 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 		}
 	}
 
+	klog.Infof("add label to configmaps")
 	// update labels in the configmap
 	cmNames := []string{"common-services-maps", "namespace-scope"}
 	cmList := &corev1.ConfigMapList{}
@@ -1978,6 +1979,7 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 		return err
 	}
 
+	klog.Infof("add label to opcon and opreg")
 	// Update labels in the OperandConfig and OperandRegistry
 	opconfigList := &odlm.OperandConfigList{}
 	opcon := &odlm.OperandConfig{}
@@ -2010,6 +2012,7 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 		return err
 	}
 
+	klog.Infof("add label to issuer")
 	// update labels in the Issuer
 	issuerList := &certmanagerv1.IssuerList{}
 	issuerNames := []string{"cs-ss-issuer", "cs-ca-issuer"}
@@ -2031,6 +2034,7 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 		return err
 	}
 
+	klog.Infof("add label to certificate")
 	// update labels in the Certificate
 	certList := &certmanagerv1.CertificateList{}
 	cert := &certmanagerv1.Certificate{}

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -1958,7 +1958,6 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 		}
 	}
 
-	klog.Infof("add label to configmaps")
 	// update labels in the configmap
 	nsscmName := "namespace-scope"
 	cmList := &corev1.ConfigMapList{}
@@ -1979,7 +1978,6 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 		return err
 	}
 
-	klog.Infof("add label to opcon and opreg")
 	// Update labels in the OperandConfig and OperandRegistry
 	opconfigList := &odlm.OperandConfigList{}
 	opcon := &odlm.OperandConfig{}
@@ -2013,7 +2011,6 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 		return err
 	}
 
-	klog.Infof("add label to issuer")
 	// update labels in the Issuer
 	issuerList := &certmanagerv1.IssuerList{}
 	issuerNames := []string{"cs-ss-issuer", "cs-ca-issuer"}
@@ -2036,7 +2033,6 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 		return err
 	}
 
-	klog.Infof("add label to certificate")
 	// update labels in the Certificate
 	certList := &certmanagerv1.CertificateList{}
 	cert := &certmanagerv1.Certificate{}

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2056,6 +2056,9 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 
 func (b *Bootstrap) UpdateResourceWithLabel(resources *unstructured.UnstructuredList, labels map[string]string) error {
 	for _, resource := range resources.Items {
+		if resource.GetName() == "" {
+			continue
+		}
 		util.EnsureLabels(&resource, labels)
 		klog.Infof("Updating labels in %s %s/%s", resource.GetKind(), resource.GetNamespace(), resource.GetName())
 		if err := b.UpdateObject(&resource); err != nil {

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2055,9 +2055,6 @@ func (b *Bootstrap) UpdateResourceLabel(instance *apiv3.CommonService) error {
 }
 
 func (b *Bootstrap) UpdateResourceWithLabel(resources *unstructured.UnstructuredList, labels map[string]string) error {
-	if len(resources.Items) == 0 {
-		return nil
-	}
 	for _, resource := range resources.Items {
 		util.EnsureLabels(&resource, labels)
 		klog.Infof("Updating labels in %s %s/%s", resource.GetKind(), resource.GetNamespace(), resource.GetName())

--- a/internal/controller/common/util.go
+++ b/internal/controller/common/util.go
@@ -47,6 +47,8 @@ import (
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"maps"
+
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/constant"
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/v4/api/v1"
@@ -679,12 +681,13 @@ func EnsureLabelsForConfigMap(cm *corev1.ConfigMap, labels map[string]string) {
 
 // EnsureLabels ensures that the specifc resource has the certain labels
 func EnsureLabels(resource *unstructured.Unstructured, labels map[string]string) {
-	if resource.Object["metadata"].(map[string]interface{})["labels"] == nil {
-		resource.Object["metadata"].(map[string]interface{})["labels"] = make(map[string]string)
+	if resource.GetLabels() == nil {
+		resource.SetLabels(labels)
+		return
 	}
-	for k, v := range labels {
-		resource.Object["metadata"].(map[string]interface{})["labels"].(map[string]string)[k] = v
-	}
+	newLabels := resource.GetLabels()
+	maps.Copy(newLabels, labels)
+	resource.SetLabels(newLabels)
 }
 
 // GetRequestNs gets requested-from-namespace of map-to-common-service-namespace


### PR DESCRIPTION
**What this PR does / why we need it**:
The issue happened on both olm and no-olm environment
- cs-operator is looking for `common-services-maps`and `namespace-scope` in [serviceNamespace](https://github.com/IBM/ibm-common-service-operator/blob/master/internal/controller/bootstrap/init.go#L1966),but they are not in service namespace in 4.x version, so it will return an empty value
- we [forgot to check](https://github.com/IBM/ibm-common-service-operator/blob/master/internal/controller/bootstrap/init.go#L2054) if input values is nil or not before we update the label
- cs-operator don't have update permission on certificates and issuers, so it can't update the label in those resources

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66196
