### PR TITLE
[CD] add handling for no-op mode in operator status checks

### DIFF
--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2366,6 +2366,10 @@ func (b *Bootstrap) CheckSubOperatorStatus(instance *apiv3.CommonService) (bool,
 			klog.Errorf("Failed to get operator %s info: %v", opt, err)
 			return false, err
 		}
+		if operator == nil {
+			klog.Infof("The operator %s is in no-op mode, skipping it", opt)
+			continue
+		}
 		optStatus, err := b.setOperatorStatus(instance, operator.Name, operator.PackageName, operator.Namespace)
 		if err != nil {
 			klog.Errorf("Failed to get operator status: %v", err)
@@ -2406,6 +2410,9 @@ func (b *Bootstrap) GetOperatorInfo(optList []odlm.Operator, optName string) (*o
 	for _, opt := range optList {
 		if opt.Name == optName && opt.InstallMode != "no-op" { // If the operator is no-op mode, skip it
 			return &opt, nil
+		}
+		if opt.Name == optName && opt.InstallMode == "no-op" {
+			return nil, nil
 		}
 	}
 	return nil, fmt.Errorf("operator %s not found in OperandRegistry", optName)


### PR DESCRIPTION
**What this PR does / why we need it**:
When CS operator detects a no-op operator requested by users from OperandRegistry status, it should skip checking no-op operator status given no-op operator will not deployed by ODLM

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66456
