### PR TITLE
Add new permission in nss managed role for Events 5.2.0

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -674,6 +674,7 @@ rules:
       - create
       - patch
       - update
+      - delete
     apiGroups:
       - ibmevents.ibm.com
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the necessary permissions for new version events operator 5.2.0

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66711