### PR TITLE
change zenservice check, update retry count

### DIFF
--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -368,14 +368,14 @@ data:
         info "Waiting for zenservice $ZENSERVICE_NAME to complete in namespace $ZEN_NAMESPACE."
         zenservice_exists=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE --no-headers || echo fail)
         if [[ $zenservice_exists != "fail" ]]; then
-            completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.zenStatus}')
+            completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.Progress}')
             retry_count=60
-            while [[ $completed != "Completed" ]] && [[ $retry_count > 0 ]]
+            while [[ $completed != "100%" ]] && [[ $retry_count > 0 ]]
             do
-                info "Wait for zenservice $ZENSERVICE_NAME to complete. Try again in 60s."
+                info "Wait for zenservice $ZENSERVICE_NAME to complete. Completion % is $completed. Try again in 60s."
                 sleep 60
-                completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.zenStatus}')
-                retry_count=$retry_count-1
+                completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.Progress}')
+                retry_count=$((retry_count-1))
             done
 
             if [[ $retry_count == 0 ]] && [[ $completed != "1/1" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**: It is possible for the zenservice's zenstatus field to be set to `InMaintenance` before the restore is started. This means that, even though the zenservice is ready for the restore job to start, the restore job will stall because it is looking specifically for the zenstatus to read `Completed`. Progress should be a more representative value as it is the 100% we are really looking for.
I am not sure why the zenservice would be set to `InMaintenance` before running the zenservice restore job as that is something the job is supposed to handle but I have run into it as a possibility with a CP4BA restore scenario.

I also needed to update the retry count logic to actually decrement the retry count otherwise the job will hang indefinitely.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action