### PR TITLE
[CD] Enable user-defined catalog source and namespace in CS CR (#2543)

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -38,6 +38,8 @@ type CSData struct {
 	OperatorNs              string
 	CatalogSourceName       string
 	CatalogSourceNs         string
+	ODLMCatalogSourceName   string
+	ODLMCatalogSourceNs     string
 	IsolatedModeEnable      string
 	ApprovalMode            string
 	OnPremMultiEnable       string
@@ -213,7 +215,7 @@ type ConfigurableCR struct {
 type ConfigStatus struct {
 	// CatalogName is the name of the CatalogSource foundational services is using
 	CatalogName CatalogName `json:"catalogName,omitempty"`
-	// CatalogNamespace is the namesapce of the CatalogSource
+	// CatalogNamespace is the namespace of the CatalogSource
 	CatalogNamespace CatalogNamespace `json:"catalogNamespace,omitempty"`
 	// OperatorNamespace is the namespace of where the foundational services'
 	// operators will be installed in.
@@ -365,17 +367,10 @@ func (r *CommonService) UpdateConfigStatus(CSData *CSData, operatorDeployed, ser
 		r.Status.ConfigStatus.ServicesNamespace = ServicesNamespace(CSData.ServicesNs)
 	}
 
-	if r.Spec.CatalogName != "" {
-		r.Status.ConfigStatus.CatalogName = r.Spec.CatalogName
-	} else {
-		r.Status.ConfigStatus.CatalogName = CatalogName(CSData.CatalogSourceName)
-	}
+	r.Status.ConfigStatus.CatalogName = r.Spec.CatalogName
 
-	if r.Spec.CatalogNamespace != "" {
-		r.Status.ConfigStatus.CatalogNamespace = r.Spec.CatalogNamespace
-	} else {
-		r.Status.ConfigStatus.CatalogNamespace = CatalogNamespace(CSData.CatalogSourceNs)
-	}
+	r.Status.ConfigStatus.CatalogNamespace = r.Spec.CatalogNamespace
+
 	r.Status.ConfigStatus.OperatorDeployed = true
 	r.Status.ConfigStatus.ServicesDeployed = true
 	r.Status.ConfigStatus.Configurable = true

--- a/bundle/manifests/operator.ibm.com_commonservices.yaml
+++ b/bundle/manifests/operator.ibm.com_commonservices.yaml
@@ -288,7 +288,7 @@ spec:
                       services is using
                     type: string
                   catalogNamespace:
-                    description: CatalogNamespace is the namesapce of the CatalogSource
+                    description: CatalogNamespace is the namespace of the CatalogSource
                     type: string
                   configurable:
                     description: |-

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -285,7 +285,7 @@ spec:
                       services is using
                     type: string
                   catalogNamespace:
-                    description: CatalogNamespace is the namesapce of the CatalogSource
+                    description: CatalogNamespace is the namespace of the CatalogSource
                     type: string
                   configurable:
                     description: |-

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -145,21 +145,25 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 		return
 	}
 
-	catalogSourceName, catalogSourceNs := util.GetCatalogSource(constant.IBMCSPackage, operatorNs, mgr.GetAPIReader())
-	if catalogSourceName == "" || catalogSourceNs == "" {
-		err = fmt.Errorf("failed to get catalogsource")
+	odlmCatalogSourceName, odlmcatalogSourceNs := util.GetCatalogSource(constant.IBMCSPackage, operatorNs, mgr.GetAPIReader())
+	if odlmCatalogSourceName == "" || odlmcatalogSourceNs == "" {
+		err = fmt.Errorf("failed to get ODLM catalogsource")
 		return
 	}
+
 	approvalMode, err := util.GetApprovalModeinNs(mgr.GetAPIReader(), operatorNs)
 	if err != nil {
 		return
 	}
+
 	csData := apiv3.CSData{
 		CPFSNs:                  cpfsNs,
 		ServicesNs:              servicesNs,
 		OperatorNs:              operatorNs,
-		CatalogSourceName:       catalogSourceName,
-		CatalogSourceNs:         catalogSourceNs,
+		CatalogSourceName:       "",
+		CatalogSourceNs:         "",
+		ODLMCatalogSourceName:   odlmCatalogSourceName,
+		ODLMCatalogSourceNs:     odlmcatalogSourceNs,
 		ApprovalMode:            approvalMode,
 		WatchNamespaces:         util.GetWatchNamespace(),
 		OnPremMultiEnable:       strconv.FormatBool(util.CheckMultiInstances(mgr.GetAPIReader())),
@@ -1549,7 +1553,7 @@ func (b *Bootstrap) DeployCertManagerCR() error {
 	return nil
 }
 
-// CleanNamespaceScopeResources will delete the v3 NamesapceScopes resources and namespace scope operator
+// CleanNamespaceScopeResources will delete the v3 NamespaceScopes resources and namespace scope operator
 // NamespaceScope resources include common-service, nss-managedby-odlm, nss-odlm-scope, and odlm-scope-managedby-odlm
 func (b *Bootstrap) CleanNamespaceScopeResources() error {
 

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -70,16 +70,22 @@ spec:
     channel: v4.0
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-mongodb-operator-v4.1
     namespace: "{{ .CPFSNs }}"
     channel: v4.1
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-mongodb-operator-v4.2
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	IMOpReg = `
@@ -102,84 +108,112 @@ spec:
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.1
     namespace: "{{ .CPFSNs }}"
     channel: v4.1
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.2
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.3
     namespace: "{{ .CPFSNs }}"
     channel: v4.3
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.4
     namespace: "{{ .CPFSNs }}"
     channel: v4.4
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.5
     namespace: "{{ .CPFSNs }}"
     channel: v4.5
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.6
     namespace: "{{ .CPFSNs }}"
     channel: v4.6
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.7
     namespace: "{{ .CPFSNs }}"
     channel: v4.7
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.8
     namespace: "{{ .CPFSNs }}"
     channel: v4.8
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.9
     namespace: "{{ .CPFSNs }}"
     channel: v4.9
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.10
     namespace: "{{ .CPFSNs }}"
     channel: v4.10
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.11
     namespace: "{{ .CPFSNs }}"
     channel: v4.11
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.12
     namespace: "{{ .CPFSNs }}"
     channel: v4.12
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.13
     namespace: "{{ .CPFSNs }}"
     channel: v4.13
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	IdpConfigUIOpReg = `
@@ -202,66 +236,88 @@ spec:
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.1
     namespace: "{{ .CPFSNs }}"
     channel: v4.1
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.2
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.3
     namespace: "{{ .CPFSNs }}"
     channel: v4.3
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.4
     namespace: "{{ .CPFSNs }}"
     channel: v4.4
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.5
     namespace: "{{ .CPFSNs }}"
     channel: v4.5
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.6
     namespace: "{{ .CPFSNs }}"
     channel: v4.6
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.7
     namespace: "{{ .CPFSNs }}"
     channel: v4.7
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.8
     namespace: "{{ .CPFSNs }}"
     channel: v4.8
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.9
     namespace: "{{ .CPFSNs }}"
     channel: v4.9
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.10
     namespace: "{{ .CPFSNs }}"
     channel: v4.10
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	PlatformUIOpReg = `
@@ -284,48 +340,64 @@ spec:
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v4.1
     namespace: "{{ .CPFSNs }}"
     channel: v4.1
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v4.2
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v4.3
     namespace: "{{ .CPFSNs }}"
     channel: v4.3
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v4.4
     namespace: "{{ .CPFSNs }}"
     channel: v4.4
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v6.0
     namespace: "{{ .CPFSNs }}"
     channel: v6.0
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v6.1
     namespace: "{{ .CPFSNs }}"
     channel: v6.1
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v6.2
     namespace: "{{ .CPFSNs }}"
     channel: v6.2
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -351,6 +423,8 @@ spec:
     namespace: "{{ .ServicesNs }}"
     packageName: rhbk-operator
     scope: public
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable-v26
     installPlanApproval: {{ .ApprovalMode }}
     name: keycloak-operator-v26
@@ -358,6 +432,8 @@ spec:
     packageName: rhbk-operator
     scope: public
     configName: keycloak-operator
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable
     fallbackChannels:
       - stable-v1.25
@@ -368,6 +444,8 @@ spec:
     packageName: cloud-native-postgresql
     scope: public
     operatorConfig: cloud-native-postgresql-operator-config
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -396,6 +474,8 @@ spec:
     packageName: cloud-native-postgresql
     scope: public
     operatorConfig: cloud-native-postgresql-operator-config
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -2194,12 +2274,16 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-mongodb-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-cert-manager-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2207,6 +2291,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-iam-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2214,6 +2300,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-healthcheck-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2221,6 +2309,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-commonui-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2228,6 +2318,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-management-ingress-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2235,6 +2327,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-ingress-nginx-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2242,6 +2336,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-auditlogging-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2249,6 +2345,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platform-api-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2256,6 +2354,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.23
     name: ibm-monitoring-grafana-operator
     namespace: "{{ .ServicesNs }}"
@@ -2263,6 +2363,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.23
     name: ibm-zen-operator
     namespace: "{{ .ServicesNs }}"
@@ -2270,6 +2372,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.23
     name: ibm-zen-cpp-operator
     namespace: "{{ .CPFSNs }}"
@@ -2277,6 +2381,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	CSV4OpReg = `
@@ -2299,73 +2405,88 @@ spec:
     packageName: ibm-usage-metering-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-user-management-operator
     namespace: "{{ .CPFSNs }}"
     channel: v1.0
     packageName: ibm-user-management-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-websphere-liberty
     namespace: "{{ .CPFSNs }}"
     channel: v1.3
     packageName: ibm-websphere-liberty
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-redis-cp-operator
     namespace: "{{ .CPFSNs }}"
     channel: v1.2
     packageName: ibm-redis-cp
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator
     namespace: "{{ .CPFSNs }}"
     channel: v4.13
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-mongodb-operator
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     installMode: no-op
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3
     name: ibm-events-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-events-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v5.1
     name: ibm-events-operator-v5.1
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-events-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v5.2
     name: ibm-events-operator-v5.2
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-events-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
     channel: v6.2
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator
     namespace: "{{ .CPFSNs }}"
     channel: v4.10
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-  - channel: stable
-    name: cloud-native-postgresql
-    namespace: "{{ .CPFSNs }}"
-    packageName: cloud-native-postgresql
-    scope: public
-    installPlanApproval: {{ .ApprovalMode }}
-    operatorConfig: cloud-native-postgresql-operator-config
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable
     name: internal-use-only-edb
     namespace: "{{ .CPFSNs }}"
@@ -2373,6 +2494,17 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
+  - channel: stable
+    name: cloud-native-postgresql
+    namespace: "{{ .CPFSNs }}"
+    packageName: cloud-native-postgresql
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    operatorConfig: cloud-native-postgresql-operator-config
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable-v1.22
     fallbackChannels:
       - stable
@@ -2383,6 +2515,8 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
     configName: cloud-native-postgresql
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable-v1.25
     fallbackChannels:
       - stable-v1.22
@@ -2394,60 +2528,80 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
     configName: cloud-native-postgresql
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: alpha
     name: ibm-user-data-services-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-user-data-services-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3
     name: ibm-bts-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-bts-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.34
     name: ibm-bts-operator-v3.34
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-bts-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.35
     name: ibm-bts-operator-v3.35
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-bts-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.3
     name: ibm-automation-flink
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-automation-flink
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.3
     name: ibm-automation-elastic
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-automation-elastic
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.1
     name: ibm-elasticsearch-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-elasticsearch-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode}}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v2.0
     name: ibm-opencontent-flink
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-opencontent-flink
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.1
     name: ibm-opensearch-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-opensearch-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode}}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -2473,12 +2627,16 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-mongodb-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-cert-manager-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2486,6 +2644,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-iam-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2493,6 +2653,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-management-ingress-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2500,6 +2662,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-ingress-nginx-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2507,6 +2671,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.23
     name: ibm-zen-operator
     namespace: "{{ .ServicesNs }}"
@@ -2514,6 +2680,8 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   `
 )
 
@@ -2654,8 +2822,8 @@ spec:
   channel: v4.5
   installPlanApproval: {{ .ApprovalMode }}
   name: ibm-odlm
-  source: {{ .CatalogSourceName }}
-  sourceNamespace: "{{ .CatalogSourceNs }}"
+  source: {{ .ODLMCatalogSourceName }}
+  sourceNamespace: "{{ .ODLMCatalogSourceNs }}"
 `
 
 // ConcatenateRegistries concatenate the two YAML strings and return the new YAML string

--- a/internal/controller/webhooks/commonservice/validatingwebhook.go
+++ b/internal/controller/webhooks/commonservice/validatingwebhook.go
@@ -106,6 +106,11 @@ func (r *Defaulter) Handle(ctx context.Context, req admission.Request) admission
 			return admission.Denied(fmt.Sprintf("Services Namespace: %v should be one of WATCH_NAMESPACE", serviceNs))
 		}
 
+		// deny if only spec.catalogName or spec.catalogNamespace is set, should be set together
+		if (cs.Spec.CatalogName != "" && cs.Spec.CatalogNamespace == "") || (cs.Spec.CatalogName == "" && cs.Spec.CatalogNamespace != "") {
+			return admission.Denied("Both User-Definded CatalogSource Name and Namespace must be set together in CommonService CR")
+		}
+
 	} else {
 		klog.Infof("Start to validate non-master CommonService CR")
 		// check OperatorNamespace
@@ -122,19 +127,20 @@ func (r *Defaulter) Handle(ctx context.Context, req admission.Request) admission
 			return admission.Denied(fmt.Sprintf("Services Namespace: %v is not allowed to be configured in namespace %v", servicesNamespace, req.AdmissionRequest.Namespace))
 		}
 
