### PR TITLE
Update setup_singleton.sh to support F5 Cert Manager

### DIFF
--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -637,10 +637,11 @@ function verify_cert_manager(){
     info "Checking cert manager readiness."
     #check webhook pod runnning
     local name="cert-manager-webhook"
+    local f5_exclude_name="f5-cert-manager-webhook"
     local retries=20
     local sleep_time=15
     local total_time_mins=$(( sleep_time * retries / 60))
-    local condition="${OC} get pod -A --no-headers --ignore-not-found | egrep '1/1' | grep ${name} || true"
+    local condition="${OC} get pod -A --no-headers --ignore-not-found | egrep '1/1' | grep -v  ${f5_exclude_name} | grep ${name} || true"
     local wait_message="Waiting for pod ${name} to be running ..."
     local success_message="Pod ${name} is running."
     local error_message="Timeout after ${total_time_mins} minutes waiting for pod ${name} to be running."
@@ -651,7 +652,7 @@ function verify_cert_manager(){
     if [[ $webhook_deployments != "1" ]]; then
     error "More than one cert-manager-webhook deployment exists on the cluster."
     fi
-    local webhook_ns=$("$OC" get deployments -A | grep cert-manager-webhook | cut -d ' ' -f1)
+    local webhook_ns=$("$OC" get deployments -A | grep -v  ${f5_exclude_name} | grep ${name} | cut -d ' ' -f1)
     
     cm_smoke_test "test-issuer" "test-certificate" "test-certificate-secret" $webhook_ns
     success "Cert manager is ready."


### PR DESCRIPTION
**What this PR does / why we need it**:

The F5 certificate manager is a fork of the community certificate manager which should be ignored by the script as it confined to a single namespace and uses different CRDs.

https://clouddocs.f5.com/service-proxy/latest/spk-cert-manager.html

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action