### PR TITLE
Update User Management bindable resources

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -577,11 +577,9 @@ spec:
           spec:
             bindings:
               public-account-iam-config-dev:
-                configmap: account-iam-env-configmap-dev
+                configmap: account-iam-env-configmap-development
               public-bootstrap-creds:
                 secret: user-mgmt-bootstrap
-              public-ibmcloudca-secret:
-                secret: ibmcloud-cluster-ca-secret
               public-mcsp-integration-details:
                 secret: mcsp-im-integration-details
             description: Binding information that should be accessible to User Management adopters


### PR DESCRIPTION
**What this PR does / why we need it**:
Correct the phase of OperandBindInfo `ibm-user-mgmt-bindinfo` to `Completed` by Updating UM bindable resources

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66939
