### PR TITLE
update fallback channels for Keycloak EDB

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -253,6 +253,7 @@ spec:
     scope: public
   - channel: stable
     fallbackChannels:
+      - stable-v1.25
       - stable-v1.22
     installPlanApproval: {{ .ApprovalMode }}
     name: edb-keycloak
@@ -2002,8 +2003,8 @@ spec:
     operatorConfig: cloud-native-postgresql-operator-config
   - channel: stable-v1.25
     fallbackChannels:
-      - stable
       - stable-v1.22
+      - stable
     name: cloud-native-postgresql-v1.25
     namespace: "{{ .CPFSNs }}"
     packageName: cloud-native-postgresql


### PR DESCRIPTION
**What this PR does / why we need it**:
Update stable-v25 for Keycloak EDB fallback channel list

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65978