### PR TITLE
add required permission for BTS service

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -1679,3 +1679,61 @@ rules:
       - secretproviderclasses
     apiGroups:
       - secrets-store.csi.x-k8s.io
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - leases
+  - verbs:
+      - create
+      - patch
+      - update
+    apiGroups:
+      - certmanager.k8s.io
+    resources:
+      - certificaterequests
+      - challenges
+      - orders
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - businessteamsservices
+  - verbs:
+      - update
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - businessteamsservices/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - operator.ibm.com
+    resources:
+      - businessteamsservices/status
+  - verbs:
+      - create
+      - delete
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses


### PR DESCRIPTION
**What this PR does / why we need it**:
BTS operator updates its namespace scoped RBAC with following additional permissions

```
E1006 14:32:34.797256 1 namespacescope_controller.go:668] Failed to create role cp1-ns/ibm-bts-operator-9269668ecad89c: roles.rbac.authorization.k8s.io "ibm-bts-operator-9269668ecad89c" is forbidden: user "system:serviceaccount:cs-operators:ibm-namespace-scope-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:cs-operators" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["leases"], Verbs:["create" "delete" "get" "list" "patch" "update" "watch"]}
{APIGroups:["certmanager.k8s.io"], Resources:["certificaterequests"], Verbs:["create" "patch" "update"]}
{APIGroups:["certmanager.k8s.io"], Resources:["challenges"], Verbs:["create" "patch" "update"]}
{APIGroups:["certmanager.k8s.io"], Resources:["orders"], Verbs:["create" "patch" "update"]}
{APIGroups:["operator.ibm.com"], Resources:["businessteamsservices"], Verbs:["create" "delete" "get" "list" "patch" "update" "watch"]}
{APIGroups:["operator.ibm.com"], Resources:["businessteamsservices/finalizers"], Verbs:["update"]}
{APIGroups:["operator.ibm.com"], Resources:["businessteamsservices/status"], Verbs:["get" "patch" "update"]}
{APIGroups:["storage.k8s.io"], Resources:["storageclasses"], Verbs:["create" "delete" "patch" "update" "watch"]}
```

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67967
