### PR TITLE
Add functionality to wait for Postgres Cluster image updates before applying configuration setting

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:4.13.0
-    createdAt: "2025-05-13T13:53:23Z"
+    createdAt: "2025-05-16T03:15:01Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -610,6 +610,13 @@ spec:
                 - patch
                 - update
                 - watch
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - clusters
+              verbs:
+                - get
+                - list
           serviceAccountName: ibm-common-service-operator
     strategy: deployment
   installModes:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -273,3 +273,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - postgresql.k8s.enterprisedb.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -235,5 +235,12 @@ rules:
       - patch
       - update
       - watch
+  - apiGroups:
+      - postgresql.k8s.enterprisedb.io
+    resources:
+      - clusters
+    verbs:
+      - get
+      - list
 ---
 {{- end }}

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2526,6 +2526,14 @@ func (b *Bootstrap) WaitForPostgresClusterImageUpdate(ctx context.Context, insta
 		Kind:    constant.PGClusterKind,
 	})
 
+	if clusterCRDExists, err := b.CheckCRD(constant.PGClusterGroup+"/v1", constant.PGClusterKind); err != nil {
+		klog.Errorf("Failed to check if Postgres Cluster CRD exists: %v", err)
+		return err
+	} else if !clusterCRDExists {
+		klog.Infof("Postgres %s Cluster CRD not found, skipping Postgres Cluster image update check", constant.PGClusterGroup+"/v1")
+		return nil
+	}
+
 	if err := b.Client.Get(ctx, types.NamespacedName{
 		Name:      constant.CSPGCluster,
 		Namespace: b.CSData.ServicesNs,

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2515,3 +2515,167 @@ func (b *Bootstrap) fetchSubscription(subName, packageManifest, operatorNs strin
 	}
 	return sub, nil
 }
+
+// Wait for Postgres Cluster CR image to be updated with the image from the configmap
+func (b *Bootstrap) WaitForPostgresClusterImageUpdate(ctx context.Context, instance *apiv3.CommonService) error {
+	// Check if Postgres Cluster CR "common-service-db" is created in service namespace
+	pgCluster := &unstructured.Unstructured{}
+	pgCluster.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   constant.PGClusterGroup,
+		Version: "v1",
+		Kind:    constant.PGClusterKind,
+	})
+
+	if err := b.Client.Get(ctx, types.NamespacedName{
+		Name:      constant.CSPGCluster,
+		Namespace: b.CSData.ServicesNs,
+	}, pgCluster); err != nil {
+		if errors.IsNotFound(err) {
+			klog.Infof("Postgres Cluster CR %s not found in namespace %s, skipping Cluster CR image update check", constant.CSPGCluster, b.CSData.ServicesNs)
+			return nil
+		}
+		return err
+	}
+
+	configMap, err := b.getPostgresImageConfigMap(ctx)
+	if err != nil {
+		return err
+	} else if configMap == nil {
+		klog.Infof("Neither %s nor %s configmap found in namespace %s, skipping Postgres Cluster image update check",
+			constant.PostgreSQLImageConfigMap, constant.CSPostgreSQLImageConfigMap, b.CSData.OperatorNs)
+		return nil
+	}
+	configMapName := configMap.GetName()
+	imageKeyName := constant.PostgreSQL16ImageKey
+
+	// Get the image from the configmap
+	desiredImage, exists := configMap.Data[imageKeyName]
+	if !exists {
+		klog.Infof("Image key %s not found in configmap %s/%s, skipping image update check",
+			imageKeyName, b.CSData.OperatorNs, configMapName)
+		return nil
+	}
+
+	// Get current image from the Postgres Cluster CR
+	currentImage, found, err := unstructured.NestedString(pgCluster.Object, "spec", "imageName")
+	if err != nil {
+		return err
+	}
+
+	// If image is already updated, return nil
+	if found && currentImage == desiredImage {
+		klog.Infof("Postgres Cluster CR %s image already updated to the desired image in configmap %s/%s",
+			constant.CSPGCluster, b.CSData.OperatorNs, configMapName)
+		return nil
+	}
+
+	// Update the configmap with ODLM metadata to trigger ODLM reconciliation
+	if err := b.updateConfigMapWithODLMMetadata(ctx, configMap); err != nil {
+		return err
+	}
+
+	// Wait for the image to be updated
+	return utilwait.PollImmediate(time.Second*10, time.Minute*2, func() (done bool, err error) {
+		// Fetch the latest Postgres Cluster CR
+		err = b.Client.Get(ctx, types.NamespacedName{
+			Name:      constant.CSPGCluster,
+			Namespace: b.CSData.ServicesNs,
+		}, pgCluster)
+
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+
+		// Check if image is updated
+		currentImage, found, err := unstructured.NestedString(pgCluster.Object, "spec", "imageName")
+		if err != nil {
+			return false, err
+		}
+
+		if found && currentImage == desiredImage {
+			klog.Infof("Postgres Cluster CR %s image updated to the desired image in configmap %s/%s",
+				constant.CSPGCluster, b.CSData.OperatorNs, configMapName)
+			return true, nil
+		}
+
+		klog.Infof("Postgres Cluster CR %s image is not updated, waiting for update to the desired image in configmap %s/%s",
+			constant.CSPGCluster, b.CSData.OperatorNs, configMapName)
+		return false, nil
+	})
+}
+
+// getPostgresImageConfigMap gets the configmap containing PostgreSQL image information
+// It first tries to get the configmap deployed with Postgres Operator,
+// and if not found, it looks for the configmap created by CS operator
+func (b *Bootstrap) getPostgresImageConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{}
+	configMapName := constant.PostgreSQLImageConfigMap
+
+	if err := b.Client.Get(ctx, types.NamespacedName{
+		Name:      configMapName,
+		Namespace: b.CSData.OperatorNs,
+	}, configMap); err != nil && errors.IsNotFound(err) {
+		// If the configmap is not found, find configmap created by CS operator
+		configMapName = constant.CSPostgreSQLImageConfigMap
+
+		if err := b.Client.Get(ctx, types.NamespacedName{
+			Name:      configMapName,
+			Namespace: b.CSData.OperatorNs,
+		}, configMap); err != nil {
+			if errors.IsNotFound(err) {
+
+				return nil, nil
+			}
+			klog.Errorf("Failed to get configmap %s in namespace %s: %v", configMapName, b.CSData.OperatorNs, err)
+			return nil, err
+		}
+	} else if err != nil {
+		klog.Errorf("Failed to get configmap %s in namespace %s: %v", configMapName, b.CSData.OperatorNs, err)
+		return nil, err
+	}
+
+	return configMap, nil
+}
+
+// updateConfigMapWithODLMMetadata adds ODLM-specific labels and annotations to a ConfigMap
+// to ensure it's properly reconciled by the Operand Deployment Lifecycle Manager
+func (b *Bootstrap) updateConfigMapWithODLMMetadata(ctx context.Context, configMap *corev1.ConfigMap) error {
+	// Check if the configmap has the required label and annotation
+	needsLabelUpdate := false
+	cmLabels := configMap.GetLabels()
+	if cmLabels == nil {
+		cmLabels = make(map[string]string)
+		needsLabelUpdate = true
+	}
+
+	if _, exists := cmLabels[constant.ODLMWatchLabel]; !exists {
+		cmLabels[constant.ODLMWatchLabel] = "true"
+		needsLabelUpdate = true
+	}
+
+	cmAnnotations := configMap.GetAnnotations()
+	if cmAnnotations == nil {
+		cmAnnotations = make(map[string]string)
+		needsLabelUpdate = true
+	}
+
+	expectedAnnotation := fmt.Sprintf("OperandConfig.%s.common-service", b.CSData.ServicesNs)
+	if cmAnnotations[constant.ODLMReferenceAnno] != expectedAnnotation {
+		cmAnnotations[constant.ODLMReferenceAnno] = expectedAnnotation
+		needsLabelUpdate = true
+	}
+
+	if needsLabelUpdate {
+		klog.Infof("Updating configmap %s/%s with ODLM labels and annotations to trigger the ODLM reconciliation", configMap.Namespace, configMap.Name)
+		configMap.SetLabels(cmLabels)
+		configMap.SetAnnotations(cmAnnotations)
+		if err := b.Client.Update(ctx, configMap); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -250,13 +250,23 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		return ctrl.Result{}, statusErr
 	}
 
+	// Wait for Postgres Cluster image to be updated
+	if err := r.Bootstrap.WaitForPostgresClusterImageUpdate(ctx, instance); err != nil {
+		klog.Errorf("Failed to update Postgres Cluster image: %v", err)
+		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
+			klog.Error(err)
+		}
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		return ctrl.Result{}, err
+	}
+
 	// Apply new configs to CommonService CR
 	cs := util.NewUnstructured("operator.ibm.com", "CommonService", "v3")
 	if statusErr = r.Bootstrap.Client.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, cs); statusErr != nil {
 		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		return ctrl.Result{}, statusErr
 	}
