### PR TITLE
Exclude one type of Role and Rolebinding for more robust restores

### DIFF
--- a/velero/restore/restore-cs-db.yaml
+++ b/velero/restore/restore-cs-db.yaml
@@ -12,6 +12,7 @@ spec:
   - backups.velero.io
   - restores.velero.io
   - resticrepositories.velero.io
+  - authorization.openshift.io
   hooks: {}
   includedNamespaces:
   - '*'

--- a/velero/restore/restore-cs-db.yaml
+++ b/velero/restore/restore-cs-db.yaml
@@ -12,7 +12,8 @@ spec:
   - backups.velero.io
   - restores.velero.io
   - resticrepositories.velero.io
-  - authorization.openshift.io
+  - roles.authorization.openshift.io
+  - rolebindings.authorization.openshift.io
   hooks: {}
   includedNamespaces:
   - '*'

--- a/velero/restore/restore-zen5-data.yaml
+++ b/velero/restore/restore-zen5-data.yaml
@@ -12,6 +12,7 @@ spec:
   - backups.velero.io
   - restores.velero.io
   - resticrepositories.velero.io
+  - authorization.openshift.io
   hooks: {}
   includedNamespaces:
   - '*'

--- a/velero/restore/restore-zen5-data.yaml
+++ b/velero/restore/restore-zen5-data.yaml
@@ -12,7 +12,8 @@ spec:
   - backups.velero.io
   - restores.velero.io
   - resticrepositories.velero.io
-  - authorization.openshift.io
+  - roles.authorization.openshift.io
+  - rolebindings.authorization.openshift.io
   hooks: {}
   includedNamespaces:
   - '*'


### PR DESCRIPTION
**What this PR does / why we need it**: The problem description can be found here https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66735#issuecomment-115699689 but to put it more clearly, velero essentially sees both the cs db and zen backup roles and rolebindings as having two versions each. To visualize this, here is the output of restore resources for cs db data:
```
Resource List:
  apps/v1/Deployment:
    - cp25pods/cs-db-backup(created)
  apps/v1/ReplicaSet:
    - cp25pods/cs-db-backup-698c454486(created)
  authorization.openshift.io/v1/Role:
    - cp25pods/cs-db-backup-role(failed)
  authorization.openshift.io/v1/RoleBinding:
    - cp25pods/cs-db-backup-rolebinding(failed)
  rbac.authorization.k8s.io/v1/Role:
    - cp25pods/cs-db-backup-role(created)
  rbac.authorization.k8s.io/v1/RoleBinding:
    - cp25pods/cs-db-backup-rolebinding(created)
  v1/ConfigMap:
    - cp25pods/cs-db-br-configmap(created)
  v1/PersistentVolume:
    - pvc-b44bb145-5d08-4020-ae89-c78be5b2ebf7(skipped)
  v1/PersistentVolumeClaim:
    - cp25pods/cs-db-backup-pvc(created)
  v1/Pod:
    - cp25pods/cs-db-backup-698c454486-kv5wc(created)
  v1/ServiceAccount:
    - cp25pods/cs-db-backup-sa(created)
```

We can see that there are two different resource type entries for both roles and rolebindings and one set is listed as failed to restore. This failure is harmless in that ultimately the role is present and the velero post restore hook can run successfully. However, this leads to a PartiallyFailed status from the velero output which can disrupt automation and confuse users. The solution to this problem is to mark the `rolebindings.authorization.openshift.io` and `roles.authorization.openshift.io` resources as excluded so velero never attempts to restore them and we never run into the collision problem. After marking these resources as excluded, the resource list looks like:

```
Resource List:
  apps/v1/Deployment:
    - cs-serv/cs-db-backup(created)
  apps/v1/ReplicaSet:
    - cs-serv/cs-db-backup-5c85698c84(created)
  rbac.authorization.k8s.io/v1/Role:
    - cs-serv/cs-db-backup-role(created)
  rbac.authorization.k8s.io/v1/RoleBinding:
    - cs-serv/cs-db-backup-rolebinding(created)
  v1/ConfigMap:
    - cs-serv/cs-db-br-configmap(created)
  v1/PersistentVolume:
    - pvc-86ae66f3-8c55-43aa-9e59-9dea749fa8ff(skipped)
  v1/PersistentVolumeClaim:
    - cs-serv/cs-db-backup-pvc(created)
  v1/Pod:
    - cs-serv/cs-db-backup-5c85698c84-vks7w(created)
  v1/ServiceAccount:
    - cs-serv/cs-db-backup-sa(created)
```

Where we can clearly see that there is no longer an attempt to restore duplicate resources. Excluding the resource in the restore does not prevent it from being restored though so we retain flexibility to either switch which resource type should be excluded or not exclude at all should that be necessary.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66735

**Special notes for your reviewer**:

1. How the test is done?

Usual OADP based BR process but use the restore resources from this pr. Verify restore completes and that there is only one set of Roles/Rolebindings included in the restore

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
3. The PR will be automatically created in the target branch after merging this PR
4. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action