### PR TITLE
Add RBAC permission for Usage Metering Operator

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -113,6 +113,10 @@ rules:
       - jobs
   - verbs:
       - create
+      - delete
+      - list
+      - watch
+      - patch
       - get
       - update
     apiGroups:
@@ -244,7 +248,6 @@ rules:
     apiGroups:
       - apps
     resources:
-      - deployments
       - statefulsets
       - daemonsets
   - verbs:
@@ -320,6 +323,35 @@ rules:
     resources:
       - certificates
       - issuers
+  - verbs:
+      - get
+      - create
+      - delete
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - ibmusagemeterings
+      - ibmservicemeterdefinitions
+  - verbs:
+      - update
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - ibmusagemeterings/finalizers
+      - ibmservicemeterdefinitions/finalizers
+  - verbs:
+      - update
+      - get
+      - patch
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - ibmservicemeterdefinitions/status
+      - ibmusagemeterings/status
   - verbs:
       - delete
     apiGroups:
@@ -400,24 +432,6 @@ rules:
       - get
       - list
       - watch
-      - create
-      - delete
-      - update
-      - patch
-    apiGroups:
-      - route.openshift.io
-    resources:
-      - routes
-  - verbs:
-      - create
-    apiGroups:
-      - route.openshift.io
-    resources:
-      - routes/custom-host
-  - verbs:
-      - get
-      - list
-      - watch
     apiGroups:
       - route.openshift.io
     resources:
@@ -463,7 +477,6 @@ rules:
     apiGroups:
       - apps
     resources:
-      - deployments
       - daemonsets
   - verbs:
       - get
@@ -493,7 +506,6 @@ rules:
       - apps
     resources:
       - replicasets
-      - deployments
       - statefulsets
   - verbs:
       - create
@@ -642,18 +654,13 @@ rules:
     resources:
       - secrets
   - verbs:
-      - create
-    apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-  - verbs:
       - get
       - list
       - watch
       - delete
       - patch
       - update
+      - create
     apiGroups:
       - coordination.k8s.io
     resources:
@@ -774,7 +781,6 @@ rules:
     apiGroups:
       - apps
     resources:
-      - deployments
       - statefulsets
       - replicasets
   - verbs:
@@ -787,8 +793,8 @@ rules:
       - deployments/scale
   - verbs:
       - create
+      - patch
     apiGroups:
-      - ''
       - events.k8s.io
     resources:
       - events
@@ -854,47 +860,10 @@ rules:
       - get
       - list
       - watch
-      - create
-      - delete
-      - update
-      - patch
-    apiGroups:
-      - route.openshift.io
-    resources:
-      - routes
-  - verbs:
-      - create
-    apiGroups:
-      - route.openshift.io
-    resources:
-      - routes/custom-host
-  - verbs:
-      - get
-      - list
-      - watch
     apiGroups:
       - route.openshift.io
     resources:
       - routes/status
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - ''
-    resources:
-      - pods
-      - services
-      - services/finalizers
-      - endpoints
-      - persistentvolumeclaims
-      - events
-      - configmaps
-      - secrets
   - verbs:
       - create
       - delete
@@ -1639,18 +1608,6 @@ rules:
       - packages.operators.coreos.com
     resources:
       - packagemanifests
-  - verbs:
-      - create
-      - delete
-      - get
-      - list
-      - patch
-      - update
-      - watch
-    apiGroups:
-      - route.openshift.io
-    resources:
-      - routes
   - verbs:
       - get
     apiGroups:


### PR DESCRIPTION
**What this PR does / why we need it**:
Collect RBAC permissions for usage-metering-operator into `nss-managed-bedrock-core-role.yaml`.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66812

**How to test:**
1. install cs with this new role yaml file
2. request `ibm-metering-operator` and check if ODLM does not have permission error