### PR TITLE
Implement dynamic default and fallback channels for operators in OperandRegistry

### DIFF
--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -469,15 +469,24 @@ func (r *CommonServiceReconciler) ReconcileNonConfigurableCR(ctx context.Context
 	return ctrl.Result{}, nil
 }
 
-func (r *CommonServiceReconciler) mappingToCsRequest() handler.MapFunc {
+func (r *CommonServiceReconciler) mappingToCsRequestForConfigMaps() handler.MapFunc {
 	return func(object client.Object) []reconcile.Request {
-		CsInstance := []reconcile.Request{}
-		cmName := object.GetName()
-		cmNs := object.GetNamespace()
-		if cmName == constant.CsMapConfigMap && cmNs == "kube-public" {
-			CsInstance = append(CsInstance, reconcile.Request{NamespacedName: types.NamespacedName{Name: constant.MasterCR, Namespace: r.Bootstrap.CSData.OperatorNs}})
+		configMap, ok := object.(*corev1.ConfigMap)
+		if !ok {
+			return nil
 		}
-		return CsInstance
+
+		// Check two configmaps: common-service-maps and ibm-cpp-config
+		if (configMap.Name == constant.CsMapConfigMap && configMap.Namespace == constant.CsMapConfigMapNs) ||
+			(configMap.Name == constant.IBMCPPCONFIG && configMap.Namespace == r.Bootstrap.CSData.ServicesNs) {
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{
+					Name:      constant.MasterCR,
+					Namespace: r.Bootstrap.CSData.OperatorNs,
+				}},
+			}
+		}
+		return nil
 	}
 }
 