-	// Set "Pengding" condition and "Updating" for phase when config CS CR
+	// Set "Pending" condition and "Updating" for phase when config CS CR
 	instance.SetPendingCondition(constant.MasterCR, apiv3.ConditionTypeReconciling, corev1.ConditionTrue, apiv3.ConditionReasonConfig, apiv3.ConditionMessageConfig)
 	instance.Status.Phase = apiv3.CRUpdating
 	newConfigs, serviceControllerMapping, statusErr := r.getNewConfigs(cs)
@@ -379,6 +389,16 @@ func (r *CommonServiceReconciler) ReconcileGeneralCR(ctx context.Context, instan
 	// Generate Issuer and Certificate CR
 	if err := r.Bootstrap.DeployCertManagerCR(); err != nil {
 		klog.Errorf("Failed to deploy cert manager CRs: %v", err)
+		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
+			klog.Error(err)
+		}
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		return ctrl.Result{}, err
+	}
+
+	// Wait for Postgres Cluster image to be updated
+	if err := r.Bootstrap.WaitForPostgresClusterImageUpdate(ctx, instance); err != nil {
+		klog.Errorf("Failed to update Postgres Cluster image: %v", err)
 		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
 			klog.Error(err)
 		}

--- a/internal/controller/constant/cloudNativePostgresql.go
+++ b/internal/controller/constant/cloudNativePostgresql.go
@@ -24,6 +24,7 @@ metadata:
   namespace: "{{ .CPFSNs }}"
   labels:
     operator.ibm.com/managedByCsOperator: "true"
