### PR TITLE
Remove image list cm and edb config secret during migration

### DIFF
--- a/bedrock-migration/templates/adopt-cs-cr.yaml
+++ b/bedrock-migration/templates/adopt-cs-cr.yaml
@@ -1,4 +1,3 @@
-#not sure this is necessary
 apiVersion: operator.ibm.com/v3
 kind: CommonService
 metadata:

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -86,7 +86,6 @@ spec:
 
             echo "Deleting EDB config resources in namespace $operatorNamespace to be regenerated after migration..."
             oc delete secret postgresql-operator-controller-manager-config --ignore-not-found -n $operatorNamespace
-            oc delete configmap postgresql-operator-controller-manager-config --ignore-not-found -n $operatorNamespace
             oc delete configmap cloud-native-postgresql-image-list --ignore-not-found -n $operatorNamespace
 
             echo "Deleting IM, UI, and EDB ServiceAccounts and Jobs in operator namespace $operatorNamespace and services namespace $servicesNamespace..."

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -84,6 +84,11 @@ spec:
               oc delete --ignore-not-found csv $edbCSV -n $operatorNamespace && oc delete --ignore-not-found subscription.operators.coreos.com $edbSub -n $operatorNamespace
             fi
 
+            echo "Deleting EDB config resources in namespace $operatorNamespace to be regenerated after migration..."
+            oc delete secret postgresql-operator-controller-manager-config --ignore-not-found -n $operatorNamespace
+            oc delete configmap postgresql-operator-controller-manager-config --ignore-not-found -n $operatorNamespace
+            oc delete configmap cloud-native-postgresql-image-list --ignore-not-found -n $operatorNamespace
+
             echo "Deleting IM, UI, and EDB ServiceAccounts and Jobs in operator namespace $operatorNamespace and services namespace $servicesNamespace..."
             oc delete --ignore-not-found sa postgresql-operator-manager edb-license-sa -n $operatorNamespace
             oc delete --ignore-not-found sa ibm-iam-operand-restricted ibm-commonui-operand common-service-db -n $servicesNamespace

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -85,7 +85,6 @@ spec:
             fi
 
             echo "Deleting EDB config resources in namespace $operatorNamespace to be regenerated after migration..."
-            oc delete secret postgresql-operator-controller-manager-config --ignore-not-found -n $operatorNamespace
             oc delete configmap cloud-native-postgresql-image-list --ignore-not-found -n $operatorNamespace
 
             echo "Deleting IM, UI, and EDB ServiceAccounts and Jobs in operator namespace $operatorNamespace and services namespace $servicesNamespace..."

--- a/bedrock-migration/templates/rbac.yaml
+++ b/bedrock-migration/templates/rbac.yaml
@@ -39,6 +39,7 @@ rules:
   resources:
   - configmaps
   - serviceaccounts
+  - secrets
   verbs:
   - list
   - get

--- a/bedrock-migration/templates/rbac.yaml
+++ b/bedrock-migration/templates/rbac.yaml
@@ -64,7 +64,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: bedrock-migration-job-rb
+  name: bedrock-migration-job-rb-{{ .Values.global.operatorNamespace }}
   namespace: {{ .Values.global.operatorNamespace }}
   annotations:
     "helm.sh/hook": pre-install

--- a/bedrock-migration/templates/rbac.yaml
+++ b/bedrock-migration/templates/rbac.yaml
@@ -76,7 +76,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: bedrock-migration-job-role
+  name: bedrock-migration-job-role-{{ .Values.global.operatorNamespace }}
 {{- $watchNamespaces := .Values.global.tetheredNamespaces | default list -}}
 {{- if .Values.global.instanceNamespace -}}
 {{- $watchNamespaces = append $watchNamespaces .Values.global.instanceNamespace -}}

--- a/bedrock-migration/templates/rbac.yaml
+++ b/bedrock-migration/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: bedrock-migration-job-role
+  name: bedrock-migration-job-role-{{ .Values.global.operatorNamespace }}
   namespace: {{ .Values.global.operatorNamespace }}
   annotations:
     "helm.sh/hook": pre-install


### PR DESCRIPTION
**What this PR does / why we need it**: Resolves issue with certain resources being created by the edb chart. These resources are ok to be regenerated and do not need to be carried over so we can remove them in the migration process and allow the EDB chart to recreate them as normal.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action