### PR TITLE
fix broken wait_for_deployment function

### DIFF
--- a/cp3pt0-deployment/common/utils.sh
+++ b/cp3pt0-deployment/common/utils.sh
@@ -473,15 +473,11 @@ function patch_watch_namespace() {
 function wait_for_deployment() {
     local namespace=$1
     local name=$2
+    local retries="${3:-10}"
     local needReplicas=$(${OC} -n ${namespace} get deployment ${name} --no-headers --ignore-not-found -o jsonpath='{.spec.replicas}' | awk '{print $1}')
     local readyReplicas="${OC} -n ${namespace} get deployment ${name} --no-headers --ignore-not-found -o jsonpath='{.status.readyReplicas}' | grep '${needReplicas}'"
     local replicas="${OC} -n ${namespace} get deployment ${name} --no-headers --ignore-not-found -o jsonpath='{.status.replicas}' | grep '${needReplicas}'"
     local condition="(${readyReplicas} && ${replicas})"
-    if [[ $3 != "" ]]; then
-        local retries=$3
-    else
-        local retries=10
-    fi
     local sleep_time=30
     local total_time_mins=$(( sleep_time * retries / 60))
     local wait_message="Waiting for Deployment ${name} to be ready"


### PR DESCRIPTION
Broken in this commit https://github.com/IBM/ibm-common-service-operator/commit/b92c5c2011ab92aa848c169ebcbd2c248a434bc6.

The retries parameter is supposed to be an optional parameter but if used without passing in the third parameter, the function complains about the retries variable being unset. The change in this pr establishes a default value (matching the original 10) and a specified value as an optional third parameter. 

Unfortunately this broke some older scripts that rely on this function so this is required


I have already tested this change as part of work for https://github.com/IBM/ibm-common-service-operator/pull/2629