### PR TITLE
[SC2] add labelSelector for common-service-db in topology constraints

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1742,9 +1742,21 @@ spec:
             - maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchExpressions:
+                  - key: k8s.enterprisedb.io/cluster
+                    operator: In
+                    values:
+                      - common-service-db
             - maxSkew: 1
               topologyKey: topology.kubernetes.io/region
               whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchExpressions:
+                  - key: k8s.enterprisedb.io/cluster
+                    operator: In
+                    values:
+                      - common-service-db
             imageName:
               templatingValueFrom:
                 default:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add labels into topologySpread `zone` and `region` for EDB Cluster pod

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65924

### Test
1. Build dev image and patch it on the cluster.
2. The OperandConfig would be updated the template containing the labelselector
3. Create OperandRequest to request `common-service-postgresql`
4. Observe `common-service-db` pod having label selector for `topologyKey: topology.kubernetes.io/zone` and `topologyKey: topology.kubernetes.io/region`



<img width="968" alt="Screenshot 2025-03-28 at 4 49 31 PM" src="https://github.com/user-attachments/assets/b8333c24-34ef-4f78-aa23-fcb842d3b2bd" />
