### PR TITLE
[CD] Update backchannel-dynamic as the first-class citizen of the Keycloak…

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1325,32 +1325,67 @@ spec:
                         name: keycloak
                         path: .spec.host
                       required: true
+              backchannelDynamic:
+                templatingValueFrom:
+                  conditional:
+                    expression:
+                      and:
+                        - greaterThan:
+                            left:
+                              objectRef:
+                                apiVersion: apps/v1
+                                kind: Deployment
+                                name: rhbk-operator
+                                path: .metadata.labels.olm\.owner
+                            right:
+                              literal: rhbk-operator.v26.0.0
+                        - equal:
+                            left:
+                              objectRef:
+                                apiVersion: apiextensions.k8s.io/v1
+                                kind: CustomResourceDefinition
+                                name: keycloaks.k8s.keycloak.org
+                                path: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.hostname.properties.backchannelDynamic.type
+                            right:
+                              literal: "boolean"
+                    then:
+                      boolean: true
             additionalOptions:
               templatingValueFrom:
                 conditional:
                   expression:
-                    lessThan:
-                      left:
-                        objectRef:
-                          apiVersion: apps/v1
-                          kind: Deployment
-                          name: rhbk-operator
-                          path: .metadata.labels.olm\.owner
-                      right:
-                        literal: rhbk-operator.v26.0.0
+                    and:
+                      - greaterThan:
+                          left:
+                            objectRef:
+                              apiVersion: apps/v1
+                              kind: Deployment
+                              name: rhbk-operator
+                              path: .metadata.labels.olm\.owner
+                          right:
+                            literal: rhbk-operator.v26.0.0
+                      - notEqual:
+                          left:
+                            objectRef:
+                              apiVersion: apiextensions.k8s.io/v1
+                              kind: CustomResourceDefinition
+                              name: keycloaks.k8s.keycloak.org
+                              path: .spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.hostname.properties.backchannelDynamic.type
+                          right:
+                            literal: "boolean"
                   then:
-                    array:
-                      - map:
-                          name: spi-user-profile-declarative-user-profile-config-file
-                          value: /mnt/user-profile/cs-keycloak-user-profile.json       
-                  else:
                     array:
                       - map:
                           name: spi-user-profile-declarative-user-profile-config-file
                           value: /mnt/user-profile/cs-keycloak-user-profile.json
                       - map:
                           name: hostname-backchannel-dynamic
-                          value: 'true'
+                          value: "true"
+                  else:
+                    array:
+                      - map:
+                          name: spi-user-profile-declarative-user-profile-config-file
+                          value: /mnt/user-profile/cs-keycloak-user-profile.json
             http:
               tlsSecret: cs-keycloak-tls-secret
             ingress:


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the CRD schema, the `backchannel-dynamic` setting should be configured as a boolean property under the `hostname` section, not as an option in additionalOptions

Cherry-pick: https://github.com/IBM/ibm-common-service-operator/pull/2501

**Which issue(s) this PR fixes** 
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66572

**How to test**:
1. Test images
    CS: quay.io/yuchen_shen/cs_operator:kc_warning
    ODLM: quay.io/yuchen_shen/odlm:kc_warning
2. Install CS 4.6.14 and replaced by above images
3. Request a Keycloak 26 and check the `backchannelDynamic` is under `hostname` field and no warning msg
