### PR TITLE
Reduce cluster-level RBAC scope

### DIFF
--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:4.15.0
-    createdAt: "2025-05-16T03:15:01Z"
+    createdAt: "2025-10-06T18:52:18Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -267,14 +267,6 @@ spec:
                 - update
             - apiGroups:
                 - ""
-              resourceNames:
-                - cloud-native-postgresql-image-list
-              resources:
-                - configmaps
-              verbs:
-                - delete
-            - apiGroups:
-                - ""
               resources:
                 - configmaps
               verbs:
@@ -296,20 +288,14 @@ spec:
               verbs:
                 - get
                 - list
-                - watch
             - apiGroups:
                 - admissionregistration.k8s.io
               resources:
                 - mutatingwebhookconfigurations
                 - validatingwebhookconfigurations
               verbs:
-                - create
-                - delete
                 - get
-                - list
-                - patch
-                - update
-                - watch
+                - delete
             - apiGroups:
                 - config.openshift.io
               resources:
@@ -322,13 +308,8 @@ spec:
                 - clusterrolebindings
                 - clusterroles
               verbs:
-                - create
-                - delete
                 - get
-                - list
-                - patch
-                - update
-                - watch
+                - delete
           serviceAccountName: ibm-common-service-operator
       deployments:
         - label:
@@ -431,8 +412,13 @@ spec:
               resources:
                 - configmaps
               verbs:
+                - create
                 - delete
+                - get
+                - list
                 - patch
+                - update
+                - watch
             - apiGroups:
                 - operator.ibm.com
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,14 +14,6 @@ rules:
   resourceNames:
   - common-service-maps
 - verbs:
-  - delete
-  apiGroups:
-  - ""
-  resources:
-  - configmaps
-  resourceNames:
-  - cloud-native-postgresql-image-list
-- verbs:
   - create
   - get
   - list
@@ -45,7 +37,6 @@ rules:
   verbs:
   - get
   - list
-  - watch
 # manage mutation webhook configuration
 - apiGroups:
   - admissionregistration.k8s.io
@@ -53,13 +44,8 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - create
-  - delete
   - get
-  - list
-  - patch
-  - update
-  - watch
+  - delete
 - verbs:
   - get
   apiGroups:
@@ -72,13 +58,8 @@ rules:
   - clusterrolebindings
   - clusterroles
   verbs:
-  - create
-  - delete
   - get
-  - list
-  - patch
-  - update
-  - watch
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -88,8 +69,13 @@ rules:
 - apiGroups:
   - ""
   verbs:
+  - create
   - delete
+  - get
+  - list
   - patch
+  - update
+  - watch
   resources:
   - configmaps
 - apiGroups:

--- a/helm-cluster-scoped/templates/cluster-rbac.yaml
+++ b/helm-cluster-scoped/templates/cluster-rbac.yaml
@@ -22,14 +22,6 @@ rules:
       - update
   - apiGroups: 
       - ""
-    resourceNames: 
-      - cloud-native-postgresql-image-list
-    resources: 
-      - configmaps
-    verbs: 
-      - delete
-  - apiGroups: 
-      - ""
     resources: 
       - configmaps
     verbs: 
@@ -51,20 +43,14 @@ rules:
     verbs: 
       - get
       - list
-      - watch
   - apiGroups: 
       - admissionregistration.k8s.io
     resources: 
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
     verbs: 
-      - create
-      - delete
       - get
-      - list
-      - patch
-      - update
-      - watch
+      - delete
   - apiGroups: 
       - config.openshift.io
     resources: 
@@ -77,13 +63,8 @@ rules:
       - clusterrolebindings
       - clusterroles
     verbs: 
-      - create
-      - delete
       - get
-      - list
-      - patch
-      - update
-      - watch
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/testdata/deploy/role.yaml
+++ b/testdata/deploy/role.yaml
@@ -177,13 +177,8 @@ rules:
     - mutatingwebhookconfigurations
     - validatingwebhookconfigurations
   verbs:
-    - create
-    - delete
     - get
-    - list
-    - patch
-    - update
-    - watch
+    - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/testdata/deploy/role.yaml.bak
+++ b/testdata/deploy/role.yaml.bak
@@ -120,7 +120,8 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - '*'
+  - get
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
Tighten the Common Service Operator’s RBAC footprint by limiting cluster-scoped permissions

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67915

**What Changes**

- Pruned unused verbs/resources from role.yaml
- Shifted EDB ConfigMap write access into the namespaced Role.
- Propagated the RBAC updates through Helm templates, test fixtures, and the bundle CSV.

**How to test**
1. Test image:  `quay.io/yuchen_shen/cs_operator:reduce_permission`
2. Install the whole CPFS and see if everything working properly.