### PR TITLE
Remove sourceName and sourceNamespace fields from OperandRegistry

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -386,7 +386,10 @@ func (r *CommonService) SetPendingCondition(name string, ct ConditionType, cs co
 
 // SetReadyCondition creates a Condition to claim Ready.
 func (r *CommonService) SetReadyCondition(name string, ct ConditionType, cs corev1.ConditionStatus) {
-	r.UpdateConditionList(corev1.ConditionFalse)
+	r.RemoveCondition(ConditionTypePending)
+	r.RemoveCondition(ConditionTypeReconciling)
+	r.RemoveCondition(ConditionTypeBlocked)
+	r.RemoveCondition(ConditionTypeError)
 	c := newCondition(ConditionTypeReady, cs, ConditionReasonReady, ConditionMessageReady)
 	r.setCondition(*c)
 }

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -316,6 +316,16 @@ func (b *Bootstrap) CheckWarningCondition(instance *apiv3.CommonService) error {
 	// check if there is no storageClass declared under spec section and the default count is not 1
 	if instance.Spec.StorageClass == "" && defaultCount != 1 {
 		instance.SetWarningCondition(constant.MasterCR, apiv3.ConditionTypeWarning, corev1.ConditionTrue, apiv3.ConditionReasonWarning, apiv3.ConditionMessageMissSC)
+	} else {
+		// remove the warning condition if storageClass is configured
+		instance.RemoveCondition(apiv3.ConditionTypeWarning, apiv3.ConditionMessageMissSC)
+	}
+
+	if instance.Spec.CatalogName != "" || instance.Spec.CatalogNamespace != "" {
+		instance.SetWarningCondition(constant.MasterCR, apiv3.ConditionTypeWarning, corev1.ConditionTrue, apiv3.ConditionReasonWarning, apiv3.ConditionMessageCatalogNotSupported)
+	} else {
+		// remove the warning condition if catalogSource is not configured
+		instance.RemoveCondition(apiv3.ConditionTypeWarning, apiv3.ConditionMessageCatalogNotSupported)
 	}
 	return nil
 }

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -70,22 +70,16 @@ spec:
     channel: v4.0
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-mongodb-operator-v4.1
     namespace: "{{ .CPFSNs }}"
     channel: v4.1
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-mongodb-operator-v4.2
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	IMOpReg = `
@@ -108,48 +102,36 @@ spec:
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.1
     namespace: "{{ .CPFSNs }}"
     channel: v4.1
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.2
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.3
     namespace: "{{ .CPFSNs }}"
     channel: v4.3
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.4
     namespace: "{{ .CPFSNs }}"
     channel: v4.4
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-operator-v4.5
     namespace: "{{ .CPFSNs }}"
     channel: v4.5
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	IdpConfigUIOpReg = `
@@ -172,40 +154,30 @@ spec:
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.1
     namespace: "{{ .CPFSNs }}"
     channel: v4.1
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.2
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.3
     namespace: "{{ .CPFSNs }}"
     channel: v4.3
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator-v4.4
     namespace: "{{ .CPFSNs }}"
     channel: v4.4
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	PlatformUIOpReg = `
@@ -228,40 +200,30 @@ spec:
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v4.1
     namespace: "{{ .CPFSNs }}"
     channel: v4.1
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v4.2
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v4.3
     namespace: "{{ .CPFSNs }}"
     channel: v4.3
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator-v4.4
     namespace: "{{ .CPFSNs }}"
     channel: v4.4
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -287,8 +249,6 @@ spec:
     namespace: "{{ .ServicesNs }}"
     packageName: rhbk-operator
     scope: public
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable-v26
     installPlanApproval: {{ .ApprovalMode }}
     name: keycloak-operator-v26
@@ -296,8 +256,6 @@ spec:
     packageName: rhbk-operator
     scope: public
     configName: keycloak-operator
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable
     fallbackChannels:
       - stable-v1.25
@@ -308,8 +266,6 @@ spec:
     packageName: cloud-native-postgresql
     scope: public
     operatorConfig: cloud-native-postgresql-operator-config
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -338,8 +294,6 @@ spec:
     packageName: cloud-native-postgresql
     scope: public
     operatorConfig: cloud-native-postgresql-operator-config
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -1987,16 +1941,12 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-mongodb-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-cert-manager-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2004,8 +1954,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-iam-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2013,8 +1961,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-healthcheck-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2022,8 +1968,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-commonui-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2031,8 +1975,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-management-ingress-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2040,8 +1982,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-ingress-nginx-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2049,8 +1989,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-auditlogging-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2058,8 +1996,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platform-api-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2067,8 +2003,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.23
     name: ibm-monitoring-grafana-operator
     namespace: "{{ .ServicesNs }}"
@@ -2076,8 +2010,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.23
     name: ibm-zen-operator
     namespace: "{{ .ServicesNs }}"
@@ -2085,8 +2017,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.23
     name: ibm-zen-cpp-operator
     namespace: "{{ .CPFSNs }}"
@@ -2094,8 +2024,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	CSV4OpReg = `
@@ -2118,56 +2046,42 @@ spec:
     packageName: ibm-iam-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-im-mongodb-operator
     namespace: "{{ .CPFSNs }}"
     channel: v4.2
     installMode: no-op
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3
     name: ibm-events-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-events-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v5.1
     name: ibm-events-operator-v5.1
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-events-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v5.2
     name: ibm-events-operator-v5.2
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-events-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
     channel: v4.4
     packageName: ibm-zen-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-idp-config-ui-operator
     namespace: "{{ .CPFSNs }}"
     channel: v4.4
     packageName: ibm-commonui-operator-app
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable
     name: cloud-native-postgresql
     namespace: "{{ .CPFSNs }}"
@@ -2175,8 +2089,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable-v1.22
     fallbackChannels:
       - stable
@@ -2187,8 +2099,6 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
     configName: cloud-native-postgresql
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: stable-v1.25
     fallbackChannels:
       - stable-v1.22
@@ -2200,80 +2110,60 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
     configName: cloud-native-postgresql
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: alpha
     name: ibm-user-data-services-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-user-data-services-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3
     name: ibm-bts-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-bts-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.34
     name: ibm-bts-operator-v3.34
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-bts-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.35
     name: ibm-bts-operator-v3.35
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-bts-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.3
     name: ibm-automation-flink
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-automation-flink
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.3
     name: ibm-automation-elastic
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-automation-elastic
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.1
     name: ibm-elasticsearch-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-elasticsearch-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode}}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v2.0
     name: ibm-opencontent-flink
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-opencontent-flink
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.1
     name: ibm-opensearch-operator
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-opensearch-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode}}
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -2299,16 +2189,12 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-mongodb-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
     packageName: ibm-mongodb-operator-app
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-cert-manager-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2316,8 +2202,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-iam-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2325,8 +2209,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-management-ingress-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2334,8 +2216,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-ingress-nginx-operator
     namespace: "{{ .ServicesNs }}"
     channel: v3.23