-		// check CatalogName
-		catalogName := cs.Spec.CatalogName
-		deniedCatalog := r.CheckConfig(string(catalogName), catalogSourceName)
-		if deniedCatalog {
-			return admission.Denied(fmt.Sprintf("CatalogSource Name: %v is not allowed to be configured in namespace %v", catalogName, req.AdmissionRequest.Namespace))
-		}
+		// // check CatalogName
+		// catalogName := cs.Spec.CatalogName
+		// deniedCatalog := r.CheckConfig(string(catalogName), catalogSourceName)
+		// if deniedCatalog {
+		// 	return admission.Denied(fmt.Sprintf("CatalogSource Name: %v is not allowed to be configured in namespace %v", catalogName, req.AdmissionRequest.Namespace))
+		// }
 
-		// check CatalogNamespace
-		catalogNamespace := cs.Spec.CatalogNamespace
-		deniedCatalogNs := r.CheckConfig(string(catalogNamespace), catalogSourceNs)
-		if deniedCatalogNs {
-			return admission.Denied(fmt.Sprintf("CatalogSource Namespace: %v is not allowed to be configured in namespace %v", catalogNamespace, req.AdmissionRequest.Namespace))
-		}
+		// // check CatalogNamespace
+		// catalogNamespace := cs.Spec.CatalogNamespace
+		// deniedCatalogNs := r.CheckConfig(string(catalogNamespace), catalogSourceNs)
+		// if deniedCatalogNs {
+		// 	return admission.Denied(fmt.Sprintf("CatalogSource Namespace: %v is not allowed to be configured in namespace %v", catalogNamespace, req.AdmissionRequest.Namespace))
+		// }
+
 	}
 
 	// check HugePageSetting


