### PR TITLE
Ignore certified-operators if found another catalogsource

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -616,6 +616,30 @@ function get_catalogsource() {
         # Extracting the values using string manipulation
         catalog_source=$(echo "$result" | awk -F': ' '{print $2}' | awk -F',' '{print $1}')
         catalog_namespace=$(echo "$result" | awk -F': ' '{print $NF}')
+    elif [[ count -eq 2 ]]; then
+        # If there are two catalog sources, 
+        # case 1: "catalog_source_1" and "catalog_source_2", we return both of them
+        # case 2: "certified-operators" and "catalog_source_2", we only return "catalog_source_2"
+
+        # Split the result into lines
+        IFS=$'\n' read -rd '' -a lines <<< "$result"
+
+        for ((i = 0; i < ${#lines[@]}; i+=2)); do
+            name_line=${lines[$i]}
+            ns_line=${lines[$i+1]}
+            name=$(echo "$name_line" | awk -F': ' '{print $2}')
+            ns=$(echo "$ns_line" | awk -F': ' '{print $2}')
+            # If the catalog source is not "certified-operators", we use it
+            if [[ "$name" != "certified-operators" ]]; then
+                catalog_source=$name
+                catalog_namespace=$ns
+            else
+                # If the catalog source is "certified-operators", we skip it
+                echo "Skipping catalog source: $name in namespace: $ns"
+                count=1
+                continue
+            fi
+        done
     fi
     echo "$count $catalog_source $catalog_namespace"
 }

--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -620,7 +620,6 @@ function get_catalogsource() {
         # If there are two catalog sources, 
         # case 1: "catalog_source_1" and "catalog_source_2", we return both of them
         # case 2: "certified-operators" and "catalog_source_2", we only return "catalog_source_2"
-
         # Split the result into lines
         IFS=$'\n' read -rd '' -a lines <<< "$result"
 
@@ -635,7 +634,6 @@ function get_catalogsource() {
                 catalog_namespace=$ns
             else
                 # If the catalog source is "certified-operators", we skip it
-                echo "Skipping catalog source: $name in namespace: $ns"
                 count=1
                 continue
             fi


### PR DESCRIPTION
**What this PR does / why we need it**:
If we found 2 catalogsource in get_catalogsource function, there are two cases:
**case 1**: "catalog_source_1" and "catalog_source_2", we return both of them
**case 2**: "certified-operators" and "catalog_source_2", we only return "catalog_source_2"

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67140