### PR TITLE
Update the image digest in the Cluster CR as referenced from the ConfigMap in the PostgreSQL operator bundle

### DIFF
--- a/common/scripts/lint_go.sh
+++ b/common/scripts/lint_go.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-GOGC=25 golangci-lint run -c ./common/config/.golangci.yml --timeout=360s
+GOGC=25 golangci-lint run -c ./common/config/.golangci.yml --timeout=480s

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -811,6 +811,10 @@ spec:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
                           namespace: {{ $.OperatorNs }}
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-operand-images-config
+                        key: edb-postgres-license-provider-image
+                        namespace: {{ $.OperatorNs }}
                   name: edb-license
                   resources:
                     limits:
@@ -840,6 +844,10 @@ spec:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
                           namespace: {{ $.OperatorNs }}
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-operand-images-config
+                        key: edb-postgres-license-provider-image
+                        namespace: {{ $.OperatorNs }}
                   name: restart-edb-pod
                   resources:
                     limits:
@@ -1665,6 +1673,10 @@ spec:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
                           namespace: {{ .OperatorNs }}
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-operand-images-config
+                        key: edb-postgres-license-provider-image
+                        namespace: {{ $.OperatorNs }}
                   name: edb-license
                   resources:
                     limits:
@@ -1694,6 +1706,10 @@ spec:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
                           namespace: {{ .OperatorNs }}
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-operand-images-config
+                        key: edb-postgres-license-provider-image
+                        namespace: {{ $.OperatorNs }}
                   name: restart-edb-pod
                   resources:
                     limits:
@@ -1768,11 +1784,11 @@ spec:
                   required: true
                   configMapKeyRef:
                     name: cloud-native-postgresql-image-list
-                    key: ibm-postgresql-16-operand-image
+                    key: ibm-postgresql-14-operand-image
                     namespace: {{ .OperatorNs }}
                 configMapKeyRef:
                   name: cloud-native-postgresql-operand-images-config
-                  key: ibm-postgresql-16-operand-image
+                  key: ibm-postgresql-14-operand-image
                   namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1764,15 +1764,30 @@ spec:
                 owner: app
             imageName:
               templatingValueFrom:
-                default:
-                  required: true
-                  configMapKeyRef:
-                    name: cloud-native-postgresql-image-list
-                    key: ibm-postgresql-14-operand-image
-                    namespace: {{ .OperatorNs }}
-                configMapKeyRef:
-                    name: ibm-cpp-config
-                    key: edb-keycloak-operand-image
+                conditional:
+                  expression:
+                    equal:
+                      left:
+                        objectRef:
+                          apiVersion: v1
+                          kind: ConfigMap
+                          name: cloud-native-postgresql-operand-images-config
+                          namespace: {{ .OperatorNs }}
+                          path: .metadata.labels.app\.kubernetes\.io/name
+                      right:
+                        literal: cloud-native-postgresql
+                  then:
+                    configMapKeyRef:
+                      name: cloud-native-postgresql-operand-images-config
+                      key: ibm-postgresql-16-operand-image
+                      namespace: {{ .OperatorNs }}
+                  else:
+                    default:
+                      required: true
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-image-list
+                        key: ibm-postgresql-16-operand-image
+                        namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key
             logLevel: info
@@ -2016,12 +2031,30 @@ spec:
                       - common-service-db
             imageName:
               templatingValueFrom:
