### PR TITLE
match backup template to schedule template

### DIFF
--- a/velero/backup/backup.yaml
+++ b/velero/backup/backup.yaml
@@ -26,27 +26,27 @@ spec:
       - subscription
       - singleton-subscription
       - operand
-      - zen-data
+      - zen-data #zen 4 data
       - mongo-data
       - entitlementkey
       - commonservice
       - pull-secret
       - operatorgroup
-      - zen
+      - zen #non-data zen 4 resources
       - licensing
       - cert-manager
       - namespace
       - configmap
-      - zen5
-      - zen5-data
+      - zen5 #non-data zen 5 resources
+      - zen5-data #zen 5 data
       - crd
-      - lsr
-      - lsr-data
-      - cs-db-data
-      - cs-db
-      - keycloak-data
-      - keycloak
-      - user-mgmt
+      - lsr #non-data license service reporter resources
+      - lsr-data #license service reporter data
+      - cs-db-data #pgdump approach to BR IM EDB data
+      - cs-db #velero plugin approach to BR IM EDB data
+      - keycloak-data #pgdump approach to BR keycloak data
+      - keycloak #velero plugin approach to BR keycloak data
+      - user-mgmt #non-data user-management operator resources
       - nss
       - cs-chart
       - cs-cluster
@@ -66,6 +66,7 @@ spec:
       - lsr-cluster
       - lsr-chart
       - ibm-cm-chart
+      - ums
   snapshotMoveData: false
   storageLocation: <storage location name>
   ttl: 4h0m0s


### PR DESCRIPTION
**What this PR does / why we need it**: backup template is really only used in our automation but it currently does not include the ums label and a few others. This pr just keeps it in line with our schedule template which is where we typically define the list of resources included in a backup.

**Which issue(s) this PR fixes**:
Fixes # Found while testing a separate issue

**Special notes for your reviewer**:

1. How the test is done?

**How to backport this PR to other branch**:
1. Add label to this PR with the target branch name `backport <branch-name>`
2. The PR will be automatically created in the target branch after merging this PR
3. If this PR is already merged, you can still add the label with the target branch name `backport <branch-name>` and leave a comment `/backport` to trigger the backport action