### PR TITLE
add `manage-cert-rotation: yes` label to cs-ca-certificate CR 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ else
 ARTIFACTORYA_REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 endif
 
-REGISTRY ?= "quay.io/yuchen_li1"
+REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= common-service-operator

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ else
 ARTIFACTORYA_REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 endif
 
-REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
+REGISTRY ?= "quay.io/yuchen_li1"
 
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= common-service-operator

--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -124,6 +124,9 @@ type CommonServiceSpec struct {
 	License LicenseList `json:"license"`
 	// +optional
 	EnableInstanaMetricCollection bool `json:"enableInstanaMetricCollection,omitempty"`
+	// DisableManageCertRotation is a bool to enable or disable schedule cert renewal
+	// +optional
+	DisableManageCertRotation bool `json:"disableManageCertRotation,omitempty"`
 }
 
 // OperatorConfig is configuration composed of key-value pairs to be injected into specified CSVs

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -68,6 +68,10 @@ spec:
                   DefalutAdminUser is the name of the default admin user for foundational
                   services IM, default is cpadmin
                 type: string
+              disableManageCertRotation:
+                description: DisableManageCertRotation is a bool to enable or disable
+                  schedule cert renewal
+                type: boolean
               enableInstanaMetricCollection:
                 type: boolean
               features:

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -472,7 +472,11 @@ func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, alwaysUpdate ...b
 			// ignore renewBefore time when updating the certificate
 			klog.Info("create or update certificate")
 			cert := &unstructured.Unstructured{}
-			cert.SetGroupVersionKind(olmv1alpha1.SchemeGroupVersion.WithKind("certificate"))
+			cert.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "cert-manager.io",
+				Version: "v1",
+				Kind:    "Certificate",
+			})
 			certKey := types.NamespacedName{
 				Name:      obj.GetName(),
 				Namespace: obj.GetNamespace(),
@@ -486,7 +490,7 @@ func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, alwaysUpdate ...b
 				klog.Info("ignore renewBefore")
 				cert.Object["spec"].(map[string]interface{})["renewBefore"] = obj.Object["spec"].(map[string]interface{})["renewBefore"]
 			}
