### PR TITLE
use Reader to get EDB configmap

### DIFF
--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -2662,7 +2662,7 @@ func (b *Bootstrap) getPostgresImageConfigMap(ctx context.Context) (*corev1.Conf
 	configMap := &corev1.ConfigMap{}
 	configMapName := constant.PostgreSQLImageConfigMap
 
-	if err := b.Client.Get(ctx, types.NamespacedName{
+	if err := b.Reader.Get(ctx, types.NamespacedName{
 		Name:      configMapName,
 		Namespace: b.CSData.OperatorNs,
 	}, configMap); err != nil && errors.IsNotFound(err) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Side effect of cache upgrade, because `cloud-native-postgresql-operand-images-config` doesn't contain watchByCSoperatorLabel we can't use client to get it from cache, use reader instead
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67248
