### PR TITLE
Make roksEnabled default to true in Helm

### DIFF
--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -39,14 +39,14 @@ metadata:
             "servicesNamespace": "{{ .Values.global.instanceNamespace }}",
             "size": "{{ .Values.cpfs.size }}",
             "storageClass": "{{ .Values.global.blockStorageClass }}"
-            {{- if not .Values.cpfs.roksEnabled }},
+            {{- if not (.Values.cpfs.roksEnabled | default true) }},
             "services": [
               {
                 "name": "ibm-im-operator",
                 "spec": {
                   "authentication": {
                     "config": {
-                      "roksEnabled": {{ .Values.cpfs.roksEnabled }}
+                      "roksEnabled": {{ .Values.cpfs.roksEnabled | default true }}
                     }
                   }
                 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In the case that ```.Values.cpfs.roksEnabled``` doesn't exist, we will make roksEnabled default to true inside the template. The case where ```roksEnabled``` doesn't exist can happen if the values.yaml that's with the template is not used. If the value doesn't exist, it defaults to nil and can cause errors. Adding for safety. 