### PR TITLE
Singleton recipe refresh

### DIFF
--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -366,7 +366,7 @@ function label_subscription() {
         ${OC} label subscriptions.operators.coreos.com $lis_pm foundationservices.cloudpak.ibm.com=singleton-subscription -n $LICENSING_NAMESPACE --overwrite=true 2>/dev/null
     fi
     if [[ $ENABLE_LSR -eq 1 ]]; then
-        ${OC} label subscriptions.operators.coreos.com $lsr_pm foundationservices.cloudpak.ibm.com=lsr -n $LSR_NAMESPACE --overwrite=true 2>/dev/null
+        ${OC} label subscriptions.operators.coreos.com $lsr_pm foundationservices.cloudpak.ibm.com=singleton-subscription -n $LSR_NAMESPACE --overwrite=true 2>/dev/null
     fi
     echo ""
 }

--- a/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
+++ b/velero/schedule/license_service_reporter/lsr-br-scripts-cm.yaml
@@ -29,10 +29,14 @@ data:
 
     function main {
         if [[ $MODE == "backup" ]]; then
+            save_log "logs" "backup_log"
+            trap cleanup_log EXIT
             info "Mode set to backup, beginning backup process."
             backup
             success "Backup completed successfully."
         elif [[ $MODE == "restore" ]]; then
+            save_log "logs" "restore_log"
+            trap cleanup_log EXIT
             info "Mode is set to restore, beginning restore process."
             restore
             success "Restore completed successfully."
@@ -54,11 +58,59 @@ data:
 
     function restore {
         CNPG_PRIMARY_POD=`oc get pods -n $LSR_NAMESPACE | grep ibm-license-service-reporter-instance | awk '{print $1}'`
+        wait_for_ls_reporter $CNPG_PRIMARY_POD
         oc exec $CNPG_PRIMARY_POD -n $LSR_NAMESPACE -- mkdir -p /run/lsr_backup
         oc cp $BACKUP_DIR/database/lsr_db_backup.dump $LSR_NAMESPACE/$CNPG_PRIMARY_POD:/run/lsr_backup/lsr_db_backup.dump
         oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- psql -U postgres -c "\list" -c "\dn" -c "\du"
         oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- pg_restore -U postgres --dbname postgres --format=c --clean -v /run/lsr_backup/lsr_db_backup.dump
         oc -n $LSR_NAMESPACE exec -t $CNPG_PRIMARY_POD -c database -- psql -U postgres -c "\list" -c "\dn" -c "\du"
+    }
+
+    function wait_for_ls_reporter() {
+        CNPG_PRIMARY_POD=$1
+        ready=$(oc get pod/$CNPG_PRIMARY_POD -n $LSR_NAMESPACE -o jsonpath="{.status.conditions[?(@.type=='ContainersReady')].status}")
+        if [[ $ready != "True" ]]; then
+            retry_count=60
+            while [[ $ready != "True" ]] && [[ retry_count > 0 ]]
+            do
+                info "Waiting for License Service Reporter instance to come ready. ConatinersReady status for pod $CNPG_PRIMARY_POD is: $ready"
+                sleep 15
+                ready=$(oc get pod/$CNPG_PRIMARY_POD -n $LSR_NAMESPACE -o jsonpath="{.status.conditions[?(@.type=='ContainersReady')].status}")
+                retry_count=$((retry_count-1))
+            done
+        else
+            info "Pod $CNPG_PRIMARY_POD is now ready, proceeding with restore..."
+        fi
+    }
+
+    function save_log(){
+        local LOG_DIR="$BACKUP_DIR/$1"
+        LOG_FILE="$LOG_DIR/$2_$(date +'%Y%m%d%H%M%S').log"
+
+        if [[ ! -d $LOG_DIR ]]; then
+            mkdir -p "$LOG_DIR"
+        fi
+
+        # Create a named pipe
+        PIPE=$(mktemp -u)
+        mkfifo "$PIPE"
+
+        # Tee the output to both the log file and the terminal
+        tee "$LOG_FILE" < "$PIPE" &
+
+        # Redirect stdout and stderr to the named pipe
+        exec > "$PIPE" 2>&1
+
+        # Remove the named pipe
+        rm "$PIPE"
+    }
+
+    function cleanup_log() {
+        # Check if the log file already exists
+        if [[ -e $LOG_FILE ]]; then
+            # Remove ANSI escape sequences from log file
+            sed -E 's/\x1B\[[0-9;]+[A-Za-z]//g' "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+        fi
     }
 
     function msg() {

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-cert-manager-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-cert-manager-recipe.yaml
@@ -2,10 +2,10 @@ apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
 kind: Recipe
 metadata:
   name: child-cert-manager-recipe
-  namespace: ibm-fusion
+  namespace: <fusion ns>
   labels:
-    dp.isf.ibm.com/parent-recipe: parent-cpfs-singleton-recipe
-    dp.isf.ibm.com/parent-recipe-namespace: ibm-fusion
+    dp.isf.ibm.com/parent-recipe: cpfs-singleton-parent-recipe
+    dp.isf.ibm.com/parent-recipe-namespace: <fusion ns>
 spec:
   appType: singleton
   groups:
@@ -61,7 +61,6 @@ spec:
     - failOn: essential-error
       name: singleton-resources-restore
       sequence:
-        - group: cert-manager-crds
-        - group: cert-manager-workload-resources
+        - group: cert-manager-resources
         - hook: cert-manager-operator-check/podReady
         - hook: cert-manager-webhook-check/podReady

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-cert-manager-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-cert-manager-recipe.yaml
@@ -1,0 +1,67 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  name: child-cert-manager-recipe
+  namespace: ibm-fusion
+  labels:
+    dp.isf.ibm.com/parent-recipe: parent-cpfs-singleton-recipe
+    dp.isf.ibm.com/parent-recipe-namespace: ibm-fusion
+spec:
+  appType: singleton
+  groups:
+    - includeClusterResources: true
+      includedResourceTypes:
+        - certmanagerconfigs.operator.ibm.com
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=cert-manager
+      name: cert-manager-resources
+      type: resource
+    - backupRef: cert-manager-resources
+      includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+      name: cert-manager-crds
+      type: resource
+    - backupRef: cert-manager-resources
+      includeClusterResources: true
+      includedResourceTypes:
+        - certmanagerconfigs.operator.ibm.com
+      name: cert-manager-workload-resources
+      type: resource
+  hooks:
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: app.kubernetes.io/name=cert-manager
+      name: cert-manager-operator-check
+      namespace: <cert manager namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: cert-manager-webhook-check
+      nameSelector: cert-manager-webhook
+      namespace: <cert manager namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+  workflows:
+    - failOn: essential-error
+      name: singleton-resources-backup
+      sequence:
+        - group: cert-manager-resources
+    - failOn: essential-error
+      name: singleton-resources-restore
+      sequence:
+        - group: cert-manager-crds
+        - group: cert-manager-workload-resources
+        - hook: cert-manager-operator-check/podReady
+        - hook: cert-manager-webhook-check/podReady

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-licensing-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-licensing-recipe.yaml
@@ -2,10 +2,10 @@ apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
 kind: Recipe
 metadata:
   name: child-licensing-recipe
-  namespace: ibm-fusion
+  namespace: <fusion ns>
   labels:
-    dp.isf.ibm.com/parent-recipe: parent-cpfs-singleton-recipe
-    dp.isf.ibm.com/parent-recipe-namespace: ibm-fusion
+    dp.isf.ibm.com/parent-recipe: cpfs-singleton-parent-recipe
+    dp.isf.ibm.com/parent-recipe-namespace: <fusion ns> 
 spec:
   appType: singleton
   groups:

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-licensing-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-licensing-recipe.yaml
@@ -1,0 +1,24 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  name: child-licensing-recipe
+  namespace: ibm-fusion
+  labels:
+    dp.isf.ibm.com/parent-recipe: parent-cpfs-singleton-recipe
+    dp.isf.ibm.com/parent-recipe-namespace: ibm-fusion
+spec:
+  appType: singleton
+  groups:
+    - labelSelector: foundationservices.cloudpak.ibm.com=licensing
+      name: licensing-resources
+      type: resource
+  workflows:
+    - failOn: any-error
+      name: singleton-resources-backup
+      sequence:
+        - group: licensing-resources
+    - failOn: any-error
+      name: singleton-resources-restore
+      sequence:
+        - group: licensing-resources
+    

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-ls-reporter-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-ls-reporter-recipe.yaml
@@ -2,10 +2,10 @@ apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
 kind: Recipe
 metadata:
   name: child-license-reporter-recipe
-  namespace: ibm-fusion
+  namespace: <fusion ns>
   labels:
-    dp.isf.ibm.com/parent-recipe: parent-cpfs-singleton-recipe
-    dp.isf.ibm.com/parent-recipe-namespace: ibm-fusion
+    dp.isf.ibm.com/parent-recipe: cpfs-singleton-parent-recipe
+    dp.isf.ibm.com/parent-recipe-namespace: <fusion ns>
 spec:
   appType: common-service
   groups:
@@ -26,28 +26,20 @@ spec:
       type: resource
     - includeClusterResources: true
       includedResourceTypes:
-        - deployments
         - serviceaccount
         - role
         - rolebinding
         - configmaps
-      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
-      name: license-service-reporter-resources
-      type: resource
-    - backupRef: license-service-reporter-resources
-      includeClusterResources: true
-      includedResourceTypes:
-        - serviceaccount
-        - role
-        - rolebinding
-        - configmaps
+        - clusterrole
+        - clusterrolebinding
       name: lsr-pre-deploy
       type: resource
-    - backupRef: license-service-reporter-resources
-      includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+    - includeClusterResources: true
       includedResourceTypes:
         - deployments
       name: lsr-deployment
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
       type: resource
     - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
       name: lsr-volume
@@ -58,8 +50,20 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      name: license-service-reporter-check
+      name: lsr-operator-check
       labelSelector: app.kubernetes.io/name=ibm-license-service-reporter
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: lsr-instance-check
+      labelSelector: app.kubernetes.io/name=ibm-license-service-reporter-instance
       namespace: <lsr namespace>
       onError: fail
       selectResource: pod
@@ -99,16 +103,18 @@ spec:
       name: singleton-resources-backup
       sequence:
         - hook: lsr-data/backup
-        - group: lsr-volume
-        - group: license-service-reporter-parent
-        - group: license-service-reporter-resources
-    - failOn: any-error
-      name: singleton-resources-restore
-      sequence:
-        - hook: license-service-reporter-check/podReady
         - group: license-service-reporter-parent
         - group: lsr-pre-deploy
         - group: lsr-volume
         - group: lsr-deployment
+    - failOn: any-error
+      name: singleton-resources-restore
+      sequence:
+        - group: license-service-reporter-parent
+        - hook: lsr-operator-check/podReady
+        - group: lsr-pre-deploy
+        - group: lsr-volume
+        - group: lsr-deployment
         - hook: lsr-deployment/podReady
+        - hook: lsr-instance-check/podReady
         - hook: lsr-data/restore

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-ls-reporter-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/child-ls-reporter-recipe.yaml
@@ -1,0 +1,114 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  name: child-license-reporter-recipe
+  namespace: ibm-fusion
+  labels:
+    dp.isf.ibm.com/parent-recipe: parent-cpfs-singleton-recipe
+    dp.isf.ibm.com/parent-recipe-namespace: ibm-fusion
+spec:
+  appType: common-service
+  groups:
+    - includeClusterResources: true
+      includedResourceTypes:
+        - customresourcedefinitions.apiextensions.k8s.io
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr
+      name: license-service-reporter-parent
+      type: resource
+    - backupRef: license-service-reporter-parent
+      includeClusterResources: true
+      includedResourceTypes:
+        - secrets
+        - ibmlicenseservicereporters.operator.ibm.com
+      name: license-service-reporter-instances
+      type: resource
+    - includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: license-service-reporter-resources
+      type: resource
+    - backupRef: license-service-reporter-resources
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: lsr-pre-deploy
+      type: resource
+    - backupRef: license-service-reporter-resources
+      includeClusterResources: true
+      includedResourceTypes:
+        - deployments
+      name: lsr-deployment
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-volume
+      type: volume
+  hooks:
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      name: license-service-reporter-check
+      labelSelector: app.kubernetes.io/name=ibm-license-service-reporter
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - chks:
+        - condition: '{$.spec.replicas} == {$.status.readyReplicas}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-deployment
+      namespace: <lsr namespace>
+      onError: fail
+      selectResource: deployment
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=lsr-data
+      name: lsr-data
+      namespace: <lsr namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /lsr/lsr-backup/database; /lsr/br_lsr.sh <lsr namespace> backup"]
+          container: lsr-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/lsr/br_lsr.sh <lsr namespace> restore"]
+          container: lsr-backup-job
+          name: restore
+          timeout: 2000
+      selectResource: pod
+      type: exec
+  workflows:
+    - failOn: any-error
+      name: singleton-resources-backup
+      sequence:
+        - hook: lsr-data/backup
+        - group: lsr-volume
+        - group: license-service-reporter-parent
+        - group: license-service-reporter-resources
+    - failOn: any-error
+      name: singleton-resources-restore
+      sequence:
+        - hook: license-service-reporter-check/podReady
+        - group: license-service-reporter-parent
+        - group: lsr-pre-deploy
+        - group: lsr-volume
+        - group: lsr-deployment
+        - hook: lsr-deployment/podReady
+        - hook: lsr-data/restore

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/parent-singleton-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/parent-singleton-recipe.yaml
@@ -1,8 +1,8 @@
 apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
 kind: Recipe
 metadata:
-  name: parent-cpfs-singleton-recipe
-  namespace: ibm-fusion
+  name: cpfs-singleton-parent-recipe
+  namespace: <fusion ns>
 spec:
   appType: singleton
   groups:

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/parent-singleton-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/parent-singleton-recipe.yaml
@@ -1,0 +1,48 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  name: parent-cpfs-singleton-recipe
+  namespace: ibm-fusion
+spec:
+  appType: singleton
+  groups:
+    - includedResourceTypes:
+        - catalogsources.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=catalog
+      name: catalogsource
+      type: resource
+    - includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=namespace
+      name: namespace
+      type: resource
+    - includedResourceTypes:
+        - operatorgroups.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=operatorgroup
+      name: operatorgroup
+      type: resource
+    - includedResourceTypes:
+        - subscriptions.operators.coreos.com
+      labelSelector: foundationservices.cloudpak.ibm.com=singleton-subscription
+      name: subscription
+      type: resource
+  workflows:
+    - name: singleton-resources-backup
+      priority: 0
+      sequence: []
+    - name: singleton-resources-restore
+      priority: 0
+      sequence: []
+    - name: backup
+      sequence:
+        - group: namespace
+        - group: operatorgroup
+        - group: catalogsource
+        - group: subscription
+        - workflow: singleton-resources-backup
+    - name: restore
+      sequence: 
+        - group: namespace
+        - group: operatorgroup
+        - group: catalogsource
+        - group: subscription
+        - workflow: singleton-resources-restore

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/peripheral-resources.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/peripheral-resources.yaml
@@ -1,0 +1,60 @@
+apiVersion: application.isf.ibm.com/v1alpha1
+kind: Application
+metadata:
+  name: cs-singleton
+  namespace: <fusion ns>
+spec:
+  enableDR: false
+  includedNamespaces:
+    #default namespaces for licensing, cert manager, and reporter operators
+    - ibm-cert-manager
+    - ibm-licensing
+    - ibm-ls-reporter
+
+---
+
+apiVersion: data-protection.isf.ibm.com/v1alpha1
+kind: BackupPolicy
+metadata:
+  name: cs-singleton-backup-policy
+  namespace: <fusion ns>
+spec:
+  backupStorageLocation: cutie
+  provider: isf-backup-restore
+  retention:
+    number: 5
+    unit: days
+  schedule:
+    cron: '00 0  * * * '
+    timezone: America/New_York
+
+---
+
+apiVersion: data-protection.isf.ibm.com/v1alpha1
+kind: PolicyAssignment
+metadata:
+  name: cs-policy-assignment
+  namespace: <fusion ns>
+spec:
+  application: cs-singleton
+  backupPolicy: cs-singleton-backup-policy
+  recipe:
+    apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+    name: cpfs-singleton-parent-recipe
+    namespace: <fusion ns>
+  runNow: false
+
+---
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: <location name>-secret-0
+  namespace: <fusion ns>
+  labels:
+    dp.isf.ibm.com/ownedBy: fbsl
+    dp.isf.ibm.com/provider-name: isf-backup-restore
+data:
+  access-key-id: <base 64 encoded access key id>
+  secret-access-key: <base 64 encoded secret access key>
+type: Opaque

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/peripheral-resources.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/peripheral-resources.yaml
@@ -22,7 +22,7 @@ metadata:
   name: cs-singleton-backup-policy
   namespace: <fusion ns>
 spec:
-  backupStorageLocation: cutie
+  backupStorageLocation: <location name>
   provider: isf-backup-restore
   retention:
     number: 5
@@ -61,3 +61,23 @@ data:
   access-key-id: <base 64 encoded access key id>
   secret-access-key: <base 64 encoded secret access key>
 type: Opaque
+
+---
+
+apiVersion: data-protection.isf.ibm.com/v1alpha1
+kind: BackupStorageLocation
+metadata:
+  name: <location name>
+  namespace: <fusion ns>
+  finalizers:
+    - backupstoragelocation
+  labels:
+    dp.isf.ibm.com/backupstoragelocation-type: ibm
+    dp.isf.ibm.com/provider-name: isf-backup-restore
+spec:
+  credentialName: <location name>-secret-0
+  params:
+    bucket: <bucket name>
+    endpoint: <s3 url>
+  provider: isf-backup-restore
+  type: ibm

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/peripheral-resources.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/singletons/peripheral-resources.yaml
@@ -7,9 +7,12 @@ spec:
   enableDR: false
   includedNamespaces:
     #default namespaces for licensing, cert manager, and reporter operators
-    - ibm-cert-manager
-    - ibm-licensing
-    - ibm-ls-reporter
+    #- ibm-cert-manager
+    #- ibm-licensing
+    #- ibm-ls-reporter
+    - <cert manager namespace>
+    - <licensing namespace>
+    - <lsr namespace>
 
 ---
 


### PR DESCRIPTION
**What this PR does / why we need it**: With the recently released fusion feature supporting dynamic recipes (aka parent/child), we can create a modular recipe that covers all combinations of singleton components together. This allows us to separate the singletons from installed instances of bedrock to run independent BR operations against either. It also simplifies both the singleton and the core recipes since there are fewer resources to worry about in either set of recipes. 

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64751

**Special notes for your reviewer**:

1. How the test is done? 
Same testing process as https://github.com/IBM/ibm-common-service-operator/pull/2560 except we need to create new peripheral resources specific to the singleton namespaces. There is a peripheral-resources.yaml file that contains the skeleton for these resources. The only resources that are not necessary to recreate are the backupstoragelocation and its secret as the ones created by the fusion-setup.sh script can be reused

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
3. The PR will be automatically created in the target branch after merging this PR
4. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action