### PR TITLE
upgrade zen default channel to v6.2

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -738,6 +738,9 @@ spec:
   - name: ibm-platformui-operator-v6.1
     spec:
       operandBindInfo: {}
+  - name: ibm-platformui-operator-v6.2
+    spec:
+      operandBindInfo: {}
 `
 )
 

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -308,6 +308,12 @@ spec:
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+  - name: ibm-platformui-operator-v6.2
+    namespace: "{{ .CPFSNs }}"
+    channel: v6.2
+    packageName: ibm-zen-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
 `
 )
 
@@ -2295,7 +2301,7 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
-    channel: v6.1
+    channel: v6.2
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}


### PR DESCRIPTION
**What this PR does / why we need it**:
upgrade zen default channel to v6.2
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66595
