### PR TITLE
Add clarification about ingress vs egress network policies

### DIFF
--- a/networkpolicy/install_networkpolicy.sh
+++ b/networkpolicy/install_networkpolicy.sh
@@ -86,13 +86,13 @@ function print_usage() {
     script_name=`basename ${0}`
     echo "Usage: ${script_name} [OPTIONS]..."
     echo ""
-    echo "Install IBM Common Services NetworkPolicies"
+    echo "Install IBM Common Services NetworkPolicies. By default only ingress NetworkPolicies are installed."
     echo ""
     echo "Options:"
     echo "   -n, --namespace string       IBM Common Services namespace. Default is same namespace as IBM Common Services"
     echo "   -z, --zen-namespace string   Zen namespace. Default is same namespace as IBM Common Services"
     echo "   -u, --uninstall              Uninstall IBM Common Services Network Policies"
-    echo "   -e, --egress                 Deploy egress NetworkPolicies"
+    echo "   -e, --egress                 Deploy only egress NetworkPolicies. Without this option, only ingress NetworkPolicies are deployed"
     echo "   -h, --help                   Print usage information"
     echo ""
 }


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66645

```sh
% ./install_networkpolicy.sh -h
Usage: install_networkpolicy.sh [OPTIONS]...

Install IBM Common Services NetworkPolicies. By default only ingress NetworkPolicies are installed.

Options:
   -n, --namespace string       IBM Common Services namespace. Default is same namespace as IBM Common Services
   -z, --zen-namespace string   Zen namespace. Default is same namespace as IBM Common Services
   -u, --uninstall              Uninstall IBM Common Services Network Policies
   -e, --egress                 Deploy only egress NetworkPolicies. Without this option, only ingress NetworkPolicies are deployed
   -h, --help                   Print usage information
```