### PR DESCRIPTION
**What this PR does / why we need it**:
1.  User-Configurable Catalog Source for Services:
    *   Adopters can now specify their preferred catalog source (`spec.catalogName` and `spec.catalogNamespace`) directly in the `CommonService` CR.
    *   These values, when provided, will be propagated to `status.configStatus` in CS CR and subsequently used into `OperandRegistry`
    *   Operators and services deployed will then be sourced from this user-defined catalog
    *   If they are not provided in the CS CR, ODLM will select appropriate catalog for the operators
    *   The user-defined catalog are supported to be added, removed and changed to another one in CS CR
    *   Webhook will deny the request if only catalogsource name or catalogsource namespace is set in the CR, they should be set together

2.  Dedicated ODLM Catalog Source Aligned with CS Operator:
    *   The ODLM will now consistently use a dedicated catalog source as CS operator has

Cherry-pick: https://github.com/IBM/ibm-common-service-operator/pull/2543

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65905

**How to test**:
1. Test image: quay.io/yuchen_shen/cs_operator:catalog
2. Install a CSFS, and config catalog and its namespace under `spec.catalogName` and `spec.catalogNamespace` in CS CR, delete ODLM, restart CS pod
3. After ODLM coming up again, its catalog should be the same as CS operator and, the given catalog will be shown in OperandRegistry each entry