### PR TITLE
Adopt postgresql operator to 1.25.1 for CS 4.6.12

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -275,8 +275,9 @@ metadata:
     status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
-  - channel: stable-v1.22
+  - channel: stable-v1.25
     fallbackChannels:
+      - stable-v1.22
       - stable
     installPlanApproval: {{ .ApprovalMode }}
     name: common-service-postgresql
@@ -1527,7 +1528,7 @@ spec:
           spec:
             requests:
               - operands:
-                  - name: cloud-native-postgresql-v1.22
+                  - name: cloud-native-postgresql-v1.25
                 registry: common-service
                 registryNamespace: {{ .ServicesNs }}
         force: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Update postgresql operator to 1.25.1 for both `common-service-postgresql ` and `cloud-native-postgresql`

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65978