### PR TITLE
Add the User Management Operator to the status-monitored services in OperandRegistry

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -47,7 +47,7 @@ var ServiceNames = map[string][]string{
 
 const (
 	ExcludedCatalog         = "certified-operators,community-operators,redhat-marketplace,ibm-cp-automation-foundation-catalog,operatorhubio-catalog"
-	StatusMonitoredServices = "ibm-idp-config-ui-operator,ibm-mongodb-operator,ibm-im-operator"
+	StatusMonitoredServices = "ibm-idp-config-ui-operator,ibm-mongodb-operator,ibm-im-operator,ibm-user-management-operator"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable status monitoring for the User Management Operator in the OperandRegistry, aligned with the status implementation in PR: https://github.com/IBM/ibm-user-management-operator/pull/92/files

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65127

