### PR TITLE
Update IBM PG Cluster CR to use ibm-pg-operator-operand-images ConfigMap

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2305,8 +2305,8 @@ spec:
             imageName:
               templatingValueFrom:
                 configMapKeyRef:
-                  name: ibm-pg-operator-operand-images-config
-                  key: ibm-postgresql-16-operand-image
+                  name: ibm-pg-operator-operand-images
+                  key: postgres-16
                   namespace: {{ .OperatorNs }}
             imagePullSecrets:
               - name: {{ .ImagePullSecret }}


### PR DESCRIPTION
## Context
The IBM Common Service Operator needs to be updated to reference the new `ibm-pg-operator-operand-images` ConfigMap for PostgreSQL cluster images. The ConfigMap structure has changed from the previous `ibm-pg-operator-operand-images-config` format.

## ConfigMap reference
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: ibm-pg-operator-operand-images
  labels:
    olm.managed: 'true'
    operator.ibm.com/watched-by-odlm: 'true'
    operators.coreos.com/ibm-pg-operator.edb-to-cnpg: ''
data:
  postgres-16: 'preprod.icr.io/cpopen/ibm-pg/ibm-pg-16:16.13-v28.2.0@sha256:95ca22af8eccc33999123c1dfcc3d13920b37c7ce17fbce0404008f72c12636f'
  postgres-17: 'preprod.icr.io/cpopen/ibm-pg/ibm-pg-17:17.9-v28.2.0@sha256:8ea0a26b607eb7206f010f4b5777225d1dd5c68a48873e5cc8fe4c3a5914919a'
  postgres-18: 'preprod.icr.io/cpopen/ibm-pg/ibm-pg-18:18.3-v28.2.0@sha256:d243b288aebec796681387d808448dee0f766e0cf6c62e82b79a2b43b5456a64'
```

## Changes
- Changed ConfigMap name from `ibm-pg-operator-operand-images-config` to `ibm-pg-operator-operand-images`
- Changed key from `ibm-postgresql-16-operand-image` to `postgres-16`

## Test
```console
➜  oc get cluster.pg.ibm.com common-service-db -ojsonpath='{.spec.imageName}'
preprod.icr.io/cpopen/ibm-pg/ibm-pg-16:16.13-v28.2.0@sha256:95ca22af8eccc33999123c1dfcc3d13920b37c7ce17fbce0404008f72c12636f%     
                            
➜  oc get configmap ibm-pg-operator-operand-images -ojsonpath='{.data.postgres-16}'
preprod.icr.io/cpopen/ibm-pg/ibm-pg-16:16.13-v28.2.0@sha256:95ca22af8eccc33999123c1dfcc3d13920b37c7ce17fbce0404008f72c12636f%     
```