### PR TITLE
adopt configName in OperandRegistry API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/IBM/controller-filtered-cache v0.3.5
 	github.com/IBM/ibm-namespace-scope-operator/v4 v4.2.4-0.20240501132320-6675f97bc34f
 	github.com/IBM/ibm-secretshare-operator v1.20.3
-	github.com/IBM/operand-deployment-lifecycle-manager/v4 v4.3.6-beta
+	github.com/IBM/operand-deployment-lifecycle-manager/v4 v4.3.11-alpha
 	github.com/ghodss/yaml v1.0.0
 	github.com/ibm/ibm-cert-manager-operator v0.0.0-20230705134954-f3b9b344298a
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826

--- a/go.sum
+++ b/go.sum
@@ -75,8 +75,8 @@ github.com/IBM/ibm-namespace-scope-operator/v4 v4.2.4-0.20240501132320-6675f97bc
 github.com/IBM/ibm-namespace-scope-operator/v4 v4.2.4-0.20240501132320-6675f97bc34f/go.mod h1:p9DwVRJG6GF3b+kWQru/4fSEr3OQhlHKVEuJZcKewLs=
 github.com/IBM/ibm-secretshare-operator v1.20.3 h1:4Mz7FJ3f9TwFJqTVu4SfBHhspqtXwaCPtLnxv7DWT14=
 github.com/IBM/ibm-secretshare-operator v1.20.3/go.mod h1:gAkGb8Hts8swz5Ptbvkq/S0YylHE4zOTmUvj68uTQDI=
-github.com/IBM/operand-deployment-lifecycle-manager/v4 v4.3.6-beta h1:IgthjeLSNpRchewht8XwqMgrn7O5XaGjhcPFvpT/EO0=
-github.com/IBM/operand-deployment-lifecycle-manager/v4 v4.3.6-beta/go.mod h1:xRmAdXxi7Yq1BgEv0UVIMlOVLWNdjim+1IlGxn4zl3U=
+github.com/IBM/operand-deployment-lifecycle-manager/v4 v4.3.11-alpha h1:RfUXJDlXXBN5nbTiRMHQ9k25Abq/9/BMXd+G9J+OLNE=
+github.com/IBM/operand-deployment-lifecycle-manager/v4 v4.3.11-alpha/go.mod h1:eAYIb0oNnZj1Tax/1yZUxhIo6vt0fcZz21udWEH/Xec=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -41,8 +41,6 @@ var (
 var ServiceNames = map[string][]string{
 	"PostgreSQL": {
 		"cloud-native-postgresql",
-		"cloud-native-postgresql-v1.22",
-		"cloud-native-postgresql-v1.25",
 	},
 	// Add more service categories as needed
 }
@@ -251,6 +249,13 @@ spec:
     namespace: "{{ .ServicesNs }}"
     packageName: rhbk-operator
     scope: public
+  - channel: stable-v26
+    installPlanApproval: {{ .ApprovalMode }}
+    name: keycloak-operator-v26
+    namespace: "{{ .ServicesNs }}"
+    packageName: rhbk-operator
+    scope: public
+    configName: keycloak-operator
   - channel: stable
     fallbackChannels:
       - stable-v1.25
@@ -697,7 +702,23 @@ spec:
               public-cs-keycloak-service:
                 configmap: cs-keycloak-service
             description: Binding information that should be accessible to Keycloak adopters
-            operand: keycloak-operator
+            operand:
+              templatingValueFrom:
+                conditional:
+                  expression:
+                    lessThan:
+                      left:
+                        objectRef:
+                          apiVersion: apps/v1
+                          kind: Deployment
+                          name: rhbk-operator
+                          path: .metadata.labels.olm\.owner
+                      right:
+                        literal: rhbk-operator.v26.0.0
+                  then:
+                    literal: "keycloak-operator" 
+                  else:
+                    literal: "keycloak-operator-v26"
             registry: common-service
             registryNamespace: {{ .ServicesNs }}
         force: true
@@ -2009,6 +2030,7 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
+    configName: cloud-native-postgresql
   - channel: stable-v1.25
     fallbackChannels:
       - stable-v1.22
@@ -2019,6 +2041,7 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
+    configName: cloud-native-postgresql
   - channel: alpha
     name: ibm-user-data-services-operator
     namespace: "{{ .CPFSNs }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Consolidate OperandConfig for entry `keycloak-operator` and `keycloak-operator-v26`
- Consolidate OperandConfig for entry `cloud-native-postgresql`, `cloud-native-postgresql-v1.22` and `cloud-native-postgresql-v1.25`


**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66289
