### PR TITLE
Make namespace deletion optional for uninstall tenant script

### DIFF
--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -75,11 +75,9 @@ function parse_arguments() {
             OPERATOR_NS=$1
             ;;
         --retain-ns)
-            shift
             RETAIN="true"
             ;;
         -f)
-            shift
             FORCE_DELETE=1
             ;;
         -v | --debug)

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -19,6 +19,7 @@ OPERATOR_NS_LIST=""
 CONTROL_NS=""
 FORCE_DELETE=0
 DEBUG=0
+RETAIN="false"
 
 # ---------- Command variables ----------
 
@@ -46,7 +47,9 @@ function main() {
     delete_rbac_resource
     delete_webhook
     delete_unavailable_apiservice
-    delete_tenant_ns
+    if [[ $RETAIN == "false" ]]; then
+        delete_tenant_ns
+    fi
 }
 
 function parse_arguments() {
@@ -68,6 +71,10 @@ function parse_arguments() {
         --operator-namespace)
             shift
             OPERATOR_NS=$1
+            ;;
+        --retain-ns)
+            shift
+            RETAIN="true"
             ;;
         -f)
             shift
@@ -102,6 +109,7 @@ function print_usage() {
     echo "   --yq string                    Optional. File path to yq CLI. Default uses yq in your PATH"
     echo "   --operator-namespace string    Required. Namespace to uninstall Foundational services operators and the whole tenant."
     echo "   -f                             Optional. Enable force delete. It will take much more time if you add this label, we suggest run this script without -f label first"
+    echo "   --retain-ns                    Optional. Prevents script from deleting tenant namespaces during uninstall."
     echo "   -v, --debug integer            Optional. Verbosity of logs. Default is 0. Set to 1 for debug logs"
     echo "   -h, --help                     Print usage information"
     echo ""

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -416,6 +416,8 @@ function cleanup_extra_resources() {
         ${OC} delete commonservice common-service -n $ns --ignore-not-found
         ${OC} delete operandconfig common-service -n $ns --ignore-not-found
         ${OC} delete operandregistry common-service -n $ns --ignore-not-found
+        info "Remaining resources (minus package manifests and events) in namespace $ns:"
+        ${OC} get "$(${OC} api-resources --namespaced=true --verbs=list -o name | awk '{printf "%s%s",sep,$0;sep=","}')"  --ignore-not-found -n $ns -o=custom-columns=KIND:.kind,NAME:.metadata.name --sort-by='kind' | grep -v PackageManifest | grep -v Event
     done
     success "Excess resources cleaned up in retained tenant namespaces."
 }


### PR DESCRIPTION
**What this PR does / why we need it**: CPD has asked for an uninstall script that does not delete the namespaces and only deletes CPFS resources. The difficulty with this is that we use the namespace deletion to determine which resources to delete (when a namespace is terminating, it highlights the remaining resources with finalizers to remove to facilitate namespace deletion). No deleting the namespace means we have to be more prescriptive about what we are deleting.

In this PR, I have created a fork that would skip deleting the namespaces of the tenant in favor of deleting specific resources associated with CPFS after operand requests and operators are uninstalled. This is a relatively short list of resources though so its possible this would need to expand. For example, right now this will uninstall the zen operator but it will not delete the zenservice so all zen resources are still present minus the operator. Is that CPFS or Zen uninstall script responsibility?

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67725