+    operator.ibm.com/watched-by-odlm: "true"
   annotations:
     version: {{ .Version }}
 data:

--- a/internal/controller/constant/constant.go
+++ b/internal/controller/constant/constant.go
@@ -122,6 +122,22 @@ const (
 	RequeueDuration = 30 * time.Second
 	// OpreqLabel is the label used to label the Subscription/CR/Configmap managed by ODLM
 	OpreqLabel string = "operator.ibm.com/opreq-control"
+	// CSPGCluster is the name of the common service postgresql cluster
+	CSPGCluster = "common-service-db"
+	// PGClusterGroup is the name of the common service postgresql cluster group
+	PGClusterGroup = "postgresql.k8s.enterprisedb.io"
+	// PGClusterKind is the kind of the common service postgresql cluster
+	PGClusterKind = "Cluster"
+	// PostgreSQLImageConfigMap is the name of the postgresql image list ConfigMap deployed with Postgres Operator
+	PostgreSQLImageConfigMap = "cloud-native-postgresql-operand-images-config"
+	// CSPostgreSQLImageConfigMap is the name of the postgresql image list ConfigMap deployed by Common Service Operator
+	CSPostgreSQLImageConfigMap = "cloud-native-postgresql-image-list"
+	// PostgreSQL16ImageKey is the key for PostgreSQL 16 image in the ConfigMap
+	PostgreSQL16ImageKey = "ibm-postgresql-16-operand-image"
+	// ODLMWatchLabel is the label used to label the Subscription/CR/Configmap managed by ODLM
+	ODLMWatchLabel = "operator.ibm.com/watched-by-odlm"
+	// ODLMReferenceAnno is the annotation used to label the Subscription/CR/Configmap managed by ODLM
+	ODLMReferenceAnno = "operator.ibm.com/referenced-by-odlm-resource"
 )
 
 // DefaultChannels defines the default channels available for each operator


