### PR TITLE
[SC2] Update the image digest in the Cluster CR as referenced from the Conf…

### DIFF
--- a/common/scripts/lint_go.sh
+++ b/common/scripts/lint_go.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-GOGC=25 golangci-lint run -c ./common/config/.golangci.yml --timeout=360s
+GOGC=25 golangci-lint run -c ./common/config/.golangci.yml --timeout=480s

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -586,6 +586,10 @@ spec:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
                           namespace: {{ $.OperatorNs }}
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-operand-images-config
+                        key: edb-postgres-license-provider-image
+                        namespace: {{ $.OperatorNs }}
                   name: edb-license
                   resources:
                     limits:
@@ -615,6 +619,10 @@ spec:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
                           namespace: {{ $.OperatorNs }}
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-operand-images-config
+                        key: edb-postgres-license-provider-image
+                        namespace: {{ $.OperatorNs }}
                   name: restart-edb-pod
                   resources:
                     limits:
@@ -1406,6 +1414,10 @@ spec:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
                           namespace: {{ .OperatorNs }}
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-operand-images-config
+                        key: edb-postgres-license-provider-image
+                        namespace: {{ $.OperatorNs }}
                   name: edb-license
                   resources:
                     limits:
@@ -1435,6 +1447,10 @@ spec:
                           name: cloud-native-postgresql-image-list
                           key: edb-postgres-license-provider-image
                           namespace: {{ .OperatorNs }}
+                      configMapKeyRef:
+                        name: cloud-native-postgresql-operand-images-config
+                        key: edb-postgres-license-provider-image
+                        namespace: {{ $.OperatorNs }}
                   name: restart-edb-pod
                   resources:
                     limits:
@@ -1512,8 +1528,9 @@ spec:
                     key: ibm-postgresql-14-operand-image
                     namespace: {{ .OperatorNs }}
                 configMapKeyRef:
-                    name: ibm-cpp-config
-                    key: edb-keycloak-operand-image
+                  name: cloud-native-postgresql-operand-images-config
+                  key: ibm-postgresql-14-operand-image
+                  namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key
             logLevel: info
@@ -1765,6 +1782,10 @@ spec:
                     name: cloud-native-postgresql-image-list
                     key: ibm-postgresql-16-operand-image
                     namespace: {{ .OperatorNs }}
+                configMapKeyRef:
+                  name: cloud-native-postgresql-operand-images-config
+                  key: ibm-postgresql-16-operand-image
+                  namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: ibm-entitlement-key
             logLevel: info


### PR DESCRIPTION
**What this PR does / why we need it**:
By using EDB CASE 5.16+, request EDB 1.22/1.25. 
1. ODLM will read `cloud-native-postgresql-operand-images-config` ConfigMap, find the image digest and then put the value into Cluster CR `.spec.imageName`
2. If such ConfigMap does not exist, ODLM will fall back to read from `cloud-native-postgresql-image-list` ConfigMap to update imageName as before

Cherry-pick: https://github.com/IBM/ibm-common-service-operator/pull/2520

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66594

**How to test**:
1. Test Image: quay.io/yuchen_shen/cs_operator:edb_cm
2. Change the test image for cs operator and request `ibm-im-operator`
4. Check the value under `.spec.imageName` in the Cluster CR is the same as the value in `cloud-native-postgresql-operand-images-config` ConfigMap