### PR TITLE
Edb license job removed from odlm.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ OPENSHIFT_VERSIONS ?= v4.12-v4.17
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
-CONTAINER_TOOL ?= podman
+CONTAINER_TOOL ?= docker
 
 CSV_PATH=bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ OPENSHIFT_VERSIONS ?= v4.12-v4.17
 # Be aware that the target commands are only tested with Docker which is
 # scaffolded by default. However, you might want to replace it to use other
 # tools. (i.e. podman)
-CONTAINER_TOOL ?= docker
+CONTAINER_TOOL ?= podman
 
 CSV_PATH=bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
 

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -969,6 +969,7 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
 		constant.UserMgmtOpCon,
 		constant.IdpConfigUIOpCon,
 		constant.PlatformUIOpCon,
+		constant.EDBOpCon,
 		constant.KeyCloakOpCon,
 		constant.CommonServicePGOpCon,
 		constant.CommonServiceCNPGOpCon,

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -969,7 +969,6 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool) error {
 		constant.UserMgmtOpCon,
 		constant.IdpConfigUIOpCon,
 		constant.PlatformUIOpCon,
-		constant.EDBOpCon,
 		constant.KeyCloakOpCon,
 		constant.CommonServicePGOpCon,
 		constant.CommonServiceCNPGOpCon,

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1047,117 +1047,21 @@ spec:
   {{- range .ServiceNames.PostgreSQL }}
   - name: {{ . }}
     resources:
-      - apiVersion: batch/v1
-        kind: Job
-        name: create-postgres-license-config
+      - apiVersion: v1
+        kind: Secret
+        name: postgresql-operator-controller-manager-config
         namespace: "{{ $.OperatorNs }}"
-        labels:
-          operator.ibm.com/opreq-control: 'true'
-        data:
-          spec:
-            activeDeadlineSeconds: 600
-            backoffLimit: 5
-            template:
-              metadata:
-                annotations:
-                  productID: 068a62892a1e4db39641342e592daa25
-                  productMetric: FREE
-                  productName: IBM Cloud Platform Common Services
-              spec:
-                imagePullSecrets:
-                  - name: ibm-entitlement-key
-                affinity:
-                  nodeAffinity:
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      nodeSelectorTerms:
-                      - matchExpressions:
-                        - key: kubernetes.io/arch
-                          operator: In
-                          values:
-                          - amd64
-                          - ppc64le
-                          - s390x
-                initContainers:
-                - command:
-                  - bash
-                  - -c
-                  - |
-                    cat << EOF | kubectl apply -f -
-                    apiVersion: v1
-                    kind: Secret
-                    type: Opaque
-                    metadata:
-                      name: postgresql-operator-controller-manager-config
-                    data:
-                      EDB_LICENSE_KEY: $(base64 /license_keys/edb/EDB_LICENSE_KEY | tr -d '\n')
-                    EOF
-                  image:
-                    templatingValueFrom:
-                      default:
-                        required: true
-                        configMapKeyRef:
-                          name: cloud-native-postgresql-image-list
-                          key: edb-postgres-license-provider-image
-                          namespace: {{ $.OperatorNs }}
-                      configMapKeyRef:
-                        name: cloud-native-postgresql-operand-images-config
-                        key: edb-postgres-license-provider-image
-                        namespace: {{ $.OperatorNs }}
-                  name: edb-license
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
-                    requests:
-                      cpu: 100m
-                      memory: 50Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                      - ALL
-                    privileged: false
-                    readOnlyRootFilesystem: true
-                containers:
-                - command: ["bash", "-c"]
-                  args:
-                  - |
-                    kubectl delete pods -l app.kubernetes.io/name=cloud-native-postgresql
-                    kubectl annotate secret postgresql-operator-controller-manager-config ibm-license-key-applied="EDB Database with IBM License Key"
-                  image:
-                    templatingValueFrom:
-                      default:
-                        required: true
-                        configMapKeyRef:
-                          name: cloud-native-postgresql-image-list
-                          key: edb-postgres-license-provider-image
-                          namespace: {{ $.OperatorNs }}
-                      configMapKeyRef:
-                        name: cloud-native-postgresql-operand-images-config
-                        key: edb-postgres-license-provider-image
-                        namespace: {{ $.OperatorNs }}
-                  name: restart-edb-pod
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
-                    requests:
-                      cpu: 100m
-                      memory: 50Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                      - ALL
-                    privileged: false
-                    readOnlyRootFilesystem: true
-                hostIPC: false
-                hostNetwork: false
-                hostPID: false
-                restartPolicy: OnFailure
-                securityContext:
-                  runAsNonRoot: true
-                serviceAccountName: edb-license-sa
+        annotations:
+          postgresql-operator-controller-manager-ready:
+            templatingValueFrom:
+              objectRef:
+                apiVersion: v1
+                kind: Pod
+                labelSelector:
+                  app.kubernetes.io/name: postgresql-operator-controller-manager
+                path: .metadata.name
+                namespace: {{ $.OperatorNs }}
+              required: true
       - apiVersion: v1
         kind: ServiceAccount
         name: edb-license-sa
@@ -1905,118 +1809,21 @@ spec:
               supportedLocales: [ "en", "de" , "es", "fr", "it", "ja", "ko", "pt_BR", "zh_CN", "zh_TW"]
   - name: edb-keycloak
     resources:
-      - apiVersion: batch/v1
-        kind: Job
-        force: true
-        name: create-postgres-license-config
+      - apiVersion: v1
+        kind: Secret
+        name: postgresql-operator-controller-manager-config
         namespace: "{{ .OperatorNs }}"
-        labels:
-          operator.ibm.com/opreq-control: 'true'
-        data:
-          spec:
-            activeDeadlineSeconds: 600
-            backoffLimit: 5
-            template:
-              metadata:
-                annotations:
-                  productID: 068a62892a1e4db39641342e592daa25
-                  productMetric: FREE
-                  productName: IBM Cloud Platform Common Services
-              spec:
-                imagePullSecrets:
-                  - name: ibm-entitlement-key
-                affinity:
-                  nodeAffinity:
-                    requiredDuringSchedulingIgnoredDuringExecution:
-                      nodeSelectorTerms:
-                      - matchExpressions:
-                        - key: kubernetes.io/arch
-                          operator: In
-                          values:
-                          - amd64
-                          - ppc64le
-                          - s390x
-                initContainers:
-                - command:
-                  - bash
-                  - -c
-                  - |
-                    cat << EOF | kubectl apply -f -
-                    apiVersion: v1
-                    kind: Secret
-                    type: Opaque
-                    metadata:
-                      name: postgresql-operator-controller-manager-config
-                    data:
-                      EDB_LICENSE_KEY: $(base64 /license_keys/edb/EDB_LICENSE_KEY | tr -d '\n')
-                    EOF
-                  image:
-                    templatingValueFrom:
-                      default:
-                        required: true
-                        configMapKeyRef:
-                          name: cloud-native-postgresql-image-list
-                          key: edb-postgres-license-provider-image
-                          namespace: {{ .OperatorNs }}
-                      configMapKeyRef:
-                        name: cloud-native-postgresql-operand-images-config
-                        key: edb-postgres-license-provider-image
-                        namespace: {{ $.OperatorNs }}
-                  name: edb-license
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
-                    requests:
-                      cpu: 100m
-                      memory: 50Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                      - ALL
-                    privileged: false
-                    readOnlyRootFilesystem: true
-                containers:
-                - command: ["bash", "-c"]
-                  args:
-                  - |
-                    kubectl delete pods -l app.kubernetes.io/name=cloud-native-postgresql
-                    kubectl annotate secret postgresql-operator-controller-manager-config ibm-license-key-applied="EDB Database with IBM License Key"
-                  image:
-                    templatingValueFrom:
-                      default:
-                        required: true
-                        configMapKeyRef:
-                          name: cloud-native-postgresql-image-list
-                          key: edb-postgres-license-provider-image
-                          namespace: {{ .OperatorNs }}
-                      configMapKeyRef:
-                        name: cloud-native-postgresql-operand-images-config
-                        key: edb-postgres-license-provider-image
-                        namespace: {{ $.OperatorNs }}
-                  name: restart-edb-pod
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 512Mi
-                    requests:
-                      cpu: 100m
-                      memory: 50Mi
-                  securityContext:
-                    allowPrivilegeEscalation: false
-                    capabilities:
-                      drop:
-                      - ALL
-                    privileged: false
-                    readOnlyRootFilesystem: true
-                hostIPC: false
-                hostNetwork: false
-                hostPID: false
-                restartPolicy: OnFailure
-                securityContext:
-                  runAsNonRoot: true
-                serviceAccountName: edb-license-sa
+        annotations:
+          postgresql-operator-controller-manager-ready:
+            templatingValueFrom:
+              objectRef:
+                apiVersion: v1
+                kind: Pod
+                labelSelector:
+                  app.kubernetes.io/name: postgresql-operator-controller-manager
+                path: .metadata.name
+                namespace: {{ .OperatorNs }}
+              required: true
       - apiVersion: v1
         kind: ServiceAccount
         name: edb-license-sa
@@ -2056,7 +1863,7 @@ spec:
                   apiVersion: v1
                   kind: Secret
                   name: postgresql-operator-controller-manager-config
-                  path: .metadata.annotations.ibm-license-key-applied
+                  path: .metadata.annotations.postgresql-operator-controller-manager-ready
                   namespace: {{ .OperatorNs }}
                 required: true
             bootstrap:
@@ -2259,7 +2066,7 @@ spec:
                   apiVersion: v1
                   kind: Secret
                   name: postgresql-operator-controller-manager-config
-                  path: .metadata.annotations.ibm-license-key-applied
+                  path: .metadata.annotations.postgresql-operator-controller-manager-ready
                   namespace: {{ .OperatorNs }}
                 required: true
             bootstrap:

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1032,6 +1032,64 @@ spec:
 `
 )
 
+const EDBOpCon = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+spec:
+  services:
+  {{- range .ServiceNames.PostgreSQL }}
+  - name: {{ . }}
+    resources:
+      - apiVersion: v1
+        kind: Secret
+        name: postgresql-operator-controller-manager-config
+        namespace: "{{ $.OperatorNs }}"
+        annotations:
+          postgresql-operator-controller-manager-ready:
+            templatingValueFrom:
+              objectRef:
+                apiVersion: v1
+                kind: Pod
+                labelSelector:
+                  app.kubernetes.io/name: postgresql-operator-controller-manager
+                path: .metadata.name
+                namespace: {{ $.OperatorNs }}
+              required: true
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: edb-license-sa
+        namespace: "{{ $.OperatorNs }}"
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: edb-license-role
+        namespace: "{{ $.OperatorNs }}"
+        data:
+          rules:
+          - apiGroups: [""]
+            resources: ["pods", "secrets"]
+            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"]
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: edb-license-rolebinding
+        namespace: "{{ $.OperatorNs }}"
+        data:
+          subjects:
+          - kind: ServiceAccount
+            name: edb-license-sa
+          roleRef:
+            kind: Role
+            name: edb-license-role
+            apiGroup: rbac.authorization.k8s.io
+  {{- end }}
+`
+
 const (
 	KeyCloakOpCon = `
 apiVersion: operator.ibm.com/v1alpha1
@@ -1751,6 +1809,46 @@ spec:
               supportedLocales: [ "en", "de" , "es", "fr", "it", "ja", "ko", "pt_BR", "zh_CN", "zh_TW"]
   - name: edb-keycloak
     resources:
+      - apiVersion: v1
+        kind: Secret
+        name: postgresql-operator-controller-manager-config
+        namespace: "{{ .OperatorNs }}"
+        annotations:
+          postgresql-operator-controller-manager-ready:
+            templatingValueFrom:
+              objectRef:
+                apiVersion: v1
+                kind: Pod
+                labelSelector:
+                  app.kubernetes.io/name: postgresql-operator-controller-manager
+                path: .metadata.name
+                namespace: {{ .OperatorNs }}
+              required: true
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: edb-license-sa
+        namespace: "{{ .OperatorNs }}"
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: edb-license-role
+        namespace: "{{ .OperatorNs }}"
+        data:
+          rules:
+          - apiGroups: [""]
+            resources: ["pods", "secrets"]
+            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"] 
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: edb-license-rolebinding
+        namespace: "{{ .OperatorNs }}"
+        data:
+          subjects:
+          - kind: ServiceAccount
+            name: edb-license-sa
+          roleRef:
+            kind: Role
+            name: edb-license-role
+            apiGroup: rbac.authorization.k8s.io
       - apiVersion: postgresql.k8s.enterprisedb.io/v1
         data:
           spec:
@@ -1759,6 +1857,15 @@ spec:
                 backup.velero.io/backup-volumes: pgdata,pg-wal
               labels:
                 foundationservices.cloudpak.ibm.com: keycloak
+            description:
+              templatingValueFrom:
+                objectRef:
+                  apiVersion: v1
+                  kind: Secret
+                  name: postgresql-operator-controller-manager-config
+                  path: .metadata.annotations.postgresql-operator-controller-manager-ready
+                  namespace: {{ .OperatorNs }}
+                required: true
             bootstrap:
               initdb:
                 database: keycloak
@@ -1953,6 +2060,15 @@ spec:
             inheritedMetadata:
               labels:
                 foundationservices.cloudpak.ibm.com: cs-db
+            description:
+              templatingValueFrom:
+                objectRef:
+                  apiVersion: v1
+                  kind: Secret
+                  name: postgresql-operator-controller-manager-config
+                  path: .metadata.annotations.postgresql-operator-controller-manager-ready
+                  namespace: {{ .OperatorNs }}
+                required: true
             bootstrap:
               initdb:
                 database: im

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1032,64 +1032,6 @@ spec:
 `
 )
 
-const EDBOpCon = `
-apiVersion: operator.ibm.com/v1alpha1
-kind: OperandConfig
-metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-spec:
-  services:
-  {{- range .ServiceNames.PostgreSQL }}
-  - name: {{ . }}
-    resources:
-      - apiVersion: v1
-        kind: Secret
-        name: postgresql-operator-controller-manager-config
-        namespace: "{{ $.OperatorNs }}"
-        annotations:
-          postgresql-operator-controller-manager-ready:
-            templatingValueFrom:
-              objectRef:
-                apiVersion: v1
-                kind: Pod
-                labelSelector:
-                  app.kubernetes.io/name: postgresql-operator-controller-manager
-                path: .metadata.name
-                namespace: {{ $.OperatorNs }}
-              required: true
-      - apiVersion: v1
-        kind: ServiceAccount
-        name: edb-license-sa
-        namespace: "{{ $.OperatorNs }}"
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        name: edb-license-role
-        namespace: "{{ $.OperatorNs }}"
-        data:
-          rules:
-          - apiGroups: [""]
-            resources: ["pods", "secrets"]
-            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"]
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        name: edb-license-rolebinding
-        namespace: "{{ $.OperatorNs }}"
-        data:
-          subjects:
-          - kind: ServiceAccount
-            name: edb-license-sa
-          roleRef:
-            kind: Role
-            name: edb-license-role
-            apiGroup: rbac.authorization.k8s.io
-  {{- end }}
-`
-
 const (
 	KeyCloakOpCon = `
 apiVersion: operator.ibm.com/v1alpha1
@@ -1809,46 +1751,6 @@ spec:
               supportedLocales: [ "en", "de" , "es", "fr", "it", "ja", "ko", "pt_BR", "zh_CN", "zh_TW"]
   - name: edb-keycloak
     resources:
-      - apiVersion: v1
-        kind: Secret
-        name: postgresql-operator-controller-manager-config
-        namespace: "{{ .OperatorNs }}"
-        annotations:
-          postgresql-operator-controller-manager-ready:
-            templatingValueFrom:
-              objectRef:
-                apiVersion: v1
-                kind: Pod
-                labelSelector:
-                  app.kubernetes.io/name: postgresql-operator-controller-manager
-                path: .metadata.name
-                namespace: {{ .OperatorNs }}
-              required: true
-      - apiVersion: v1
-        kind: ServiceAccount
-        name: edb-license-sa
-        namespace: "{{ .OperatorNs }}"
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: Role
-        name: edb-license-role
-        namespace: "{{ .OperatorNs }}"
-        data:
-          rules:
-          - apiGroups: [""]
-            resources: ["pods", "secrets"]
-            verbs: ["create", "update", "patch", "get", "list", "delete", "watch"] 
-      - apiVersion: rbac.authorization.k8s.io/v1
-        kind: RoleBinding
-        name: edb-license-rolebinding
-        namespace: "{{ .OperatorNs }}"
-        data:
-          subjects:
-          - kind: ServiceAccount
-            name: edb-license-sa
-          roleRef:
-            kind: Role
-            name: edb-license-role
-            apiGroup: rbac.authorization.k8s.io
       - apiVersion: postgresql.k8s.enterprisedb.io/v1
         data:
           spec:
@@ -1857,15 +1759,6 @@ spec:
                 backup.velero.io/backup-volumes: pgdata,pg-wal
               labels:
                 foundationservices.cloudpak.ibm.com: keycloak
-            description:
-              templatingValueFrom:
-                objectRef:
-                  apiVersion: v1
-                  kind: Secret
-                  name: postgresql-operator-controller-manager-config
-                  path: .metadata.annotations.postgresql-operator-controller-manager-ready
-                  namespace: {{ .OperatorNs }}
-                required: true
             bootstrap:
               initdb:
                 database: keycloak
@@ -2060,15 +1953,6 @@ spec:
             inheritedMetadata:
               labels:
                 foundationservices.cloudpak.ibm.com: cs-db
-            description:
-              templatingValueFrom:
-                objectRef:
-                  apiVersion: v1
-                  kind: Secret
-                  name: postgresql-operator-controller-manager-config
-                  path: .metadata.annotations.postgresql-operator-controller-manager-ready
-                  namespace: {{ .OperatorNs }}
-                required: true
             bootstrap:
               initdb:
                 database: im

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1820,17 +1820,6 @@ spec:
   services:
   - name: common-service-postgresql
     resources:
-      - apiVersion: operator.ibm.com/v1alpha1
-        data:
-          spec:
-            requests:
-              - operands:
-                  - name: cloud-native-postgresql-v1.25
-                registry: common-service
-                registryNamespace: {{ .ServicesNs }}
-        force: true
-        kind: OperandRequest
-        name: postgresql-operator-request
       - apiVersion: cert-manager.io/v1
         kind: Certificate
         name: common-service-db-replica-tls-cert


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove edb license job as it's no longer required and is causing edb to restart without a purpose which causes issues for other deployments. Remove all resources related to edb license.

**Which issue(s) this PR fixes**:
Fixes #https://github.ibm.com/IBMPrivateCloud/roadmap/issues/68424

**Special notes for your reviewer**:

1. How the test is done?
Normal installation flow. Check with install of edb and im. Make sure these changes don't mark the operator's readiness prematurely,