### PR DESCRIPTION
**What this PR does / why we need it**:
Postgres operator webhook will deny the EDB Cluster CR update when the update contains both image and configuration changes.
```
  - failed to update k8s resource -- Kind: Cluster, NamespacedName: aiops/common-service-db: failed to update k8s resource -- Kind: Cluster, NamespacedName: aiops/common-service-db: admission webhook "vcluster.k8s.enterprisedb.io" denied the request: Cluster.cluster.k8s.enterprisedb.io "common-service-db" is invalid: spec.imageName: Invalid value: "icr.io/cpopen/edb/postgresql:16.8@sha256:43599de779d84195ffc7558541883545068aec300a2b745303327ea8b7b5aaf4": Can't change image name and configuration at the same time. There are differences in PostgreSQL configuration parameters: {"max_slot_wal_keep_size":["","8GB"],"shared_buffers":["","150MB"]}
```

The idea of solution is to update Cluster CR field in sequence. CS operator will NOT apply OperandConfig changes(including EDB Cluster Configuration) UNTIL ODLM updates Cluster CR with the latest image specified in Postgres Operand ConfigMap.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66478

**Test**:
1. Install latest dev build
2. Patch CS operator CSV to pull image `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:dev`
3. Observe the CS operator logs
   - Fresh installation without Postgres Cluster CRD
      ```
      I0516 13:39:22.152630 1 init.go:1529] Checking Cert Manager Certs and Issuers deployment
      I0516 13:39:27.687904 1 init.go:2533] Postgres postgresql.k8s.enterprisedb.io/v1 Cluster CRD not found, skipping Postgres Cluster image update check
      I0516 13:39:27.691871 1 render_template.go:185] Applying size configuration
      I0516 13:39:27.723812 1 render_template.go:185] Applying size configuration
      ```
   - Fresh installation without Postgres Cluster CR
      ```
      I0516 03:16:44.956887 1 init.go:1529] Checking Cert Manager Certs and Issuers deployment
      I0516 03:16:44.969040 1 init.go:2534] Postgres Cluster CR common-service-db not found in namespace edb-upgrade, skipping Cluster CR image update check
      I0516 03:16:44.971621 1 render_template.go:185] Applying size configuration
      I0516 03:16:44.995656 1 render_template.go:185] Applying size configuration
      ```
   - Continuous reconciliation when the EDB Cluster CR is up-to-dated.
      ```
      I0516 03:18:57.965342 1 init.go:1529] Checking Cert Manager Certs and Issuers deployment
      I0516 03:18:57.983798 1 init.go:2567] Postgres Cluster CR common-service-db image already updated to the desired image in configmap edb-upgrade/cloud-native-postgresql-operand-images-config
      I0516 03:18:57.987318 1 render_template.go:185] Applying size configuration
      I0516 03:18:58.013636 1 render_template.go:185] Applying size configuration
      ```
   - Scale down ODLM, and update ConfigMap with new image digest, then scale back ODLM, to wait for Cluster CR to be updated with latest image.
      ```
      I0516 13:52:48.890772 1 init.go:2612] Postgres Cluster CR common-service-db image is not updated, waiting for update to the desired image in configmap edb-upgrade/cloud-native-postgresql-operand-images-config
      I0516 13:52:58.900778 1 init.go:2612] Postgres Cluster CR common-service-db image is not updated, waiting for update to the desired image in configmap edb-upgrade/cloud-native-postgresql-operand-images-config
      1.7474035861302078e+09 DEBUG controller-runtime.webhook.webhooks received request {"webhook": "/mutate-operator-ibm-com-v1alpha1-operandrequest", "UID": "9dd3ac52-a72c-41a8-85d5-1af0ccd8368d", "kind": "operator.ibm.com/v1alpha1, Kind=OperandRequest", "resource": {"group":"operator.ibm.com","version":"v1alpha1","resource":"operandrequests"}}
      I0516 13:53:06.130314 1 mutatingwebhook.go:50] Webhook is invoked by OperandRequest edb-upgrade/postgresql-operator-request
      1.747403586131256e+09 DEBUG controller-runtime.webhook.webhooks wrote response {"webhook": "/mutate-operator-ibm-com-v1alpha1-operandrequest", "code": 200, "reason": "", "UID": "9dd3ac52-a72c-41a8-85d5-1af0ccd8368d", "allowed": true}
      I0516 13:53:08.896873 1 init.go:2612] Postgres Cluster CR common-service-db image is not updated, waiting for update to the desired image in configmap edb-upgrade/cloud-native-postgresql-operand-images-config
      I0516 13:53:18.900514 1 init.go:2607] Postgres Cluster CR common-service-db image updated to the desired image in configmap edb-upgrade/cloud-native-postgresql-operand-images-config
      ```