### PR TITLE
enhance Postgres Cluster image update function

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,14 +23,8 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles467.css
     containerImage: icr.io/cpopen/common-service-operator:4.6.15
-    createdAt: "2025-03-06T19:45:25Z"
+    createdAt: "2025-06-06T02:09:35Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
-    nss.operator.ibm.com/managed-operators: ibm-common-service-operator
-    nss.operator.ibm.com/managed-webhooks: ""
-    olm.skipRange: ">=3.3.0 <4.6.15"
-    operatorChannel: v4.6
-    operatorVersion: 4.6.15
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
     features.operators.openshift.io/proxy-aware: "false"
@@ -38,6 +32,12 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
+    nss.operator.ibm.com/managed-operators: ibm-common-service-operator
+    nss.operator.ibm.com/managed-webhooks: ""
+    olm.skipRange: ">=3.3.0 <4.6.15"
+    operatorChannel: v4.6
+    operatorVersion: 4.6.15
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.38.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/IBM/ibm-common-service-operator
@@ -622,6 +622,7 @@ spec:
               verbs:
                 - get
                 - list
+                - update
           serviceAccountName: ibm-common-service-operator
     strategy: deployment
   installModes:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -272,3 +272,4 @@ rules:
   verbs:
   - get
   - list
+  - update

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2274,8 +2274,8 @@ func (b *Bootstrap) fetchSubscription(subName, packageManifest, operatorNs strin
 	return sub, nil
 }
 
