### PR TITLE
Add MCSP IDP configuration update to common service database restore process

### DIFF
--- a/velero/schedule/common-service-db/cs-db-br-script-cm-4.6.10.4.11.yaml
+++ b/velero/schedule/common-service-db/cs-db-br-script-cm-4.6.10.4.11.yaml
@@ -137,7 +137,6 @@ data:
         
         info "Detected cluster domain: $CLUSTER_DOMAIN"
         
-        # Construct the new IDP URL based on the cluster domain and namespace
         NEW_IDP_URL="https://cp-console.${CSDB_NAMESPACE}.${CLUSTER_DOMAIN}/idprovider/v1/auth"
         
         info "Updating IDP URLs to: $NEW_IDP_URL"
@@ -146,12 +145,18 @@ data:
         ACCOUNT_IAM_EXISTS=$(oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" | grep "account_iam" || echo False)
         
         if [[ $ACCOUNT_IAM_EXISTS != "False" ]]; then
-            # Update the idp column in the idp_config table
             oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -d account_iam -c "
                 UPDATE accountiam.idp_config 
                 SET idp = '$NEW_IDP_URL', 
                     modified_ts = NOW()
                 WHERE idp LIKE '%/idprovider/v1/%';
+            "
+            
+            info "Verifying IDP configuration update..."
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -d account_iam -c "
+                SELECT uid, realm, idp, modified_ts 
+                FROM accountiam.idp_config 
+                ORDER BY modified_ts DESC;
             "
             
             success "IDP configuration updated successfully."

--- a/velero/schedule/common-service-db/cs-db-br-script-cm-4.6.10.4.11.yaml
+++ b/velero/schedule/common-service-db/cs-db-br-script-cm-4.6.10.4.11.yaml
@@ -104,6 +104,9 @@ data:
             if [[ $ACCOUNT_IAM != "False" ]]; then
                 info "Beginning restore of account_iam database..."
                 oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_restore -U postgres --dbname account_iam --format=c --clean --exit-on-error -v /run/cs-db_backup/cs-db_account_iam_backup.dump        
+                
+                # Update IDP configuration with actual cluster domain
+                update_idp_config
             fi
             oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" -c "\dn" -c "\du"
         else
@@ -119,6 +122,42 @@ data:
         oc apply -f /tmp/oidc-client-registration.yaml
         rm -f /tmp/oidc-client-registration.yaml
         wait_for_oidc
+    }
+
+    function update_idp_config {
+        info "Updating IDP configuration with actual cluster domain..."
+        
+        # Get the cluster domain from the management ingress
+        CLUSTER_DOMAIN=$(oc get route console -n openshift-console -o jsonpath='{.spec.host}' | sed 's/^console-openshift-console\.//')
+        
+        if [[ -z $CLUSTER_DOMAIN ]]; then
+            error "Could not determine cluster domain. Please update IDP configuration manually."
+            return 1
+        fi
+        
+        info "Detected cluster domain: $CLUSTER_DOMAIN"
+        
+        # Construct the new IDP URL based on the cluster domain and namespace
+        NEW_IDP_URL="https://cp-console.${CSDB_NAMESPACE}.${CLUSTER_DOMAIN}/idprovider/v1/auth"
+        
+        info "Updating IDP URLs to: $NEW_IDP_URL"
+        
+        # Check if account_iam database exists
+        ACCOUNT_IAM_EXISTS=$(oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" | grep "account_iam" || echo False)
+        
+        if [[ $ACCOUNT_IAM_EXISTS != "False" ]]; then
+            # Update the idp column in the idp_config table
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -d account_iam -c "
+                UPDATE accountiam.idp_config 
+                SET idp = '$NEW_IDP_URL', 
+                    modified_ts = NOW()
+                WHERE idp LIKE '%/idprovider/v1/%';
+            "
+            
+            success "IDP configuration updated successfully."
+        else
+            warning "account_iam database not found, skipping IDP configuration update."
+        fi
     }
 
     function wait_for_oidc {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds automatic IDP URL updating functionality to the common-services database restore script. After restoring the `account_iam` database, the it now automatically updates IDP configuration URLs to match the current cluster domain.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67335

**How to test**:
1. oc login into a cluster and install UM operator
2. Manually change the idp in database to other URL 
3. Create a simple test script for the new functions and execute.
4. Check if the idp URL changes back

Test result:
```
➜  common-service-db git:(update_idp) ✗ bash test-idp-update.sh mcsp  
Getting primary PostgreSQL pod...
Primary pod: common-service-db-1
Checking if account_iam database exists...
Current IDP configuration BEFORE update:
                 uid                  |    realm     |                                  idp                                   |          modified_ts          
--------------------------------------+--------------+------------------------------------------------------------------------+-------------------------------
 0a928673-f2a7-4804-b781-ffa9f54e7985 | PrimaryRealm | https://test-idp-url.example.com/idprovider/v1/auth | 2025-08-14 21:38:05.730994+00
 ed890909-2896-4a7a-951c-954f524892ad | SAML         | https://test-idp-url.example.com/idprovider/v1/auth | 2025-08-14 21:38:05.730994+00
 2d13f58e-19bb-4601-9d29-e8d9c295cf71 | OIDC         | https://test-idp-url.example.com/idprovider/v1/auth | 2025-08-14 21:38:05.730994+00
 d26bb99a-ed17-4b4c-8918-04ef966c52ee | PrimaryRealm | https://test-idp-url.example.com/idprovider/v1/auth | 2025-08-14 21:38:05.730994+00
(4 rows)

Getting cluster domain...
Detected cluster domain: apps.cutie1.cp.fyre.ibm.com
New IDP URL will be: https://cp-console.mcsp.apps.cutie1.cp.fyre.ibm.com/idprovider/v1/auth
Updating IDP configuration...
UPDATE 4
IDP configuration AFTER update:
                 uid                  |    realm     |                                  idp                                   |          modified_ts          
--------------------------------------+--------------+------------------------------------------------------------------------+-------------------------------
 0a928673-f2a7-4804-b781-ffa9f54e7985 | PrimaryRealm | https://cp-console.mcsp.apps.cutie1.cp.fyre.ibm.com/idprovider/v1/auth | 2025-08-14 21:55:25.937126+00
 ed890909-2896-4a7a-951c-954f524892ad | SAML         | https://cp-console.mcsp.apps.cutie1.cp.fyre.ibm.com/idprovider/v1/auth | 2025-08-14 21:55:25.937126+00
 2d13f58e-19bb-4601-9d29-e8d9c295cf71 | OIDC         | https://cp-console.mcsp.apps.cutie1.cp.fyre.ibm.com/idprovider/v1/auth | 2025-08-14 21:55:25.937126+00
 d26bb99a-ed17-4b4c-8918-04ef966c52ee | PrimaryRealm | https://cp-console.mcsp.apps.cutie1.cp.fyre.ibm.com/idprovider/v1/auth | 2025-08-14 21:55:25.937126+00
(4 rows)

Test completed!
```