### PR TITLE
Adopt postgres operator to 1.25.1 (#2456)

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -347,8 +347,9 @@ metadata:
     status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
-  - channel: stable-v1.22
+  - channel: stable-v1.25
     fallbackChannels:
+      - stable-v1.22
       - stable
     installPlanApproval: {{ .ApprovalMode }}
     name: common-service-postgresql
@@ -1718,7 +1719,7 @@ spec:
           spec:
             requests:
               - operands:
-                  - name: cloud-native-postgresql-v1.22
+                  - name: cloud-native-postgresql-v1.25
                 registry: common-service
                 registryNamespace: {{ .ServicesNs }}
         force: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Update postgresql operator to 1.25.1 for both `common-service-postgresql ` and `cloud-native-postgresql`
Cherry-pick: https://github.com/IBM/ibm-common-service-operator/pull/2456

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65978