@@ -2343,8 +2223,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v3.23
     name: ibm-zen-operator
     namespace: "{{ .ServicesNs }}"
@@ -2352,8 +2230,6 @@ spec:
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
     installMode: no-op
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
   `
 )
 

--- a/internal/controller/webhooks/commonservice/validatingwebhook.go
+++ b/internal/controller/webhooks/commonservice/validatingwebhook.go
@@ -126,21 +126,6 @@ func (r *Defaulter) Handle(ctx context.Context, req admission.Request) admission
 		if deniedServicesNs {
 			return admission.Denied(fmt.Sprintf("Services Namespace: %v is not allowed to be configured in namespace %v", servicesNamespace, req.AdmissionRequest.Namespace))
 		}
-
-		// // check CatalogName
-		// catalogName := cs.Spec.CatalogName
-		// deniedCatalog := r.CheckConfig(string(catalogName), catalogSourceName)
-		// if deniedCatalog {
-		// 	return admission.Denied(fmt.Sprintf("CatalogSource Name: %v is not allowed to be configured in namespace %v", catalogName, req.AdmissionRequest.Namespace))
-		// }
-
-		// // check CatalogNamespace
-		// catalogNamespace := cs.Spec.CatalogNamespace
-		// deniedCatalogNs := r.CheckConfig(string(catalogNamespace), catalogSourceNs)
-		// if deniedCatalogNs {
-		// 	return admission.Denied(fmt.Sprintf("CatalogSource Namespace: %v is not allowed to be configured in namespace %v", catalogNamespace, req.AdmissionRequest.Namespace))
-		// }
-
 	}
 
 	// check HugePageSetting


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert the change about allowing catalog configuration via CommonService CR https://github.com/IBM/ibm-common-service-operator/pull/2543

Also make additional enhancements on status conditions:
1. Add warning conditions when catalog is configured in CS, to state that it is not a supported configuration
2. When CommonService CR is reconciled successfully, remove other unnecessary `Pending`, `Error`, `Reconciling` and `Blocked` conditions

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67342

**Special notes for your reviewer**:
1. Test with image `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:dev`
2. Configure CommonService CR with any arbitrary catalog like following
    ```console
    ➜  ~ oc get commonservice common-service -ojsonpath='{.spec.catalogName} {.spec.catalogNamespace}'
    opefdfdsfsdsd sdsadasdas%
    ```
3. Create OperandRequest to install `ibm-im-operator`
4. Observe that all subscriptions are installed from expected catalog based on ODLM discovery logic, it is not impacted by CommonService CR configuration
    ```console
    ➜  ~ oc get subscription
    NAME                                       PACKAGE                        SOURCE                            CHANNEL
    cloud-native-postgresql                    cloud-native-postgresql        cloud-native-postgresql-catalog   stable-v1.25
    ibm-common-service-operator                ibm-common-service-operator    opencloud-operators-sc2           v4.6
    ibm-commonui-operator-app                  ibm-commonui-operator-app      opencloud-operators-sc2           v4.4
    ibm-iam-operator                           ibm-iam-operator               opencloud-operators-sc2           v4.5
    ibm-namespace-scope-operator               ibm-namespace-scope-operator   opencloud-operators-sc2           v4.2
    operand-deployment-lifecycle-manager-app   ibm-odlm                       opencloud-operators-sc2           v4.3
    ```
5. Observe CommonService CR conditions status. After a successful reconciliation, only `Warning` and `Ready` conditions are left in the status.
    ```console
    ➜  ~ oc get commonservice common-service -ojsonpath='{.status.conditions}' | jq
    [
      {
        "lastTransitionTime": "2025-07-25T15:57:52Z",
        "lastUpdateTime": "2025-07-25T15:57:52Z",
        "message": "CommonService CR is ready.",
        "reason": "ReconcileSucceeded",
        "status": "True",
        "type": "Ready"
      },
      {
        "lastTransitionTime": "2025-07-25T15:57:52Z",
        "lastUpdateTime": "2025-07-25T15:57:52Z",
        "message": "warning: CatalogSource configuration is not supported. Please remove .spec.CatalogName and .spec.CatalogNamespace from the CommonService CR.",
        "reason": "WarningOccurred",
        "status": "True",
        "type": "Warning"
      }
    ]
    ```