### PR TITLE
add an new entry for events v5.2

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2302,6 +2302,12 @@ spec:
     packageName: ibm-events-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+  - channel: v5.2
+    name: ibm-events-operator-v5.2
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-events-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
     channel: v6.2


### PR DESCRIPTION
**What this PR does / why we need it**:
 add an new entry in operandreg for ibm-events-operator-v5.2
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66631
