### PR TITLE
remove hardcoded namespace value for podReady check

### DIFF
--- a/velero/spectrum-fusion/recipes/dynamic-recipes/core/child-nss-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/core/child-nss-recipe.yaml
@@ -26,7 +26,7 @@ spec:
           timeout: 600
       name: nss-check
       nameSelector: ibm-namespace-scope-operator
-      namespace: cs-op
+      namespace: <child recipe namespace>
       onError: fail
       selectResource: deployment
       timeout: 600


### PR DESCRIPTION
**What this PR does / why we need it**: Accidentally left hardcoded namespace value in nss child recipe definition

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67294

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action