### PR TITLE
update resource version in commonservice.yaml during setup

### DIFF
--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -757,6 +757,14 @@ EOF
             fi
         fi
 
+        # Get the resource version of the CommonService CR from the cluster
+        # and update the resource version in the file
+        local resource_version=$(${OC} get commonservice common-service -n ${OPERATOR_NS} -o jsonpath='{.metadata.resourceVersion}' --ignore-not-found)
+        if [[ -n "${resource_version}" ]]; then
+            debug1 "Updating resourceVersion in commonservice.yaml to ${resource_version}\n"
+            ${YQ} -i eval '.metadata.resourceVersion = "'${resource_version}'"' ${PREVIEW_DIR}/commonservice.yaml    
+        fi
+
         cat "${PREVIEW_DIR}/commonservice.yaml" | ${OC_CMD} apply -f -
 
         # Check if the patch was successful


### PR DESCRIPTION
**What this PR does / why we need it**:
If someone was using `oc apply` to manually update the CommonService CR without removing `.metadata.resourceVersion`, this leads to the issue that `.metadata.resourceVersion` was included in annotation `kubectl.kubernetes.io/last-applied-configuration` as well.

And next time when the script is trying to update the CommonService CR, script is following the best practice, to remove `.metadata.resourceVersion` from CommonService CR. However, due to the `.metadata.resourceVersion` in annotation `kubectl.kubernetes.io/last-applied-configuration`, such action is rejected.

The change is to always fetch the latest `.metadata.resourceVersion` from the existing CR in the cluster, and attach it to the CR in the local file before `oc apply`

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66949

**Test**:
This is the log from `setup_tenant.sh` script that the latest `.metadata.resourceVersion` from the existing CR in the cluster will be attached to the CR in the local file.
```
[DEBUG] ibm-common-service-operator pod is ready

[DEBUG] Updating resourceVersion in commonservice.yaml to 713000428

commonservice.operator.ibm.com/common-service configured
[✔] Successfully patched CommonService CR in cs-operators
```