### PR TITLE
update migration chart to no longer adopt the cs cr now that cs op cr…

### DIFF
--- a/bedrock-migration/templates/adopt-cs-cr.yaml
+++ b/bedrock-migration/templates/adopt-cs-cr.yaml
@@ -1,6 +1,0 @@
-apiVersion: operator.ibm.com/v3
-kind: CommonService
-metadata:
-  name: common-service
-  namespace: {{ .Values.global.operatorNamespace }}
-spec:


### PR DESCRIPTION
…eates cr

**What this PR does / why we need it**: Remove the cs cr from the migration chart. Implementation of these changes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66018 means the CS operator chart no longer creates the CS CR so there is no need to adopt the cr during migration.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66385

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action