### PR TITLE
retain the nss managed from roles to prevent lack of permissions

### DIFF
--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -114,9 +114,6 @@ spec:
                 roles="${roles} $(oc get roles -n $ns | grep cloud-native-postgresql | awk '{print $1}' | tr "\n" " ")"
                 roles="${roles} $(oc get roles -n $ns | grep common-service-db | awk '{print $1}' | tr "\n" " ")"
 
-                #get nss roles
-                roles="${roles} $(oc get roles -n $ns | grep nss-managed-role-from | awk '{print $1}' | tr "\n" " ")"
-                
                 if [[ $ns != $servicesNamespace ]]; then
                     edbSA=$(oc get sa -n $ns --ignore-not-found | grep postgresql-operator-controller-manager | awk '{print $1}' | tr "\n" " ")
                     if [[ ${edbSA// /} != "" ]]; then


### PR DESCRIPTION
NSS roles occupy a fickle spot, NSS operator specifically looks for the `nss-managed-role-from-<ns>` role to be able to project permissions but it cannot create this role itself and the helm chart also does not create this role. This role is only created through the authorize-namespace.sh script run at fresh install time. If we delete this role during the migration then we would need to rerun the authorize namespace script in order to re-create these permissions. It was a mistake to remove these permissions in the first place but I forgot these roles were created via the authorize-namespace.sh script and not by the operator itself.

So instead of rerunning authorize namespace, we will opt not to delete the roles during migration. NSS operator will function as expected with this change.