### PR TITLE
fix(pg28): update operator channel from v1.28 to v28

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -583,7 +583,7 @@ metadata:
     status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
-  - channel: v1.28
+  - channel: v28
     installPlanApproval: {{ .ApprovalMode }}
     name: common-service-cnpg
     namespace: "{{ .CPFSNs }}"
@@ -2684,8 +2684,8 @@ spec:
     configName: cloud-native-postgresql
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
-  - channel: v1.28
-    name: ibm-pg-operator-v1.28
+  - channel: v28
+    name: ibm-pg-operator-v28
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-pg-operator
     scope: public


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the PostgreSQL operator channel version from `v1.28` to `v28` across ODLM configuration files. The changes affect:
- The `common-service-cnpg` operator channel
- The `ibm-pg-operator` package name and channel references

This standardizes the channel naming convention by removing the `v1.` prefix and using just `v28`.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/ibm-pg/ibm-pg-operator/releases/tag/v28.1.0-rc1

**Special notes for your reviewer**:

1. How the test is done?
   - Verify that the ODLM operator definitions are correctly updated with the new channel version `v28`
   - Ensure the operator installation and upgrades work correctly with the updated channel naming
   - Test the deployment of common-service-cnpg and ibm-pg-operator with the new channel version

```console
➜  ~ oc get catalogsource ibm-pg-operator-catalog -oyaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: ibm-pg-operator-catalog
  namespace: edb-to-cnpg
spec:
  displayName: ibm-pg-operator-catalog
  grpcPodConfig:
    securityContextConfig: restricted
  image: preprod.icr.io/cpopen/ibm-pg-operator-catalog:v28.1.0-rc1
  publisher: IBM
  sourceType: grpc

➜  ~ oc get subscription | grep pg
ibm-pg-operator                            ibm-pg-operator               ibm-pg-operator-catalog           v28
➜  ~