### PR TITLE
update value to `manage-cert-rotation: "true"`

### DIFF
--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2203,10 +2203,10 @@ func (b *Bootstrap) UpdateManageCertRotationLabel(instance *apiv3.CommonService)
 	certLabel := make(map[string]string)
 	for _, cs := range csObjectList.Items {
 		if cs.Spec.DisableManageCertRotation {
-			certLabel[constant.ManageCertRotationLabel] = "no"
+			certLabel[constant.ManageCertRotationLabel] = "false"
 			break
 		}
-		certLabel[constant.ManageCertRotationLabel] = "yes"
+		certLabel[constant.ManageCertRotationLabel] = "true"
 	}
 
 	// update labels in the Certificate


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the key in label from `manage-cert-rotation: "yes"/"no"`  to `manage-cert-rotation: "true"/"false"` 

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66504

This image can be used to verify `quay.io/yuchen_li1/common-service-operator-amd64:dev`