### PR TITLE
Add cloud-native-postgresql-v1.25 to PostgreSQL OperatorConfig

### DIFF
--- a/internal/controller/constant/odlm_operatorconfig.go
+++ b/internal/controller/constant/odlm_operatorconfig.go
@@ -213,4 +213,50 @@ spec:
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: cloud-native-postgresql
+    - name: cloud-native-postgresql-v1.25
+      replicas: placeholder-size
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 90
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - cloud-native-postgresql
+          - weight: 50
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - cloud-native-postgresql
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloud-native-postgresql
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/region
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: cloud-native-postgresql
 `

--- a/internal/controller/constant/odlm_operatorconfig.go
+++ b/internal/controller/constant/odlm_operatorconfig.go
@@ -16,8 +16,26 @@
 
 package constant
 
-const PostGresOperatorConfig = `
-apiVersion: operator.ibm.com/v1alpha1
+import "fmt"
+
+var PostGresOperatorConfig string
+
+// Populate PostGresOperatorConfig at package initialization
+func init() {
+	services := []string{
+		"edb-keycloak",
+		"cloud-native-postgresql",
+		"common-service-postgresql",
+		"cloud-native-postgresql-v1.22",
+		"cloud-native-postgresql-v1.25",
+	}
+
+	servicesConfig := ""
+	for _, service := range services {
+		servicesConfig += fmt.Sprintf(postgresServiceTemplate, service)
+	}
+
+	PostGresOperatorConfig = `apiVersion: operator.ibm.com/v1alpha1
 kind: OperatorConfig
 metadata:
   name: cloud-native-postgresql-operator-config
@@ -28,8 +46,11 @@ metadata:
   annotations:
     version: {{ .Version }}
 spec:
-  services:
-    - name: edb-keycloak
+  services:` + servicesConfig
+}
+
+const postgresServiceTemplate = `
+    - name: %s
       replicas: placeholder-size
       affinity:
         nodeAffinity:
@@ -74,189 +95,4 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-    - name: cloud-native-postgresql
-      replicas: placeholder-size
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 90
-            podAffinityTerm:
-              topologyKey: topology.kubernetes.io/zone
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cloud-native-postgresql
-          - weight: 50
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cloud-native-postgresql
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/region
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-    - name: common-service-postgresql
-      replicas: placeholder-size
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 90
-            podAffinityTerm:
-              topologyKey: topology.kubernetes.io/zone
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cloud-native-postgresql
-          - weight: 50
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cloud-native-postgresql
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/region
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-    - name: cloud-native-postgresql-v1.22
-      replicas: placeholder-size
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 90
-            podAffinityTerm:
-              topologyKey: topology.kubernetes.io/zone
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cloud-native-postgresql
-          - weight: 50
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cloud-native-postgresql
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/region
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-    - name: cloud-native-postgresql-v1.25
-      replicas: placeholder-size
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - ppc64le
-                - s390x
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 90
-            podAffinityTerm:
-              topologyKey: topology.kubernetes.io/zone
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cloud-native-postgresql
-          - weight: 50
-            podAffinityTerm:
-              topologyKey: kubernetes.io/hostname
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - cloud-native-postgresql
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-        - maxSkew: 1
-          topologyKey: topology.kubernetes.io/region
-          whenUnsatisfiable: ScheduleAnyway
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: cloud-native-postgresql
-`
+              app.kubernetes.io/name: cloud-native-postgresql`


### PR DESCRIPTION
**What this PR does / why we need it**: 
Adding the `cloud-native-postgresql-v1.25` service name to the PostgreSQL operator configuration, and ensures consistent configuration across all the PostgreSQL service variants

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66555 

**How to test**:
1. Test image: quay.io/yuchen_shen/cs_operator:operatorconfig-125
2. Configure EDB PostgreSQL to use 2 replicas of the operator deployment and set this it in CommonService CR:
    ```yaml
    apiVersion: operator.ibm.com/v3
    kind: CommonService
    metadata:
      name: common-service
      labels:
        foundationservices.cloudpak.ibm.com: commonservice
    spec:
      license:
        accept: false
      operatorConfigs:
        - name: cloud-native-postgresql
          replicas: 2
   ```
3. Check there is new service entry `name: cloud-native-postgresql-v1.25` with replica 2 in `cloud-native-postgresql-operator-config` operatorConfig.
4. Request `cloud-native-postgresql-v1.25` in OperandRequest, there are two `postgresql-operator-controller` pods.

<img width="407" alt="Screenshot 2025-04-28 at 4 46 46 PM" src="https://github.com/user-attachments/assets/ee843f65-572d-4889-8af5-81285e9bea82" />