-// Wait for Postgres Cluster CR image to be updated with the image from the configmap
-func (b *Bootstrap) WaitForPostgresClusterImageUpdate(ctx context.Context, instance *apiv3.CommonService) error {
+// UpdatePostgresClusterImage checks if the Postgres Cluster image needs to be updated
+func (b *Bootstrap) UpdatePostgresClusterImage(ctx context.Context, instance *apiv3.CommonService) error {
 	// Check if Postgres Cluster CR "common-service-db" is created in service namespace
 	pgCluster := &unstructured.Unstructured{}
 	pgCluster.SetGroupVersionKind(schema.GroupVersionKind{
@@ -2341,7 +2341,8 @@ func (b *Bootstrap) WaitForPostgresClusterImageUpdate(ctx context.Context, insta
 	}
 
 	// Wait for the image to be updated
-	return utilwait.PollImmediate(time.Second*10, time.Minute*2, func() (done bool, err error) {
+	// If timeout occurs, controller will update the image in the Postgres Cluster CR
+	if err := utilwait.PollImmediate(time.Second*10, time.Minute*1, func() (done bool, err error) {
 		// Fetch the latest Postgres Cluster CR
 		err = b.Client.Get(ctx, types.NamespacedName{
 			Name:      constant.CSPGCluster,
@@ -2350,6 +2351,8 @@ func (b *Bootstrap) WaitForPostgresClusterImageUpdate(ctx context.Context, insta
 
 		if err != nil {
 			if errors.IsNotFound(err) {
+				klog.Infof("Postgres Cluster CR %s not found in namespace %s, skipping image update check",
+					constant.CSPGCluster, b.CSData.ServicesNs)
 				return true, nil
 			}
 			return false, err
@@ -2361,7 +2364,13 @@ func (b *Bootstrap) WaitForPostgresClusterImageUpdate(ctx context.Context, insta
 			return false, err
 		}
 
-		if found && currentImage == desiredImage {
+		if !found {
+			klog.Warningf("spec.imageName field not found in Postgres Cluster CR %s in namespace %s",
+				constant.CSPGCluster, b.CSData.ServicesNs)
+			return false, nil
+		}
+
+		if currentImage == desiredImage {
 			klog.Infof("Postgres Cluster CR %s image updated to the desired image in configmap %s/%s",
 				constant.CSPGCluster, b.CSData.OperatorNs, configMapName)
 			return true, nil
@@ -2370,7 +2379,23 @@ func (b *Bootstrap) WaitForPostgresClusterImageUpdate(ctx context.Context, insta
 		klog.Infof("Postgres Cluster CR %s image is not updated, waiting for update to the desired image in configmap %s/%s",
 			constant.CSPGCluster, b.CSData.OperatorNs, configMapName)
 		return false, nil
-	})
+	}); err != nil {
+		klog.Warningf("Failed to wait for Postgres Cluster CR %s image update: %v", constant.CSPGCluster, err)
+		// If the image is not updated, update the Postgres Cluster CR with the desired image
+		klog.Infof("Updating Postgres Cluster CR %s image to the desired image %s in configmap %s/%s",
+			constant.CSPGCluster, desiredImage, b.CSData.OperatorNs, configMapName)
+		if err := unstructured.SetNestedField(pgCluster.Object, desiredImage, "spec", "imageName"); err != nil {
+			klog.Errorf("Failed to set desired image in Postgres Cluster CR %s: %v", constant.CSPGCluster, err)
+			return err
+		}
+		if err := b.Client.Update(ctx, pgCluster); err != nil {
+			return fmt.Errorf("failed to update Postgres Cluster CR %s image update: %v", constant.CSPGCluster, err)
+		}
+	}
+
+	klog.Infof("Postgres Cluster CR %s image successfully updated to the desired image in configmap %s/%s",
+		constant.CSPGCluster, b.CSData.OperatorNs, configMapName)
+	return nil
 }
 
 // getPostgresImageConfigMap gets the configmap containing PostgreSQL image information


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Wait Postgres Cluster image update after OperandConfig is updated with latest configuration.
2. If the waiting for Postgres Cluster image update is timeout, it means that ODLM is not able to update the Postgres Cluster image, CS controller will directly update the Postgres Cluster image.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66478

### How the test is done?
1. Patch the CS operator CSV with image `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:dev`
2. Install OperandRequest with `common-service-postgresql`
3. Scale down ODLM pod
4. Change  `ibm-postgresql-16-operand-image` to `'icr.io/cpopen/edb/postgresql:16.4@sha256:d87a804d9bb7558d124bd83a83c261a074c26bccc3fe6ef095cdbe22be29a456'` in ConfigMap `cloud-native-postgresql-operand-images-config`
5. Configure CommonService CR to `large` size
6. Scale back ODLM pod
7. This will make ODLM stuck at updating EDB Cluster CR with following error
    ```
    E0606 02:59:39.995086 1 reconcile_operand.go:503] Failed to reconcile k8s resource -- Kind: Cluster, NamespacedName: /common-service-db with error: failed to update k8s resource -- Kind: Cluster, NamespacedName: keycloak/common-service-db: failed to update k8s resource -- Kind: Cluster, NamespacedName: keycloak/common-service-db: admission webhook "vcluster.k8s.enterprisedb.io" denied the request: Cluster.cluster.k8s.enterprisedb.io "common-service-db" is invalid: spec.imageName: Invalid value: "icr.io/cpopen/edb/postgresql:16.8@sha256:43599de779d84195ffc7558541883545068aec300a2b745303327ea8b7b5aaf4": Can't change image name and configuration at the same time. There are differences in PostgreSQL configuration parameters: {"max_connections":["","1100"],"shared_buffers":["64MB","150MB"]}
    ```
8. Check CS operator pod logs, it will update `common-service-db` Cluster CR image after the waiting is timeout - It is timeout because ODLM is not able to make the update.
    ```
    I0606 03:03:56.168795 1 init.go:2379] Postgres Cluster CR common-service-db image is not updated, waiting for update to the desired image in configmap keycloak/cloud-native-postgresql-operand-images-config
    I0606 03:03:56.178581 1 init.go:2379] Postgres Cluster CR common-service-db image is not updated, waiting for update to the desired image in configmap keycloak/cloud-native-postgresql-operand-images-config
    W0606 03:03:56.178614 1 init.go:2383] Failed to wait for Postgres Cluster CR common-service-db image update: timed out waiting for the condition
    I0606 03:03:56.178624 1 init.go:2385] Updating Postgres Cluster CR common-service-db image to the desired image icr.io/cpopen/edb/postgresql:16.8@sha256:43599de779d84195ffc7558541883545068aec300a2b745303327ea8b7b5aaf4 in configmap keycloak/cloud-native-postgresql-operand-images-config
    I0606 03:03:56.208825 1 init.go:2396] Postgres Cluster CR common-service-db image successfully updated to the desired image in configmap keycloak/cloud-native-postgresql-operand-images-config
    1.7491790362091439e+09 DEBUG events Normal {"object": {"kind":"CommonService","namespace":"keycloak","name":"example-commonservice","uid":"c10e9617-218a-4474-a1b8-86a91d055bec","apiVersion":"operator.ibm.com/v3","resourceVersion":"688330076"}, "reason": "Noeffect", "message": "No update to, replica sizings in the OperatorConfig keycloak/test-operator-config are larger than the profile from CommonService CR keycloak/example-commonservice"}
    I0606 03:03:56.220221 1 commonservice_controller.go:447] Finished reconciling CommonService: keycloak/example-commonservice
    ```
9. After CS operator updates the Cluster CR image, ODLM will be able to reconcile the EDB Cluster CR with other configurations as well. 