### PR TITLE
Clarify usage instructions for CP3.0 NetworkPolicies installation script

### DIFF
--- a/cp3-networkpolicy/install_networkpolicy.sh
+++ b/cp3-networkpolicy/install_networkpolicy.sh
@@ -115,7 +115,7 @@ function print_usage() {
     echo "   -lsr, --licensing-svc-reporter-namespace string      License Service Reporter namespace. No default value"
     echo "   -flink, --flink-namespace string                     Flink namespace. No default value"
     echo "   -opensearch, --opensearch-namespace string           Opensearch namespace. No default value"
-    echo "   -u, --uninstall                                      Uninstall IBM Common Services Network Policies"
+    echo "   -u, --uninstall                                      Uninstall both ingress and egress IBM Common Services Network Policies"
     echo "   -e, --egress                                         Deploy egress NetworkPolicies. Without this option, only ingress NetworkPolicies are deployed"
     echo "   -h, --help                                           Print usage information"
     echo ""

--- a/cp3-networkpolicy/install_networkpolicy.sh
+++ b/cp3-networkpolicy/install_networkpolicy.sh
@@ -104,7 +104,7 @@ function print_usage() {
     script_name=`basename ${0}`
     echo "Usage: ${script_name} [OPTIONS]..."
     echo ""
-    echo "Install IBM Common Services NetworkPolicies"
+    echo "Install IBM Common Services NetworkPolicies. By default only ingress NetworkPolicies are installed."
     echo ""
     echo "Options:"
     echo "   -n, --namespace string                               IBM Common Services operand namespace. No default value"
@@ -116,7 +116,7 @@ function print_usage() {
     echo "   -flink, --flink-namespace string                     Flink namespace. No default value"
     echo "   -opensearch, --opensearch-namespace string           Opensearch namespace. No default value"
     echo "   -u, --uninstall                                      Uninstall IBM Common Services Network Policies"
-    echo "   -e, --egress                                         Deploy egress NetworkPolicies"
+    echo "   -e, --egress                                         Deploy egress NetworkPolicies. Without this option, only ingress NetworkPolicies are deployed"
     echo "   -h, --help                                           Print usage information"
     echo ""
 }

--- a/networkpolicy/install_networkpolicy.sh
+++ b/networkpolicy/install_networkpolicy.sh
@@ -91,7 +91,7 @@ function print_usage() {
     echo "Options:"
     echo "   -n, --namespace string       IBM Common Services namespace. Default is same namespace as IBM Common Services"
     echo "   -z, --zen-namespace string   Zen namespace. Default is same namespace as IBM Common Services"
-    echo "   -u, --uninstall              Uninstall IBM Common Services Network Policies"
+    echo "   -u, --uninstall              Uninstall both ingress and egress IBM Common Services Network Policies"
     echo "   -e, --egress                 Deploy only egress NetworkPolicies. Without this option, only ingress NetworkPolicies are deployed"
     echo "   -h, --help                   Print usage information"
     echo ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the copy of #2526, to add clarify usage instructions for CP3.0 NetworkPolicies installation script.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66645