### PR TITLE
make oidc job completion check more stable

### DIFF
--- a/velero/schedule/common-service-db/cs-db-br-script-cm-4.6.10.4.11.yaml
+++ b/velero/schedule/common-service-db/cs-db-br-script-cm-4.6.10.4.11.yaml
@@ -126,17 +126,17 @@ data:
         info "Waiting for job $job_name to complete in namespace $CSDB_NAMESPACE."
         job_exists=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers || echo fail)
         if [[ $job_exists != "fail" ]]; then
-            completed=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers | awk '{print $2}')
+            completed=$(oc get job/$job_name -n $CSDB_NAMESPACE -o jsonpath="{.status.conditions[?(@.type=='Complete')].type}")
             retry_count=20
-            while [[ $completed != "1/1" ]] && [[ $retry_count > 0 ]]
+            while [[ $completed != "Complete" ]] && [[ $retry_count > 0 ]]
             do
                 info "Wait for job $job_name to complete. Try again in 15s."
                 sleep 15
-                completed=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers | awk '{print $2}')
-                retry_count=$retry_count-1
+                completed=$(oc get job/$job_name -n $CSDB_NAMESPACE -o jsonpath="{.status.conditions[?(@.type=='Complete')].type}")
+                retry_count=$((retry_count-1))
             done
 
-            if [[ $retry_count == 0 ]] && [[ $completed != "1/1" ]]; then
+            if [[ $retry_count == 0 ]] && [[ $completed != "Complete" ]]; then
                 error "Timed out waiting for job $job_name."
             else
                 info "Job $job_name completed."

--- a/velero/schedule/common-service-db/cs-db-br-script-cm.yaml
+++ b/velero/schedule/common-service-db/cs-db-br-script-cm.yaml
@@ -157,17 +157,17 @@ data:
         info "Waiting for job $job_name to complete in namespace $CSDB_NAMESPACE."
         job_exists=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers || echo fail)
         if [[ $job_exists != "fail" ]]; then
-            completed=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers | awk '{print $2}')
+            completed=$(oc get job/$job_name -n $CSDB_NAMESPACE -o jsonpath="{.status.conditions[?(@.type=='Complete')].type}")
             retry_count=20
-            while [[ ( $completed != "1/1" && $completed != "Complete" ) ]] && [[ $retry_count > 0 ]]
+            while [[ $completed != "Complete" ]] && [[ $retry_count > 0 ]]
             do
                 info "Wait for job $job_name to complete. Try again in 15s."
                 sleep 15
-                completed=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers | awk '{print $2}')
+                completed=$(oc get job/$job_name -n $CSDB_NAMESPACE -o jsonpath="{.status.conditions[?(@.type=='Complete')].type}")
                 retry_count=$((retry_count-1))
             done
 
-            if [[ $retry_count == 0 ]] && [[ ( $completed != "1/1" && $completed != "Complete" ) ]]; then
+            if [[ $retry_count == 0 ]] && [[ $completed != "Complete" ]]; then
                 error "Timed out waiting for job $job_name."
             else
                 info "Job $job_name completed."


### PR DESCRIPTION
**What this PR does / why we need it**: Checking column output can be unstable since columns are not always in the same position cluster to cluster. Changed to check the actual completion condition in the job instead at the suggestion of Arie from CPD

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action