### PR TITLE
Add new permission for IAM in 4.15

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -182,6 +182,7 @@ rules:
       - patch
       - update
       - watch
+      - list
     apiGroups:
       - postgresql.k8s.enterprisedb.io
     resources:
@@ -1670,3 +1671,11 @@ rules:
       - db2uengines
     apiGroups:
       - db2u.databases.ibm.com
+  - verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secretproviderclasses
+    apiGroups:
+      - secrets-store.csi.x-k8s.io


### PR DESCRIPTION
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67876

New required permission for IAM operator in 4.15
```
E0923 14:46:24.539923 1 namespacescope_controller.go:668] Failed to create role cp2-ns/ibm-iam-operator-81d8ce5ab86dd7: roles.rbac.authorization.k8s.io "ibm-iam-operator-81d8ce5ab86dd7" is forbidden: user "system:serviceaccount:cs-operators:ibm-namespace-scope-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:cs-operators" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["postgresql.k8s.enterprisedb.io"], Resources:["clusters/status"], Verbs:["list"]}
{APIGroups:["secrets-store.csi.x-k8s.io"], Resources:["secretproviderclasses"], Verbs:["get" "list" "watch"]}
```