-			update = !equality.Semantic.DeepEqual(cert.Object["spec"], obj.Object["spec"])
+			update = !equality.Semantic.DeepEqual(cert.Object["spec"], obj.Object["spec"]) || !equality.Semantic.DeepEqual(cert.GetLabels(), obj.GetLabels()) || !equality.Semantic.DeepEqual(cert.GetAnnotations(), obj.GetAnnotations())
 		} else {
 			v1IsLarger, convertErr := util.CompareVersion(obj.GetAnnotations()["version"], objInCluster.GetAnnotations()["version"])
 			if convertErr != nil {

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -470,7 +470,6 @@ func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, alwaysUpdate ...b
 			update = !equality.Semantic.DeepEqual(sub.Object["spec"], obj.Object["spec"])
 		} else if gvk.Kind == "Certificate" {
 			// ignore renewBefore time when updating the certificate
-			klog.Info("create or update certificate")
 			cert := &unstructured.Unstructured{}
 			cert.SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   "cert-manager.io",
@@ -487,10 +486,9 @@ func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, alwaysUpdate ...b
 			}
 			// use renewBefore time in certificate in the cluster
 			if obj.Object["spec"].(map[string]interface{})["renewBefore"] != nil {
-				klog.Info("ignore renewBefore")
-				cert.Object["spec"].(map[string]interface{})["renewBefore"] = obj.Object["spec"].(map[string]interface{})["renewBefore"]
+				obj.Object["spec"].(map[string]interface{})["renewBefore"] = cert.Object["spec"].(map[string]interface{})["renewBefore"]
 			}
-			update = !equality.Semantic.DeepEqual(cert.Object["spec"], obj.Object["spec"]) || !equality.Semantic.DeepEqual(cert.GetLabels(), obj.GetLabels()) || !equality.Semantic.DeepEqual(cert.GetAnnotations(), obj.GetAnnotations())
+			update = !equality.Semantic.DeepEqual(cert.Object["spec"], obj.Object["spec"]) || !equality.Semantic.DeepEqual(cert.GetLabels(), obj.GetLabels())
 		} else {
 			v1IsLarger, convertErr := util.CompareVersion(obj.GetAnnotations()["version"], objInCluster.GetAnnotations()["version"])
 			if convertErr != nil {

--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -318,6 +318,11 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		return ctrl.Result{}, statusErr
 	}
 
+	if statusErr = r.Bootstrap.UpdateManageCertRotationLabel(instance); statusErr != nil {
+		klog.Error(statusErr)
+		return ctrl.Result{}, statusErr
+	}
+
 	// Set Succeeded phase
 	if statusErr = r.updatePhase(ctx, instance, apiv3.CRSucceeded); statusErr != nil {
 		klog.Error(statusErr)
@@ -414,6 +419,11 @@ func (r *CommonServiceReconciler) ReconcileGeneralCR(ctx context.Context, instan
 	}
 
 	if err := r.Bootstrap.UpdateResourceLabel(instance); err != nil {
+		klog.Error(err)
+		return ctrl.Result{}, err
+	}
+
+	if err = r.Bootstrap.UpdateManageCertRotationLabel(instance); err != nil {
 		klog.Error(err)
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/constant/certmanager.go
+++ b/internal/controller/constant/certmanager.go
@@ -77,7 +77,7 @@ metadata:
     app.kubernetes.io/instance: cs-ca-certificate
     app.kubernetes.io/managed-by: cert-manager-controller
     app.kubernetes.io/name: Certificate
-    operator.ibm.com/managedByCsOperator: "true"
+    operator.ibm.com/managedByCsOperator: 'true'
     ibm-cert-manager-operator/refresh-ca-chain: 'true'
     manage-cert-rotation: yes
   name: cs-ca-certificate

--- a/internal/controller/constant/certmanager.go
+++ b/internal/controller/constant/certmanager.go
@@ -79,7 +79,7 @@ metadata:
     app.kubernetes.io/name: Certificate
     operator.ibm.com/managedByCsOperator: 'true'
     ibm-cert-manager-operator/refresh-ca-chain: 'true'
-    manage-cert-rotation: yes
+    manage-cert-rotation: 'yes'
   name: cs-ca-certificate
   namespace: "placeholder"
 spec:

--- a/internal/controller/constant/certmanager.go
+++ b/internal/controller/constant/certmanager.go
@@ -79,6 +79,7 @@ metadata:
     app.kubernetes.io/name: Certificate
     operator.ibm.com/managedByCsOperator: "true"
     ibm-cert-manager-operator/refresh-ca-chain: 'true'
+    manage-cert-rotation: yes
   name: cs-ca-certificate
   namespace: "placeholder"
 spec:

--- a/internal/controller/constant/certmanager.go
+++ b/internal/controller/constant/certmanager.go
@@ -21,9 +21,10 @@ const SecretWatchLabel string = "operator.ibm.com/watched-by-cert-manager"
 
 // Labels and Annotations added by this operator
 const (
-	OperatorGeneratedAnno = "ibm-cert-manager-operator-generated"
-	ProperV1Label         = "ibm-cert-manager-operator/conditionally-generated-v1"
-	RefreshCALabel        = "ibm-cert-manager-operator/refresh-ca-chain"
+	OperatorGeneratedAnno   = "ibm-cert-manager-operator-generated"
+	ProperV1Label           = "ibm-cert-manager-operator/conditionally-generated-v1"
+	RefreshCALabel          = "ibm-cert-manager-operator/refresh-ca-chain"
+	ManageCertRotationLabel = "manage-cert-rotation"
 )
 
 var (

--- a/internal/controller/no_olm_commonservice_controller.go
+++ b/internal/controller/no_olm_commonservice_controller.go
@@ -296,6 +296,11 @@ func (r *CommonServiceReconciler) ReconcileNoOLMMasterCR(ctx context.Context, in
 		klog.Error(statusErr)
 		return ctrl.Result{}, statusErr
 	}
+
+	if statusErr = r.Bootstrap.UpdateManageCertRotationLabel(instance); statusErr != nil {
+		klog.Error(statusErr)
+		return ctrl.Result{}, statusErr
+	}
 	// Set Succeeded phase
 	if statusErr = r.updatePhase(ctx, instance, apiv3.CRSucceeded); statusErr != nil {
 		klog.Error(statusErr)
@@ -385,6 +390,11 @@ func (r *CommonServiceReconciler) ReconcileNoOLMGeneralCR(ctx context.Context, i
 	}
 
 	if err := r.Bootstrap.UpdateResourceLabel(instance); err != nil {
+		klog.Error(err)
+		return ctrl.Result{}, err
+	}
+
+	if err = r.Bootstrap.UpdateManageCertRotationLabel(instance); err != nil {
 		klog.Error(err)
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
add `manage-cert-rotation: yes` label to cs-ca-certificate CR 
update operator code to ignore reconciling `renewBefore` field

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66198

**Special notes for your reviewer**:

How the test is done?
we could use this image to test `quay.io/yuchen_li1/common-service-operator-amd64:dev`

1. update the RenewBefore time in cs-ca-certificate
2. delete cs-operator pod to trigger a new reconcile
3. updated renewBefore time shouldn't get reverted after a new reconcile


**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
5. The PR will be automatically created in the target branch after merging this PR
6. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action