@@ -546,17 +555,11 @@ func (r *CommonServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				predicate.LabelChangedPredicate{}))).
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},
-			handler.EnqueueRequestsFromMapFunc(r.mappingToCsRequest()),
+			handler.EnqueueRequestsFromMapFunc(r.mappingToCsRequestForConfigMaps()),
 			builder.WithPredicates(predicate.Funcs{
-				CreateFunc: func(e event.CreateEvent) bool {
-					return true
-				},
-				DeleteFunc: func(e event.DeleteEvent) bool {
-					return !e.DeleteStateUnknown
-				},
-				UpdateFunc: func(e event.UpdateEvent) bool {
-					return true
-				},
+				CreateFunc: func(e event.CreateEvent) bool { return true },
+				UpdateFunc: func(e event.UpdateEvent) bool { return true },
+				DeleteFunc: func(e event.DeleteEvent) bool { return !e.DeleteStateUnknown },
 			}))
 	if isOpregAPI, err := r.Bootstrap.CheckCRD(constant.OpregAPIGroupVersion, constant.OpregKind); err != nil {
 		klog.Errorf("Failed to check if OperandRegistry CRD exists: %v", err)

--- a/internal/controller/configurationcollector/collector.go
+++ b/internal/controller/configurationcollector/collector.go
@@ -93,7 +93,21 @@ func (b *configbuilder) setKeycloakOperatorChannels() *configbuilder {
 	if b.data == nil {
 		b.data = make(map[string]string)
 	}
-	b.data["keycloak-operator"] = constant.KeyCloakVersions
+
+	keycloakChannels, exists := constant.DefaultChannels["keycloak-operator"]
+	if !exists || len(keycloakChannels) == 0 {
+		keycloakChannels = []string{"stable-v24", "stable-v22"}
+	}
+
+	var channelStr strings.Builder
+	for _, channel := range keycloakChannels {
+		channelStr.WriteString("- ")
+		channelStr.WriteString(channel)
+		channelStr.WriteString("\n")
+	}
+
+	b.data["keycloak-operator"] = channelStr.String()
+
 	return b
 }
 

--- a/internal/controller/configurationcollector/collector.go
+++ b/internal/controller/configurationcollector/collector.go
@@ -93,7 +93,7 @@ func (b *configbuilder) setKeycloakOperatorChannels() *configbuilder {
 	if b.data == nil {
 		b.data = make(map[string]string)
 	}
-	b.data["keycloak-operator"] = "- stable-v28\n- stable-v26\n- stable-v24\n- stable-v22"
+	b.data["keycloak-operator"] = constant.KeyCloakVersions
 	return b
 }
 

--- a/internal/controller/configurationcollector/collector.go
+++ b/internal/controller/configurationcollector/collector.go
@@ -34,7 +34,7 @@ import (
 
 func Buildconfig(config map[string]string, bs *bootstrap.Bootstrap) map[string]string {
 	builder := configbuilder{data: config, bs: bs}
-	updatedConfig := builder.setDefaultStorageClass()
+	updatedConfig := builder.setDefaultStorageClass().setKeycloakOperatorChannels()
 	return updatedConfig.data
 }
 
@@ -85,6 +85,15 @@ func (b *configbuilder) setDefaultStorageClass() *configbuilder {
 		b.data["storageclass.list"] = strings.Join(allSCList, ",")
 	}
 
+	return b
+}
+
+// setKeycloakOperatorChannels sets the keycloak operator channels in the config
+func (b *configbuilder) setKeycloakOperatorChannels() *configbuilder {
+	if b.data == nil {
+		b.data = make(map[string]string)
+	}
+	b.data["keycloak-operator"] = "- stable-v28\n- stable-v26\n- stable-v24\n- stable-v22"
 	return b
 }
 

--- a/internal/controller/constant/constant.go
+++ b/internal/controller/constant/constant.go
@@ -122,9 +122,12 @@ const (
 	RequeueDuration = 30 * time.Second
 	// OpreqLabel is the label used to label the Subscription/CR/Configmap managed by ODLM
 	OpreqLabel string = "operator.ibm.com/opreq-control"
-	// KeyCloak Operator versions
-	KeyCloakVersions = "- stable-v26\n- stable-v24\n- stable-v22"
 )
+
+// DefaultChannels defines the default channels available for each operator
+var DefaultChannels = map[string][]string{
+	"keycloak-operator": {"stable-v26", "stable-v24", "stable-v22"},
+}
 
 // CsOg is OperatorGroup constent for the common service operator
 const CsOperatorGroup = `

--- a/internal/controller/constant/constant.go
+++ b/internal/controller/constant/constant.go
@@ -122,6 +122,8 @@ const (
 	RequeueDuration = 30 * time.Second
 	// OpreqLabel is the label used to label the Subscription/CR/Configmap managed by ODLM
 	OpreqLabel string = "operator.ibm.com/opreq-control"
+	// KeyCloak Operator versions
+	KeyCloakVersions = "- stable-v26\n- stable-v24\n- stable-v22"
 )
 
 // CsOg is OperatorGroup constent for the common service operator

--- a/internal/controller/constant/constant.go
+++ b/internal/controller/constant/constant.go
@@ -42,6 +42,8 @@ const (
 	ClusterOperatorNamespace = "openshift-operators"
 	// CS map configMap
 	CsMapConfigMap = "common-service-maps"
+	// CS map configMap namespace
+	CsMapConfigMapNs = "kube-public"
 	// CS Saas configMap
 	SaasConfigMap = "saas-config"
 	// Namespace Scope Operator resource name

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2365,28 +2365,13 @@ func processdDynamicChannels(registry *odlm.OperandRegistry, configMapData map[s
 		// Check if this operator is in our list of operators to process
 		for _, opName := range operatorNames {
 			if operator.Name == opName {
-				// Get channel list for this operator from ConfigMap
-				channelListKey := opName
-				channelListStr, exists := configMapData[channelListKey]
-				if !exists {
-					continue // Skip if no channel list exists for this operator
-				}
 
-				var channelList []string
-				lines := strings.Split(channelListStr, "\n")
-				for _, line := range lines {
-					line = strings.TrimSpace(line)
-					if strings.HasPrefix(line, "- ") {
-						channel := strings.TrimPrefix(line, "- ")
-						channelList = append(channelList, channel)
-					}
-				}
-				if len(channelList) == 0 {
+				channelList, exists := DefaultChannels[operator.Name]
+				if !exists || len(channelList) == 0 {
 					continue
 				}
-
-				// Get the highest version supported by Bedrocks (first in list)
 				highestVersion := channelList[0]
+
 				var currentChannel string
 				if operator.Name == "keycloak-operator" {
 					// For keycloak, check the keycloak_preferred_channel in ConfigMap or use a default

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2360,7 +2360,7 @@ func applyTemplate(objectTemplate string, data interface{}) ([]byte, error) {
 }
 
 // processFallbackChannels updates operator entries with dynamic fallback channels based on ibm-cpp-config data
-func processdDynamicChannels(registry *odlm.OperandRegistry, configMapData map[string]string, operatorNames []string) error {
+func processdDynamicChannels(registry *odlm.OperandRegistry, configMapData map[string]string, operatorNames []string) {
 	for i, operator := range registry.Spec.Operators {
 		// Check if this operator is in our list of operators to process
 		for _, opName := range operatorNames {
@@ -2430,7 +2430,6 @@ func processdDynamicChannels(registry *odlm.OperandRegistry, configMapData map[s
 			}
 		}
 	}
-	return nil
 }
 
 // compareVersions compares version strings (e.g., "stable-v22" vs "stable-v24")


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance the Common Service Operator to support dynamic default channel fallback channels management for operators in the OperandRegistry.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66249

#### How to test:
1. Test image: quay.io/yuchen_shen/cs_operator:keycloak_version
2. Change `keycloak_preferred_channel` in `ibm-cpp-config` configmap and check if the channels for keycloak are updated in Opreg