-                default:
-                  required: true
-                  configMapKeyRef:
-                    name: cloud-native-postgresql-image-list
-                    key: ibm-postgresql-16-operand-image
-                    namespace: {{ .OperatorNs }}
+                conditional:
+                  expression:
+                    equal:
+                      left:
+                        objectRef:
+                          apiVersion: v1
+                          kind: ConfigMap
+                          name: cloud-native-postgresql-operand-images-config
+                          namespace: {{ .OperatorNs }}
+                          path: .metadata.labels.app\.kubernetes\.io/name
+                      right:
+                        literal: cloud-native-postgresql
+                  then:
+                    configMapKeyRef:
+                      name: cloud-native-postgresql-operand-images-config
+                      key: ibm-postgresql-16-operand-image
+                      namespace: {{ .OperatorNs }}
+                  else:
+                    default:
+                      required: true
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-image-list
+                        key: ibm-postgresql-16-operand-image
+                        namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key
             logLevel: info

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1764,30 +1764,16 @@ spec:
                 owner: app
             imageName:
               templatingValueFrom:
-                conditional:
-                  expression:
-                    equal:
-                      left:
-                        objectRef:
-                          apiVersion: v1
-                          kind: ConfigMap
-                          name: cloud-native-postgresql-operand-images-config
-                          namespace: {{ .OperatorNs }}
-                          path: .metadata.labels.app\.kubernetes\.io/name
-                      right:
-                        literal: cloud-native-postgresql
-                  then:
-                    configMapKeyRef:
-                      name: cloud-native-postgresql-operand-images-config
-                      key: ibm-postgresql-16-operand-image
-                      namespace: {{ .OperatorNs }}
-                  else:
-                    default:
-                      required: true
-                      configMapKeyRef:
-                        name: cloud-native-postgresql-image-list
-                        key: ibm-postgresql-16-operand-image
-                        namespace: {{ .OperatorNs }}
+                default:
+                  required: true
+                  configMapKeyRef:
+                    name: cloud-native-postgresql-image-list
+                    key: ibm-postgresql-16-operand-image
+                    namespace: {{ .OperatorNs }}
+                configMapKeyRef:
+                  name: cloud-native-postgresql-operand-images-config
+                  key: ibm-postgresql-16-operand-image
+                  namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key
             logLevel: info
@@ -2031,30 +2017,16 @@ spec:
                       - common-service-db
             imageName:
               templatingValueFrom:
-                conditional:
-                  expression:
-                    equal:
-                      left:
-                        objectRef:
-                          apiVersion: v1
-                          kind: ConfigMap
-                          name: cloud-native-postgresql-operand-images-config
-                          namespace: {{ .OperatorNs }}
-                          path: .metadata.labels.app\.kubernetes\.io/name
-                      right:
-                        literal: cloud-native-postgresql
-                  then:
-                    configMapKeyRef:
-                      name: cloud-native-postgresql-operand-images-config
-                      key: ibm-postgresql-16-operand-image
-                      namespace: {{ .OperatorNs }}
-                  else:
-                    default:
-                      required: true
-                      configMapKeyRef:
-                        name: cloud-native-postgresql-image-list
-                        key: ibm-postgresql-16-operand-image
-                        namespace: {{ .OperatorNs }}
+                default:
+                  required: true
+                  configMapKeyRef:
+                    name: cloud-native-postgresql-image-list
+                    key: ibm-postgresql-16-operand-image
+                    namespace: {{ .OperatorNs }}
+                configMapKeyRef:
+                  name: cloud-native-postgresql-operand-images-config
+                  key: ibm-postgresql-16-operand-image
+                  namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key
             logLevel: info


### PR DESCRIPTION
**What this PR does / why we need it**:
By using EDB CASE 5.16+, request EDB 1.22/1.25. 
1. ODLM will read `cloud-native-postgresql-operand-images-config` ConfigMap, find the image digest and then put the value into Cluster CR `.spec.imageName`
2. If such ConfigMap does not exist, ODLM will fall back to read from `cloud-native-postgresql-image-list` ConfigMap to update imageName as before

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66594

**How to test**:
1. Test Image: quay.io/yuchen_shen/cs_operator:edb_cm
2. Change the test image for cs operator and request `ibm-im-operator`
3. Check the value under `.spec.imageName` in the Cluster CR is the same as the value in `cloud-native-postgresql-operand-images-config` ConfigMap