### PR TITLE
remove last , in commonservice label template

### DIFF
--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -17,8 +17,9 @@ metadata:
           "metadata": {
             "labels": {
               "component-id": "{{ .Chart.Name }}",
-              "foundationservices.cloudpak.ibm.com": "commonservice",
+              "foundationservices.cloudpak.ibm.com": "commonservice"
               {{- range $key, $val := .Values.cpfs.labels }}
+              ,
               "{{ $key }}": "{{ $val }}"
               {{- end}}
             },


### PR DESCRIPTION
if Values.cpfs.labels is empty in helm chart, the last ',' in labels might cause issue in creating commonservice cr, so we need to move it into loop