### PR TITLE
update automation to include um resources

### DIFF
--- a/velero/backup/cert-manager/label-cert-manager.sh
+++ b/velero/backup/cert-manager/label-cert-manager.sh
@@ -171,6 +171,13 @@ function label_all_resources(){
                 info "Secret platform-auth-idp-credentials not present in namespace $namespace. Skipping..."
             fi
 
+            um_namespace_list=$(oc get secret -n $namespace | grep user-mgmt-bootstrap | grep -v "bindinfo" |  awk '{print $1}' | tr "\n" " ")
+            if [[ $um_namespace_list != "" ]]; then
+                label_specified_secret $namespace user-mgmt-bootstrap
+            else
+                info "Secret user-mgmt-bootstrap not present in namespace $namespace. Skipping..."
+            fi
+
             #grab default scim credentials
             scim_secret_namespace_list=$(oc get secret -n $namespace | grep platform-auth-scim-credentials | grep -v "bindinfo" |  awk '{print $1}' | tr "\n" " ")
             if [[ $scim_secret_namespace_list != "" ]]; then
@@ -302,6 +309,16 @@ function label_all_resources(){
             done
         else
             info "Secret platform-auth-idp-credentials not present in namespace $auth_namespace. Skipping..."
+        fi
+
+        um_namespace_list=$(oc get secret -A | grep user-mgmt-bootstrap | grep -v "bindinfo" |  awk '{print $1}' | tr "\n" " ")
+        if [[ $um_namespace_list != "" ]]; then
+            for um_namespace in $um_namespace_list
+            do
+                label_specified_secret $um_namespace user-mgmt-bootstrap
+            done
+        else
+            info "Secret user-mgmt-bootstrap not present in namespace $um_namespace. Skipping..."
         fi
 
         #grab default scim credentials

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -466,7 +466,7 @@ function label_nss(){
 function label_mcsp(){
 
     title "Start to label mcsp resources"
-    ${OC} label secret user-mgmt-bootstrap foundationservices.cloudpak.ibm.com=user-mgmt -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ${OC} label secret user-mgmt-bootstrap foundationservices.cloudpak.ibm.com=cert-manager -n $SERVICES_NS --overwrite=true 2>/dev/null
     echo ""
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Adds the user-mgmt-bootstrap secret to both the label-common-services.sh and label-cert-manager.sh scripts to ensure it is included in the cert-manager restore group (which contains all other secrets, certificates, and issuers for CPFS).

Because of it's interconnections with IM, I have found that it is not necessary to create specific backup or restore steps for the UM operator. It's only required resources that are new are its bootstrap secret and its catalogsources. The prior has been added to the automation via this PR and the latter is already included in the labeling automation. The only step left is to add the manual labeling steps to docs. Because of these shared steps, there will be no need to update the existing fusion recipes since they already execute the necessary steps, we have just added more resources into existing groups.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66267 & https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64819

**Special notes for your reviewer**:

1. How the test is done?
- Install CPFS user management operator
- create some test users
- execute the labeling scripts present in this PR
- setup OADP/Velero
- run velero backup
- restore to either a cleaned up same cluster or a fresh cluster
- verify user management still working as expected and data transferred properly

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
3. The PR will be automatically created in the target branch after merging this PR
4. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action