### PR TITLE
Move customized user profile config under additional options

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1281,7 +1281,7 @@ spec:
               templatingValueFrom:
                 conditional:
                   expression:
-                    greaterThan:
+                    lessThan:
                       left:
                         objectRef:
                           apiVersion: apps/v1
@@ -1291,10 +1291,18 @@ spec:
                       right:
                         literal: rhbk-operator.v26.0.0
                   then:
-                      array:
-                        - map:
-                            name: hostname-backchannel-dynamic
-                            value: 'true'
+                    array:
+                      - map:
+                          name: spi-user-profile-declarative-user-profile-config-file
+                          value: /mnt/user-profile/cs-keycloak-user-profile.json       
+                  else:
+                    array:
+                      - map:
+                          name: spi-user-profile-declarative-user-profile-config-file
+                          value: /mnt/user-profile/cs-keycloak-user-profile.json
+                      - map:
+                          name: hostname-backchannel-dynamic
+                          value: 'true'
             http:
               tlsSecret: cs-keycloak-tls-secret
             ingress:


### PR DESCRIPTION
**What this PR does / why we need it**:
As the script is not used since Keycloak v24, move customized user-profile declarative config onto `AdditionalOptions` in Keycloak CR directly.

Cherry-pick: https://github.com/IBM/ibm-common-service-operator/pull/2468

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66272

**How to test**:
1. Test image: quay.io/yuchen_shen/cs_operator:sc2_kc_profile
2. login keycloak console, CloudPak/ Email field is required is on `OFF` by default