### PR TITLE
Backup and restore CPFS with IBM PG on OLM and Helm

### DIFF
--- a/br-testing-automation/fusion-backup-setup.sh
+++ b/br-testing-automation/fusion-backup-setup.sh
@@ -28,9 +28,9 @@ OUTPUT_FILE="${BASE_DIR}/env-fusion.properties"
 
 function main() {
     parse_arguments "$@"
-    prereq
     info "Base Directory: $BASE_DIR"
     source $OUTPUT_FILE
+    prereq
     if [[ $HUB_SETUP == "true" ]]; then
         save_log "logs" "hub_setup_log"
         trap cleanup_log EXIT
@@ -113,6 +113,32 @@ function parse_arguments() {
         shift
     done
     echo ""
+}
+
+# Detect PostgreSQL operator type for zen-metastore cluster
+function detect_zen_operator() {
+  local namespace=$1
+  
+  # Check for IBM CloudNativePG cluster (zen-metastore without -edb suffix)
+  IBM_PG_CLUSTER=$(${OC} get cluster.pg.ibm.com zen-metastore -n $namespace --ignore-not-found 2>/dev/null)
+  if [[ -n $IBM_PG_CLUSTER ]]; then
+    info "Detected IBM CNPG cluster for zen-metastore in namespace $namespace"
+    echo "ibm-pg"
+    return 0
+  fi
+  
+  # Check for EDB cluster (zen-metastore-edb with -edb suffix)
+  EDB_CLUSTER=$(${OC} get cluster.postgresql.k8s.enterprisedb.io zen-metastore-edb -n $namespace --ignore-not-found 2>/dev/null)
+  if [[ -n $EDB_CLUSTER ]]; then
+    info "Detected EDB cluster for zen-metastore-edb in namespace $namespace"
+    echo "edb"
+    return 0
+  fi
+  
+  # Default to EDB if no cluster found (backward compatibility)
+  warning "No PostgreSQL cluster found for zen-metastore in namespace $namespace, defaulting to EDB"
+  echo "edb"
+  return 0
 }
 
 function prereq() {
@@ -393,7 +419,19 @@ function create_sf_resources(){
         #core recipes
         if [[ $NO_OLM == "true" ]]; then
             cp ../velero/spectrum-fusion/recipes/no-olm/core/child-csdb-recipe-2.10.0.yaml ./templates/child-csdb-recipe.yaml
-            cp ../velero/spectrum-fusion/recipes/no-olm/core/child-zen-recipe-2.10.0.yaml ./templates/child-zen-recipe.yaml
+            
+            # Detect PostgreSQL operator type for zen-metastore and copy appropriate recipe
+            if [[ $ZEN_ENABLED == "true" ]]; then
+                ZEN_OPERATOR=$(detect_zen_operator $SERVICES_NS)
+                if [[ $ZEN_OPERATOR == "ibm-pg" ]]; then
+                    info "Using IBM CNPG zen recipe for namespace $SERVICES_NS"
+                    cp ../velero/spectrum-fusion/recipes/no-olm/core/child-zen-recipe-ibm-pg.yaml ./templates/child-zen-recipe.yaml
+                else
+                    info "Using EDB zen recipe for namespace $SERVICES_NS"
+                    cp ../velero/spectrum-fusion/recipes/no-olm/core/child-zen-recipe-2.10.0.yaml ./templates/child-zen-recipe.yaml
+                fi
+            fi
+            
             cp ../velero/spectrum-fusion/recipes/no-olm/core/parent-cpfs-recipe.yaml ./templates/parent-cpfs-recipe.yaml
             cp ../velero/spectrum-fusion/recipes/no-olm/core/child-cs-odlm-chart-recipe.yaml ./templates/child-cs-odlm-chart-recipe.yaml
             cp ../velero/spectrum-fusion/recipes/no-olm/core/child-edb-chart-recipe.yaml ./templates/child-edb-chart-recipe.yaml
@@ -403,7 +441,19 @@ function create_sf_resources(){
             cp ../velero/spectrum-fusion/recipes/no-olm/core/peripheral-resources.yaml ./templates/peripheral-resources.yaml
         else
             cp ../velero/spectrum-fusion/recipes/dynamic-recipes/core/child-csdb-recipe-2.10.0.yaml ./templates/child-csdb-recipe.yaml
-            cp ../velero/spectrum-fusion/recipes/dynamic-recipes/core/child-zen-recipe-2.10.0.yaml ./templates/child-zen-recipe.yaml
+            
+            # Detect PostgreSQL operator type for zen-metastore and copy appropriate recipe
+            if [[ $ZEN_ENABLED == "true" ]]; then
+                ZEN_OPERATOR=$(detect_zen_operator $SERVICES_NS)
+                if [[ $ZEN_OPERATOR == "ibm-pg" ]]; then
+                    info "Using IBM CNPG zen recipe for namespace $SERVICES_NS"
+                    cp ../velero/spectrum-fusion/recipes/dynamic-recipes/core/child-zen-recipe-ibm-pg.yaml ./templates/child-zen-recipe.yaml
+                else
+                    info "Using EDB zen recipe for namespace $SERVICES_NS"
+                    cp ../velero/spectrum-fusion/recipes/dynamic-recipes/core/child-zen-recipe-2.10.0.yaml ./templates/child-zen-recipe.yaml
+                fi
+            fi
+            
             cp ../velero/spectrum-fusion/recipes/dynamic-recipes/core/child-nss-recipe.yaml ./templates/child-nss-recipe.yaml
             cp ../velero/spectrum-fusion/recipes/dynamic-recipes/core/parent-cpfs-recipe.yaml ./templates/parent-cpfs-recipe.yaml
             cp ../velero/spectrum-fusion/recipes/dynamic-recipes/core/peripheral-resources.yaml ./templates/peripheral-resources.yaml

--- a/velero/backup/backup.yaml
+++ b/velero/backup/backup.yaml
@@ -58,6 +58,8 @@ spec:
       - zen-cluster
       - edb-chart
       - edb-cluster
+      - ibm-pg-chart
+      - ibm-pg-cluster
       - iam-chart
       - iam-cluster
       - nss-cluster

--- a/velero/backup/cert-manager/label-cert-manager.sh
+++ b/velero/backup/cert-manager/label-cert-manager.sh
@@ -235,6 +235,17 @@ function label_all_resources(){
                     oc label certificate ibm-zen-metastore-edb-certificate -n $namespace foundationservices.cloudpak.ibm.com-
                 done
             fi
+
+            #remove label from metastore-db certificate and secret
+            metastore_secret_ns_list=$(oc get secret -n $namespace --no-headers | grep  ibm-zen-metastore-secret | awk '{print $1}' | tr "\n" " ")
+            if [[ $metastore_secret_ns_list != "" ]]; then
+                info "removing label from zen-metastore-secret and certificate."
+                for ns in $metastore_secret_ns_list
+                do
+                    oc label secret ibm-zen-metastore-secret -n $namespace foundationservices.cloudpak.ibm.com-
+                    oc label certificate ibm-zen-metastore-certificate -n $namespace foundationservices.cloudpak.ibm.com-
+                done
+            fi
         done
     else
         #CRDS
@@ -394,6 +405,17 @@ function label_all_resources(){
             do
                 oc label secret ibm-zen-metastore-edb-secret -n $ns foundationservices.cloudpak.ibm.com-
                 oc label certificate ibm-zen-metastore-edb-certificate -n $ns foundationservices.cloudpak.ibm.com-
+            done
+        fi
+
+        #remove label from metastore-db certificate and secret
+        metastore_secret_ns_list=$(oc get secret -n $namespace --no-headers | grep  ibm-zen-metastore-secret | awk '{print $1}' | tr "\n" " ")
+        if [[ $metastore_secret_ns_list != "" ]]; then
+            info "removing label from zen-metastore-secret and certificate."
+            for ns in $metastore_secret_ns_list
+            do
+                oc label secret ibm-zen-metastore-secret -n $namespace foundationservices.cloudpak.ibm.com-
+                oc label certificate ibm-zen-metastore-certificate -n $namespace foundationservices.cloudpak.ibm.com-
             done
         fi
     fi

--- a/velero/backup/cert-manager/label-cert-manager.sh
+++ b/velero/backup/cert-manager/label-cert-manager.sh
@@ -409,7 +409,7 @@ function label_all_resources(){
         fi
 
         #remove label from metastore-db certificate and secret
-        metastore_secret_ns_list=$(oc get secret -n $namespace --no-headers | grep  ibm-zen-metastore-secret | awk '{print $1}' | tr "\n" " ")
+        metastore_secret_ns_list=$(oc get secret -A --no-headers | grep  ibm-zen-metastore-secret | awk '{print $1}' | tr "\n" " ")
         if [[ $metastore_secret_ns_list != "" ]]; then
             info "removing label from zen-metastore-secret and certificate."
             for ns in $metastore_secret_ns_list

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -566,14 +566,13 @@ function label_helm_cluster_scope(){
 
     #ibm-pg (crds, clusterrole, clusterrolebinding, webhooks) 
     ${OC} label crd backups.pg.ibm.com clusterimagecatalogs.pg.ibm.com clusters.pg.ibm.com databases.pg.ibm.com failoverquorums.pg.ibm.com imagecatalogs.pg.ibm.com poolers.pg.ibm.com publications.pg.ibm.com scheduledbackups.pg.ibm.com subscriptions.pg.ibm.com foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
-    ${OC} label clusterrole postgresql-operator-controller-manager-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
-    ${OC} label clusterrolebinding postgresql-operator-controller-manager-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
-
+    ${OC} label clusterrole ibm-pg-operator-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
+    ${OC} label clusterrolebinding ibm-pg-operator-rolebinding-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
     ${OC} label validatingwebhookconfiguration ibm-pg-validating-webhook-configuration-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
     ${OC} label mutatingwebhookconfiguration ibm-pg-mutating-webhook-configuration-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
     ibm_pg_release_name=$(${OC} get crd clusters.pg.ibm.com -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' --ignore-not-found)
     ibm_pg_release_namespace=$(${OC} get crd clusters.pg.ibm.com -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-namespace}' --ignore-not-found)
-    ${OC} label secret sh.helm.release.v1.$ibm_pg_release_name.v1 -n $edb_release_namespace foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
+    ${OC} label secret sh.helm.release.v1.$ibm_pg_release_name.v1 -n $ibm_pg_release_namespace foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
 
 
     #zen? (crds, clusterrole, clusterrolebinding)
@@ -668,6 +667,21 @@ function label_helm_namespace_scope(){
     edb_release_namespace=$(${OC} get deploy $deploy -n $OPERATOR_NS -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-namespace}' --ignore-not-found)
     ${OC} label secret sh.helm.release.v1.$edb_release_name.v1 -n $edb_release_namespace foundationservices.cloudpak.ibm.com=edb-chart  --overwrite=true 2>/dev/null
 
+    #IBM PG
+    deploy=$(${OC} get deploy -n $OPERATOR_NS | grep ibm-pg-operator | awk '{print $1}')
+    ${OC} label deployment $deploy foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label configmap ibm-pg-operator-operand-images ibm-pg-default-monitoring ibm-pg-operator-config foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label service ibm-pg-webhook-service foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label serviceaccount ibm-pg-operator foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label role ibm-pg-operator foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label rolebinding ibm-pg-operator-rolebinding foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $OPERATOR_NS --overwrite=true 2>/dev/null
+    ${OC} label role ibm-pg-operator foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ${OC} label rolebinding ibm-pg-operator-rolebinding foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $SERVICES_NS --overwrite=true 2>/dev/null
+    ibm-pg_release_name=$(${OC} get deploy $deploy -n $OPERATOR_NS -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' --ignore-not-found)
+    ibm-pg_release_namespace=$(${OC} get deploy $deploy -n $OPERATOR_NS -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-namespace}' --ignore-not-found)
+    ${OC} label secret sh.helm.release.v1.$ibm-pg_release_name.v1 -n $ibm-pg_release_namespace foundationservices.cloudpak.ibm.com=ibm-pg-chart  --overwrite=true 2>/dev/null
+
+
     #zen
     ${OC} label deploy ibm-zen-operator foundationservices.cloudpak.ibm.com=zen-chart -n $OPERATOR_NS --overwrite=true 2>/dev/null
     #zenservice covered in label_ns_and_related function
@@ -699,6 +713,11 @@ function label_helm_namespace_scope(){
             #ui
             ${OC} label role ibm-commonui-operator foundationservices.cloudpak.ibm.com=ui-chart -n $namespace --overwrite=true 2>/dev/null
             ${OC} label rolebinding ibm-commonui-operator foundationservices.cloudpak.ibm.com=ui-chart -n $namespace --overwrite=true 2>/dev/null
+
+            #ibm-pg
+            ${OC} label role ibm-pg-operator foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $namespace --overwrite=true 2>/dev/null
+            ${OC} label rolebinding ibm-pg-operator-rolebinding foundationservices.cloudpak.ibm.com=ibm-pg-chart -n $namespace --overwrite=true 2>/dev/null
+
 
             # UMS (add deployment, serviceaccounts, roles, rolebindings, configmap, CRs)
             ${OC} label deployment ibm-usage-metering-operator foundationservices.cloudpak.ibm.com=ums -n $namespace --overwrite=true 2>/dev/null || true

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -249,13 +249,14 @@ function label_ibm_catalogsources() {
 
     # Label the CatalogSource with ".spec.publisher: IBM" in private namespace
     local ibm_catalogsources=""
-    while IFS=' ' read -r -a sources; do
-        for source in "${sources[@]}"; do
-            if ${OC} get catalogsource "$source" -n "$namespace" -o json | grep -q '"publisher": *"IBM"*'; then
-                ibm_catalogsources+=" $source"
-            fi
-        done
-    done <<< "$(${OC} get catalogsource -n "$namespace" -o jsonpath='{.items[*].metadata.name}')"
+    local sources_list
+    sources_list=$(${OC} get catalogsource -n "$namespace" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+    
+    for source in $sources_list; do
+        if ${OC} get catalogsource "$source" -n "$namespace" -o json 2>/dev/null | grep -q '"publisher": *"IBM"*'; then
+            ibm_catalogsources+=" $source"
+        fi
+    done
     
     # Add additional catalog sources
     ibm_catalogsources="${ADDITIONAL_SOURCES}${ibm_catalogsources}"
@@ -416,11 +417,11 @@ function label_lsr() {
 
     info "Start to label the necessary secrets"
     secrets=$(${OC} get secrets -n $LSR_NAMESPACE | grep ibm-license-service-reporter-token | cut -d ' ' -f1)
-    for secret in ${secrets[@]}; do
+    for secret in $secrets; do
         ${OC} label secret $secret foundationservices.cloudpak.ibm.com=lsr -n $LSR_NAMESPACE --overwrite=true 2>/dev/null
-    done    
+    done
     secrets=$(${OC} get secrets -n $LSR_NAMESPACE | grep ibm-license-service-reporter-credential | cut -d ' ' -f1)
-    for secret in ${secrets[@]}; do
+    for secret in $secrets; do
         ${OC} label secret $secret foundationservices.cloudpak.ibm.com=lsr -n $LSR_NAMESPACE --overwrite=true 2>/dev/null
     done
 

--- a/velero/backup/common-service/label-common-service.sh
+++ b/velero/backup/common-service/label-common-service.sh
@@ -564,6 +564,18 @@ function label_helm_cluster_scope(){
     edb_release_namespace=$(${OC} get crd clusters.postgresql.k8s.enterprisedb.io -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-namespace}' --ignore-not-found)
     ${OC} label secret sh.helm.release.v1.$edb_release_name.v1 -n $edb_release_namespace foundationservices.cloudpak.ibm.com=edb-cluster  --overwrite=true 2>/dev/null
 
+    #ibm-pg (crds, clusterrole, clusterrolebinding, webhooks) 
+    ${OC} label crd backups.pg.ibm.com clusterimagecatalogs.pg.ibm.com clusters.pg.ibm.com databases.pg.ibm.com failoverquorums.pg.ibm.com imagecatalogs.pg.ibm.com poolers.pg.ibm.com publications.pg.ibm.com scheduledbackups.pg.ibm.com subscriptions.pg.ibm.com foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
+    ${OC} label clusterrole postgresql-operator-controller-manager-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
+    ${OC} label clusterrolebinding postgresql-operator-controller-manager-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
+
+    ${OC} label validatingwebhookconfiguration ibm-pg-validating-webhook-configuration-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
+    ${OC} label mutatingwebhookconfiguration ibm-pg-mutating-webhook-configuration-$OPERATOR_NS foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
+    ibm_pg_release_name=$(${OC} get crd clusters.pg.ibm.com -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' --ignore-not-found)
+    ibm_pg_release_namespace=$(${OC} get crd clusters.pg.ibm.com -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-namespace}' --ignore-not-found)
+    ${OC} label secret sh.helm.release.v1.$ibm_pg_release_name.v1 -n $edb_release_namespace foundationservices.cloudpak.ibm.com=ibm-pg-cluster  --overwrite=true 2>/dev/null
+
+
     #zen? (crds, clusterrole, clusterrolebinding)
     #assuming we are still responsible for zen
     #CRD covered in label_ns_and_related function

--- a/velero/restore/no-olm/restore-cluster-scope.yaml
+++ b/velero/restore/no-olm/restore-cluster-scope.yaml
@@ -27,5 +27,6 @@ spec:
       - ui-cluster
       - zen-cluster
       - edb-cluster
+      - ibm-pg-cluster
       - iam-cluster
       - nss-cluster

--- a/velero/restore/no-olm/restore-im-ns-charts.yaml
+++ b/velero/restore/no-olm/restore-im-ns-charts.yaml
@@ -24,4 +24,5 @@ spec:
       values:
       - ui-chart
       - edb-chart
+      - ibm-pg-chart
       - iam-chart

--- a/velero/restore/no-olm/restore-namespace-scope.yaml
+++ b/velero/restore/no-olm/restore-namespace-scope.yaml
@@ -27,5 +27,6 @@ spec:
       - ui-chart
       - zen-chart
       - edb-chart
+      - ibm-pg-chart
       - iam-chart
       - nss

--- a/velero/restore/restore-cluster-auto.yaml
+++ b/velero/restore/restore-cluster-auto.yaml
@@ -47,6 +47,7 @@ spec:
       - nss
       - ui-chart
       - edb-chart
+      - ibm-pg-chat
       - iam-chart
       - cs-chart
       - odlm-chart

--- a/velero/schedule/deploy-br-resources.sh
+++ b/velero/schedule/deploy-br-resources.sh
@@ -155,6 +155,58 @@ function print_usage() {
   echo ""
 }
 
+# Detect PostgreSQL operator type for common-service-db cluster
+function detect_csdb_operator() {
+  local namespace=$1
+  
+  # Check for IBM CloudNativePG cluster
+  IBM_PG_CLUSTER=$(oc get cluster.pg.ibm.com common-service-db -n $namespace --ignore-not-found 2>/dev/null)
+  if [[ -n $IBM_PG_CLUSTER ]]; then
+    info "Detected IBM CNPG cluster for common-service-db in namespace $namespace"
+    echo "ibm-pg"
+    return 0
+  fi
+  
+  # Check for EDB cluster
+  EDB_CLUSTER=$(oc get cluster.postgresql.k8s.enterprisedb.io common-service-db -n $namespace --ignore-not-found 2>/dev/null)
+  if [[ -n $EDB_CLUSTER ]]; then
+    info "Detected EDB cluster for common-service-db in namespace $namespace"
+    echo "edb"
+    return 0
+  fi
+  
+  # Default to EDB if no cluster found (backward compatibility)
+  warning "No PostgreSQL cluster found for common-service-db in namespace $namespace, defaulting to EDB"
+  echo "edb"
+  return 0
+}
+
+# Detect PostgreSQL operator type for zen-metastore cluster
+function detect_zen_operator() {
+  local namespace=$1
+  
+  # Check for IBM CloudNativePG cluster (zen-metastore without -edb suffix)
+  IBM_PG_CLUSTER=$(oc get cluster.pg.ibm.com zen-metastore -n $namespace --ignore-not-found 2>/dev/null)
+  if [[ -n $IBM_PG_CLUSTER ]]; then
+    info "Detected IBM CNPG cluster for zen-metastore in namespace $namespace"
+    echo "ibm-pg"
+    return 0
+  fi
+  
+  # Check for EDB cluster (zen-metastore-edb with -edb suffix)
+  EDB_CLUSTER=$(oc get cluster.postgresql.k8s.enterprisedb.io zen-metastore-edb -n $namespace --ignore-not-found 2>/dev/null)
+  if [[ -n $EDB_CLUSTER ]]; then
+    info "Detected EDB cluster for zen-metastore-edb in namespace $namespace"
+    echo "edb"
+    return 0
+  fi
+  
+  # Default to EDB if no cluster found (backward compatibility)
+  warning "No PostgreSQL cluster found for zen-metastore in namespace $namespace, defaulting to EDB"
+  echo "edb"
+  return 0
+}
+
 function deploy_resources(){
   if [[ $STORAGE_CLASS == "default" ]]; then
     STORAGE_CLASS=$(oc get sc | grep default | awk '{print $1}')
@@ -163,18 +215,34 @@ function deploy_resources(){
     info "Using specified storage class $STORAGE_CLASS."
   fi
 
-  #deploy IM EDB resources
+  #deploy IM resources (EDB or IBM CNPG)
   if [[ $IM == "true" ]]; then
     info "Creating IM Backup/Restore resources in namespace $TARGET_NAMESPACE."
     
+    # Detect operator type for common-service-db cluster specifically
+    CSDB_OPERATOR=$(detect_csdb_operator $TARGET_NAMESPACE)
+    
     rm -rf tmp/common-service-db/
     mkdir tmp/common-service-db
-    cp ${BASE_DIR}/common-service-db/cs-db-backup-deployment.yaml tmp/common-service-db/cs-db-backup-deployment.yaml
-    cp ${BASE_DIR}/common-service-db/cs-db-backup-pvc.yaml tmp/common-service-db/cs-db-backup-pvc.yaml
-    cp ${BASE_DIR}/common-service-db/cs-db-role.yaml tmp/common-service-db/cs-db-role.yaml
-    cp ${BASE_DIR}/common-service-db/cs-db-rolebinding.yaml tmp/common-service-db/cs-db-rolebinding.yaml
-    cp ${BASE_DIR}/common-service-db/cs-db-sa.yaml tmp/common-service-db/cs-db-sa.yaml
-    cp ${BASE_DIR}/common-service-db/cs-db-br-script-cm-4.6.10.4.11.yaml tmp/common-service-db/cs-db-br-script-cm.yaml
+    
+    # Select appropriate resources based on cluster's operator type
+    if [[ $CSDB_OPERATOR == "ibm-pg" ]]; then
+      info "Deploying IBM CNPG resources for common-service-db"
+      cp ${BASE_DIR}/ibm-pg/common-service-db/cs-db-backup-deployment.yaml tmp/common-service-db/cs-db-backup-deployment.yaml
+      cp ${BASE_DIR}/ibm-pg/common-service-db/cs-db-backup-pvc.yaml tmp/common-service-db/cs-db-backup-pvc.yaml
+      cp ${BASE_DIR}/ibm-pg/common-service-db/cs-db-role.yaml tmp/common-service-db/cs-db-role.yaml
+      cp ${BASE_DIR}/ibm-pg/common-service-db/cs-db-rolebinding.yaml tmp/common-service-db/cs-db-rolebinding.yaml
+      cp ${BASE_DIR}/ibm-pg/common-service-db/cs-db-sa.yaml tmp/common-service-db/cs-db-sa.yaml
+      cp ${BASE_DIR}/ibm-pg/common-service-db/cs-db-br-script-cm.yaml tmp/common-service-db/cs-db-br-script-cm.yaml
+    else
+      info "Deploying EDB resources for common-service-db"
+      cp ${BASE_DIR}/common-service-db/cs-db-backup-deployment.yaml tmp/common-service-db/cs-db-backup-deployment.yaml
+      cp ${BASE_DIR}/common-service-db/cs-db-backup-pvc.yaml tmp/common-service-db/cs-db-backup-pvc.yaml
+      cp ${BASE_DIR}/common-service-db/cs-db-role.yaml tmp/common-service-db/cs-db-role.yaml
+      cp ${BASE_DIR}/common-service-db/cs-db-rolebinding.yaml tmp/common-service-db/cs-db-rolebinding.yaml
+      cp ${BASE_DIR}/common-service-db/cs-db-sa.yaml tmp/common-service-db/cs-db-sa.yaml
+      cp ${BASE_DIR}/common-service-db/cs-db-br-script-cm-4.6.10.4.11.yaml tmp/common-service-db/cs-db-br-script-cm.yaml
+    fi
 
     sed -i -E "s/<cs-db namespace>/$TARGET_NAMESPACE/" tmp/common-service-db/cs-db-backup-deployment.yaml
     sed -i -E "s/<cs-db namespace>/$TARGET_NAMESPACE/" tmp/common-service-db/cs-db-backup-pvc.yaml
@@ -184,7 +252,7 @@ function deploy_resources(){
     sed -i -E "s/<cs-db namespace>/$TARGET_NAMESPACE/" tmp/common-service-db/cs-db-sa.yaml
     sed -i -E "s/<cs-db namespace>/$TARGET_NAMESPACE/" tmp/common-service-db/cs-db-br-script-cm.yaml
     oc apply -f tmp/common-service-db -n $TARGET_NAMESPACE || error "Unable to deploy resources for IM."
-    success "Resources to backup IM deployed in namespace $TARGET_NAMESPACE."
+    success "Resources to backup IM deployed in namespace $TARGET_NAMESPACE with $CSDB_OPERATOR operator support."
   fi
 
   #Deploy IM Mongo resources
@@ -227,7 +295,7 @@ function deploy_resources(){
     success "Resources to backup Keycloak deployed in namespace $TARGET_NAMESPACE."
   fi
 
-  #Deploy zen 5 resources
+  #Deploy zen 5 resources (EDB or IBM CNPG)
   if [[ $ZEN == "true" ]]; then
     if [[ $ZENSERVICE == "" ]]; then
       ZENSERVICE=$(oc get zenservice -n $ZEN_NAMESPACE --no-headers | awk '{print $1}')
@@ -239,14 +307,30 @@ function deploy_resources(){
       else
         info "Creating Zen Backup/Restore resources in namespace $ZEN_NAMESPACE."
         
+        # Detect operator type for zen-metastore cluster specifically
+        ZEN_OPERATOR=$(detect_zen_operator $ZEN_NAMESPACE)
+        
         rm -rf tmp/zen/
         mkdir tmp/zen
-        cp ${BASE_DIR}/zen5-backup-deployment.yaml tmp/zen/zen5-backup-deployment.yaml
-        cp ${BASE_DIR}/zen5-backup-pvc.yaml tmp/zen/zen5-backup-pvc.yaml
-        cp ${BASE_DIR}/zen5-role.yaml tmp/zen/zen5-role.yaml
-        cp ${BASE_DIR}/zen5-rolebinding.yaml tmp/zen/zen5-rolebinding.yaml
-        cp ${BASE_DIR}/zen5-sa.yaml tmp/zen/zen5-sa.yaml
-        cp ${BASE_DIR}/zen5-br-scripts-cm.yaml tmp/zen/zen5-br-scripts-cm.yaml
+        
+        # Select appropriate resources based on cluster's operator type
+        if [[ $ZEN_OPERATOR == "ibm-pg" ]]; then
+          info "Deploying IBM CNPG resources for zen-metastore"
+          cp ${BASE_DIR}/ibm-pg/zen-metastore/zen5-backup-deployment.yaml tmp/zen/zen5-backup-deployment.yaml
+          cp ${BASE_DIR}/ibm-pg/zen-metastore/zen5-backup-pvc.yaml tmp/zen/zen5-backup-pvc.yaml
+          cp ${BASE_DIR}/ibm-pg/zen-metastore/zen5-role.yaml tmp/zen/zen5-role.yaml
+          cp ${BASE_DIR}/ibm-pg/zen-metastore/zen5-rolebinding.yaml tmp/zen/zen5-rolebinding.yaml
+          cp ${BASE_DIR}/ibm-pg/zen-metastore/zen5-sa.yaml tmp/zen/zen5-sa.yaml
+          cp ${BASE_DIR}/ibm-pg/zen-metastore/zen5-br-scripts-cm.yaml tmp/zen/zen5-br-scripts-cm.yaml
+        else
+          info "Deploying EDB resources for zen-metastore"
+          cp ${BASE_DIR}/zen5-backup-deployment.yaml tmp/zen/zen5-backup-deployment.yaml
+          cp ${BASE_DIR}/zen5-backup-pvc.yaml tmp/zen/zen5-backup-pvc.yaml
+          cp ${BASE_DIR}/zen5-role.yaml tmp/zen/zen5-role.yaml
+          cp ${BASE_DIR}/zen5-rolebinding.yaml tmp/zen/zen5-rolebinding.yaml
+          cp ${BASE_DIR}/zen5-sa.yaml tmp/zen/zen5-sa.yaml
+          cp ${BASE_DIR}/zen5-br-scripts-cm.yaml tmp/zen/zen5-br-scripts-cm.yaml
+        fi
 
         sed -i -E "s/<zenservice namespace>/$ZEN_NAMESPACE/" tmp/zen/zen5-backup-deployment.yaml
         sed -i -E "s/<zenservice name>/$ZENSERVICE/" tmp/zen/zen5-backup-deployment.yaml
@@ -257,7 +341,7 @@ function deploy_resources(){
         sed -i -E "s/<zenservice namespace>/$ZEN_NAMESPACE/" tmp/zen/zen5-sa.yaml
         sed -i -E "s/<zenservice namespace>/$ZEN_NAMESPACE/" tmp/zen/zen5-br-scripts-cm.yaml
         oc apply -f tmp/zen -n $ZEN_NAMESPACE || error "Unable to deploy resources for Zen 5."   
-        success "Resources to backup Zen deployed in namespace $ZEN_NAMESPACE."
+        success "Resources to backup Zen deployed in namespace $ZEN_NAMESPACE with $ZEN_OPERATOR operator support."
       fi
     else
       warning "No zenservice found in namespace $ZEN_NAMESPACE. Skipping."

--- a/velero/schedule/deploy-br-resources.sh
+++ b/velero/schedule/deploy-br-resources.sh
@@ -162,7 +162,7 @@ function detect_csdb_operator() {
   # Check for IBM CloudNativePG cluster
   IBM_PG_CLUSTER=$(oc get cluster.pg.ibm.com common-service-db -n $namespace --ignore-not-found 2>/dev/null)
   if [[ -n $IBM_PG_CLUSTER ]]; then
-    info "Detected IBM CNPG cluster for common-service-db in namespace $namespace"
+    info "Detected IBM CNPG cluster for common-service-db in namespace $namespace" >&2
     echo "ibm-pg"
     return 0
   fi
@@ -170,13 +170,13 @@ function detect_csdb_operator() {
   # Check for EDB cluster
   EDB_CLUSTER=$(oc get cluster.postgresql.k8s.enterprisedb.io common-service-db -n $namespace --ignore-not-found 2>/dev/null)
   if [[ -n $EDB_CLUSTER ]]; then
-    info "Detected EDB cluster for common-service-db in namespace $namespace"
+    info "Detected EDB cluster for common-service-db in namespace $namespace" >&2
     echo "edb"
     return 0
   fi
   
   # Default to EDB if no cluster found (backward compatibility)
-  warning "No PostgreSQL cluster found for common-service-db in namespace $namespace, defaulting to EDB"
+  warning "No PostgreSQL cluster found for common-service-db in namespace $namespace, defaulting to EDB" >&2
   echo "edb"
   return 0
 }
@@ -188,7 +188,7 @@ function detect_zen_operator() {
   # Check for IBM CloudNativePG cluster (zen-metastore without -edb suffix)
   IBM_PG_CLUSTER=$(oc get cluster.pg.ibm.com zen-metastore -n $namespace --ignore-not-found 2>/dev/null)
   if [[ -n $IBM_PG_CLUSTER ]]; then
-    info "Detected IBM CNPG cluster for zen-metastore in namespace $namespace"
+    info "Detected IBM CNPG cluster for zen-metastore in namespace $namespace" >&2
     echo "ibm-pg"
     return 0
   fi
@@ -196,13 +196,13 @@ function detect_zen_operator() {
   # Check for EDB cluster (zen-metastore-edb with -edb suffix)
   EDB_CLUSTER=$(oc get cluster.postgresql.k8s.enterprisedb.io zen-metastore-edb -n $namespace --ignore-not-found 2>/dev/null)
   if [[ -n $EDB_CLUSTER ]]; then
-    info "Detected EDB cluster for zen-metastore-edb in namespace $namespace"
+    info "Detected EDB cluster for zen-metastore-edb in namespace $namespace" >&2
     echo "edb"
     return 0
   fi
   
   # Default to EDB if no cluster found (backward compatibility)
-  warning "No PostgreSQL cluster found for zen-metastore in namespace $namespace, defaulting to EDB"
+  warning "No PostgreSQL cluster found for zen-metastore in namespace $namespace, defaulting to EDB" >&2
   echo "edb"
   return 0
 }

--- a/velero/schedule/ibm-pg/common-service-db/cs-db-backup-deployment.yaml
+++ b/velero/schedule/ibm-pg/common-service-db/cs-db-backup-deployment.yaml
@@ -1,0 +1,71 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: cs-db-backup
+  namespace: <cs-db namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: cs-db-data
+spec:
+  selector:
+    matchLabels:
+      foundationservices.cloudpak.ibm.com: cs-db-data
+  template:
+    metadata:
+      annotations:
+        backup.velero.io/backup-volumes: cs-db-backup
+        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /cs-db/cs-db-backup/database; /cs-db/br_cs-db.sh backup <cs-db namespace>"]'
+        pre.hook.backup.velero.io/on-error: Fail
+        pre.hook.backup.velero.io/timeout: 300s
+        post.hook.restore.velero.io/command: '["sh", "-c", "/cs-db/br_cs-db.sh restore <cs-db namespace>"]'
+        post.hook.restore.velero.io/on-error: Fail
+        post.hook.restore.velero.io/wait-timeout: 300s
+        post.hook.restore.velero.io/exec-timeout: 300s
+        post.hook.restore.velero.io/timeout: 720s
+      name: cs-db-backup
+      namespace: <cs-db namespace>
+      labels:
+        foundationservices.cloudpak.ibm.com: cs-db-data
+    spec:
+        containers:
+        - command:
+          - sh
+          - -c
+          - sleep infinity
+          image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2
+          imagePullPolicy: IfNotPresent
+          name: cs-db-br
+          resources:
+            limits:
+              cpu: 500m
+              ephemeral-storage: 512Mi
+              memory: 512Mi
+            requests:
+              cpu: 200m
+              ephemeral-storage: 128Mi
+              memory: 256Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+          - mountPath: /cs-db/cs-db-backup
+            name: cs-db-backup-mount
+          - name: scripts
+            mountPath: "/cs-db"
+          - mountPath: /cs-db/cs-db-backup/logs
+            name: logs
+        dnsPolicy: ClusterFirst
+        schedulerName: default-scheduler
+        securityContext:
+          runAsNonRoot: true
+        serviceAccount: cs-db-backup-sa
+        serviceAccountName: cs-db-backup-sa
+        terminationGracePeriodSeconds: 30
+        volumes:
+        - name: cs-db-backup-mount
+          persistentVolumeClaim:
+            claimName: cs-db-backup-pvc
+        - name: scripts
+          configMap:
+            name: cs-db-br-configmap
+            defaultMode: 0777
+        - emptyDir: {}
+          name: logs

--- a/velero/schedule/ibm-pg/common-service-db/cs-db-backup-pvc.yaml
+++ b/velero/schedule/ibm-pg/common-service-db/cs-db-backup-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cs-db-backup-pvc
+  namespace: <cs-db namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: cs-db-data
+spec:
+  storageClassName: <storage class>
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  volumeMode: Filesystem

--- a/velero/schedule/ibm-pg/common-service-db/cs-db-br-script-cm.yaml
+++ b/velero/schedule/ibm-pg/common-service-db/cs-db-br-script-cm.yaml
@@ -1,0 +1,344 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cs-db-br-configmap
+  namespace: <cs-db namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: cs-db-data
+data:
+  br_cs-db.sh: |
+    #!/usr/bin/env bash
+
+    # Licensed Materials - Property of IBM
+    # Copyright IBM Corporation 2024. All Rights Reserved
+    # US Government Users Restricted Rights -
+    # Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+    #
+    # This is an internal component, bundled with an official IBM product.
+    # Please refer to that particular license for additional information.
+
+    # ---------- Command arguments ----------
+
+    set -o errtrace
+    set -o errexit
+
+    MODE=$1
+    CSDB_NAMESPACE=$2
+    CLUSTER_CR=common-service-db
+
+    BACKUP_DIR=/cs-db/cs-db-backup
+
+    function main {
+        EMBEDDED=$(oc get cm -n $CSDB_NAMESPACE common-service-db-im -o jsonpath='{.data.IS_EMBEDDED}{"\n"}')
+        if [[ $MODE == "backup" ]]; then
+            save_log "logs" "backup_log"
+            trap cleanup_log EXIT
+            info "Mode set to backup, beginning backup process."
+            backup
+            success "Backup completed successfully."
+        elif [[ $MODE == "restore" ]]; then
+            save_log "logs" "restore_log"
+            trap cleanup_log EXIT
+            info "Mode is set to restore, beginning restore process."
+            restore
+            success "Restore completed successfully."
+        else
+            error "Mode selected is $MODE. Please use either \"backup\" or \"restore\"."
+        fi
+    }
+
+    function backup {
+        if [[ $EMBEDDED == "true" ]] || [[ -z $EMBEDDED ]]; then
+            info "Embedded Postgres DB in use, beginning backup."
+            mkdir -p $BACKUP_DIR/database
+            CNPG_PRIMARY_POD=`oc get cluster.pg.ibm.com common-service-db -o jsonpath="{.status.currentPrimary}" -n $CSDB_NAMESPACE` && \
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- mkdir -p /run/cs-db_backup && \
+            info "Beginning backup of im database..."
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_dump -v --username=postgres --dbname=im -f /run/cs-db_backup/cs-db_im_backup.dump --format=c
+            info "Beginning backup of zen database..."
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_dump -v --username=postgres --dbname=zen -f /run/cs-db_backup/cs-db_zen_backup.dump --format=c
+            ACCOUNT_IAM=$(oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" | grep "account_iam" || echo False)
+            if [[ $ACCOUNT_IAM != "False" ]]; then
+                info "Beginning backup of account_iam database..."
+                oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_dump -v --username=postgres --dbname=account_iam -f /run/cs-db_backup/cs-db_account_iam_backup.dump --format=c
+            fi
+
+            #Move backup to backup location
+            info "Copy backup file."
+            oc cp $CSDB_NAMESPACE/$CNPG_PRIMARY_POD:/run/cs-db_backup/cs-db_im_backup.dump $BACKUP_DIR/database/cs-db_im_backup.dump
+            oc cp $CSDB_NAMESPACE/$CNPG_PRIMARY_POD:/run/cs-db_backup/cs-db_zen_backup.dump $BACKUP_DIR/database/cs-db_zen_backup.dump
+            if [[ $ACCOUNT_IAM != "False" ]]; then
+                oc cp $CSDB_NAMESPACE/$CNPG_PRIMARY_POD:/run/cs-db_backup/cs-db_account_iam_backup.dump $BACKUP_DIR/database/cs-db_account_iam_backup.dump
+            fi
+        else
+            info "External Postgres DB in use, skipping backup."
+        fi
+
+    }
+
+    function restore {
+
+        if [[ $EMBEDDED == "true" ]] || [[ -z $EMBEDDED ]]; then
+            info "Embedded Postgres DB in use, beginning data restore."
+            wait_for_cluster_cr
+            CNPG_PRIMARY_POD=`oc get cluster.pg.ibm.com common-service-db -o jsonpath="{.status.currentPrimary}" -n $CSDB_NAMESPACE` 
+            oc exec $CNPG_PRIMARY_POD -n $CSDB_NAMESPACE -- mkdir -p /run/cs-db_backup
+            oc cp $BACKUP_DIR/database/cs-db_im_backup.dump $CSDB_NAMESPACE/$CNPG_PRIMARY_POD:/run/cs-db_backup/cs-db_im_backup.dump
+            oc cp $BACKUP_DIR/database/cs-db_zen_backup.dump $CSDB_NAMESPACE/$CNPG_PRIMARY_POD:/run/cs-db_backup/cs-db_zen_backup.dump
+            ACCOUNT_IAM=$(ls $BACKUP_DIR/database/ | grep "cs-db_account_iam_backup.dump" || echo False)
+            if [[ $ACCOUNT_IAM != "False" ]]; then
+                oc cp $BACKUP_DIR/database/cs-db_account_iam_backup.dump $CSDB_NAMESPACE/$CNPG_PRIMARY_POD:/run/cs-db_backup/cs-db_account_iam_backup.dump        
+            fi
+            
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" -c "\dn" -c "\du"
+            info "Beginning restore of im database..."
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_restore -U postgres --dbname im --format=c --clean --if-exists --exit-on-error -v /run/cs-db_backup/cs-db_im_backup.dump
+            info "Beginning restore of zen database..."
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_restore -U postgres --dbname zen --format=c --clean --if-exists --exit-on-error -v /run/cs-db_backup/cs-db_zen_backup.dump
+            if [[ $ACCOUNT_IAM != "False" ]]; then
+                info "Beginning restore of account_iam database..."
+                oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_restore -U postgres --dbname account_iam --format=c --clean --if-exists --exit-on-error -v /run/cs-db_backup/cs-db_account_iam_backup.dump        
+                
+                # Update IDP configuration with actual cluster domain
+                update_idp_config
+            fi
+            oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" -c "\dn" -c "\du"
+        else
+            info "External Postgres DB in use, skipping data restore."
+        fi
+        
+        info "🔄 Rerunning OIDC registration job..."
+        oc -n $CSDB_NAMESPACE get job oidc-client-registration -o yaml > /tmp/oidc-client-registration.yaml
+        oc -n $CSDB_NAMESPACE delete job oidc-client-registration
+        yq -i 'del(.metadata.creationTimestamp) | del(.metadata.managedFields) | del(.metadata.resourceVersion) | del(.metadata.uid) | del(.spec.selector) | del(.spec.template.metadata.labels) | del(.status)' /tmp/oidc-client-registration.yaml || error "Failed to remove metadata fields from temp oidc client registration yaml for namespace ${CSDB_NAMESPACE}."
+        info "⏸️ Wait for previous job to delete..."
+        sleep 30
+        oc apply -f /tmp/oidc-client-registration.yaml
+        rm -f /tmp/oidc-client-registration.yaml
+        wait_for_job "oidc-client-registration"
+
+        if [[ $ACCOUNT_IAM != "False" ]]; then
+            info "🔄 Rerunning account-iam-db-migration job..."
+            oc -n $CSDB_NAMESPACE get job account-iam-db-migration-job -o yaml > /tmp/account-iam-db-migration-job.yaml 2>/dev/null || {
+                info "🔍 account-iam-db-migration job not found, skipping..."
+            }
+            if [[ -f /tmp/account-iam-db-migration-job.yaml ]]; then
+                oc -n $CSDB_NAMESPACE delete job account-iam-db-migration-job
+                yq -i 'del(.metadata.creationTimestamp) | del(.metadata.managedFields) | del(.metadata.resourceVersion) | del(.metadata.uid) | del(.spec.selector) | del(.spec.template.metadata.labels) | del(.status)' /tmp/account-iam-db-migration-job.yaml || error "Failed to remove metadata fields from temp account-iam-db-migration-job yaml for namespace ${CSDB_NAMESPACE}."
+                info "⏸️ Wait for previous account-iam-db-migration job to delete..."
+                sleep 10
+                oc apply -f /tmp/account-iam-db-migration-job.yaml
+                rm -f /tmp/account-iam-db-migration-job.yaml
+                wait_for_job "account-iam-db-migration-job"
+            fi
+            info "🔄 Rerunning MCSP IM config job..."
+            oc -n $CSDB_NAMESPACE get job mcsp-im-config-job -o yaml > /tmp/mcsp-im-config-job.yaml 2>/dev/null || {
+                info "🔍 MCSP IM config job not found, skipping..."
+            }
+            if [[ -f /tmp/mcsp-im-config-job.yaml ]]; then
+                oc -n $CSDB_NAMESPACE delete job mcsp-im-config-job
+                yq -i 'del(.metadata.creationTimestamp) | del(.metadata.managedFields) | del(.metadata.resourceVersion) | del(.metadata.uid) | del(.spec.selector) | del(.spec.template.metadata.labels) | del(.status)' /tmp/mcsp-im-config-job.yaml || error "Failed to remove metadata fields from temp mcsp-im-config-job yaml for namespace ${CSDB_NAMESPACE}."
+                info "⏸️ Wait for previous MCSP IM config job to delete..."
+                sleep 10
+                oc apply -f /tmp/mcsp-im-config-job.yaml
+                rm -f /tmp/mcsp-im-config-job.yaml
+                wait_for_job "mcsp-im-config-job"
+            fi
+        fi  
+
+        
+    }
+
+    function update_idp_config {
+        info "Updating IDP configuration with actual cluster domain..."
+        
+        # Get the cluster domain from ibmcloud-cluster-info configmap
+        CLUSTER_DOMAIN=$(oc get cm ibmcloud-cluster-info -n $CSDB_NAMESPACE -o jsonpath='{.data.cluster_address}' 2>/dev/null || echo "")
+        
+        if [[ -z $CLUSTER_DOMAIN ]]; then
+            error "❌ Could not determine cluster domain from ibmcloud-cluster-info configmap. Please update IDP configuration manually."
+            return 1
+        fi
+        
+        info "✅ Detected cluster domain: $CLUSTER_DOMAIN"
+        
+        NEW_IDP_URL="https://${CLUSTER_DOMAIN}/idprovider/v1/auth"
+        
+        info "🎯 Target IDP URL: $NEW_IDP_URL"
+        
+        # Check if account_iam database exists
+        ACCOUNT_IAM_EXISTS=$(oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" | grep "account_iam" || echo False)
+        
+        if [[ $ACCOUNT_IAM_EXISTS != "False" ]]; then
+            # Check current IDP configuration
+            CURRENT_IDP=$(oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -d account_iam -t -c "SELECT TRIM(idp) FROM accountiam.idp_config WHERE idp LIKE '%/idprovider/v1/%' LIMIT 1;" 2>/dev/null | head -n1 | tr -d '\r\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' || echo "")
+            info "🌐 Current IDP URL: $CURRENT_IDP"
+            echo ""
+            
+            if [[ -n $CURRENT_IDP ]] && [[ $CURRENT_IDP != $NEW_IDP_URL ]]; then
+                info "🔄 Updating IDP configuration..."
+                
+                oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -d account_iam -c "
+                    UPDATE accountiam.idp_config 
+                    SET idp = '$NEW_IDP_URL', 
+                        modified_ts = NOW()
+                    WHERE idp LIKE '%/idprovider/v1/%';
+                "
+                echo ""
+                info "Verifying IDP configuration update..."
+                oc -n $CSDB_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -d account_iam -c "
+                    SELECT uid, realm, idp, modified_ts 
+                    FROM accountiam.idp_config 
+                    ORDER BY modified_ts DESC;
+                "
+                
+                success "IDP configuration updated successfully in account_iam database."
+                
+                # Restart account-iam pod to pick up the new configuration
+                info "🔄 Restarting account-iam pod to apply new IDP configuration..."
+                ACCOUNT_IAM_POD=$(oc get pods -n $CSDB_NAMESPACE -l app.kubernetes.io/name=account-iam --no-headers -o custom-columns=":metadata.name" | head -n1 || echo "")
+                
+                if [[ -n $ACCOUNT_IAM_POD ]]; then
+                    info "Found account-iam pod: $ACCOUNT_IAM_POD"
+                    oc delete pod $ACCOUNT_IAM_POD -n $CSDB_NAMESPACE
+                    
+                    info "⏳ Waiting for new account-iam pod to be ready..."
+                    # Wait for new pod to be running and ready
+                    retry_count=30
+                    while [[ $retry_count > 0 ]]; do
+                        NEW_POD=$(oc get pods -n $CSDB_NAMESPACE -l app.kubernetes.io/name=account-iam --no-headers -o custom-columns=":metadata.name,:status.phase" | grep Running | head -n1)
+                        if [[ -n $NEW_POD ]]; then
+                            POD_NAME=$(echo $NEW_POD | awk '{print $1}')
+                            READY_STATUS=$(oc get pod $POD_NAME -n $CSDB_NAMESPACE -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+                            if [[ $READY_STATUS == "True" ]]; then
+                                info "✅ New account-iam pod is ready: $POD_NAME"
+                                break
+                            fi
+                        fi
+                        sleep 2
+                        retry_count=$((retry_count-1))
+                    done
+                    
+                    if [[ $retry_count == 0 ]]; then
+                        warning "⚠️ Timeout waiting for new account-iam pod to be ready"
+                    fi
+                    
+                    info "✅ Account-iam pod restart completed"
+                else
+                    warning "⚠️ Could not find account-iam pod to restart. Please restart manually if needed."
+                fi
+            elif [[ $CURRENT_IDP == $NEW_IDP_URL ]]; then
+                info "✅ IDP configuration already matches target URL, no update needed."
+            else
+                info "No IDP configuration found in database, skipping update."
+            fi
+        else
+            info "account_iam database not found, IDP configuration update not applicable."
+        fi
+    }
+
+    function wait_for_job {
+        local job_name=$1
+        info "⏳ Waiting for job $job_name to complete in namespace $CSDB_NAMESPACE..."
+        job_exists=$(oc get job $job_name -n $CSDB_NAMESPACE --no-headers || echo fail)
+        if [[ $job_exists != "fail" ]]; then
+            completed=$(oc get job/$job_name -n $CSDB_NAMESPACE -o jsonpath="{.status.conditions[?(@.type=='Complete')].type}")
+            retry_count=20
+            while [[ $completed != "Complete" ]] && [[ $retry_count > 0 ]]
+            do
+                info "⏰ Wait for job $job_name to complete. Try again in 15s..."
+                sleep 15
+                completed=$(oc get job/$job_name -n $CSDB_NAMESPACE -o jsonpath="{.status.conditions[?(@.type=='Complete')].type}")
+                retry_count=$((retry_count-1))
+            done
+
+            if [[ $retry_count == 0 ]] && [[ $completed != "Complete" ]]; then
+                error "⏱️ Timed out waiting for job $job_name."
+            else
+                info "✅ Job $job_name completed."
+            fi
+        else
+            error "❌ Job $job_name not present."
+        fi
+    }
+
+    function wait_for_cluster_cr {
+        info "Waiting for IBM PG Cluster CR $CLUSTER_CR to complete in namespace $CSDB_NAMESPACE."
+        cluster_cr_exists=$(oc get cluster.pg.ibm.com $CLUSTER_CR -n $CSDB_NAMESPACE --no-headers || echo fail)
+        if [[ $cluster_cr_exists != "fail" ]]; then
+            completed=$(oc get cluster.pg.ibm.com $CLUSTER_CR -n $CSDB_NAMESPACE -o=jsonpath='{.status.phase}')
+            retry_count=40
+            while [[ $completed != "Cluster in healthy state" ]] && [[ $retry_count > 0 ]]
+            do
+                info "Wait for cluster $CLUSTER_CR to complete. Try again in 15s."
+                sleep 15
+                completed=$(oc get cluster.pg.ibm.com $CLUSTER_CR -n $CSDB_NAMESPACE -o=jsonpath='{.status.phase}')
+                retry_count=$retry_count-1
+            done
+
+            if [[ $retry_count == 0 ]] && [[ $completed != "1/1" ]]; then
+                error "Timed out waiting for cluster $CLUSTER_CR."
+            else
+                info "IBM PG cluster $CLUSTER_CR ready."
+            fi
+        else
+            error "IBM PG cluster $CLUSTER_CR not present."
+        fi
+    }
+
+    function save_log(){
+        local LOG_DIR="$BACKUP_DIR/$1"
+        LOG_FILE="$LOG_DIR/$2_$(date +'%Y%m%d%H%M%S').log"
+
+        if [[ ! -d $LOG_DIR ]]; then
+            mkdir -p "$LOG_DIR"
+        fi
+
+        # Create a named pipe
+        PIPE=$(mktemp -u)
+        mkfifo "$PIPE"
+
+        # Tee the output to both the log file and the terminal
+        tee "$LOG_FILE" < "$PIPE" &
+
+        # Redirect stdout and stderr to the named pipe
+        exec > "$PIPE" 2>&1
+
+        # Remove the named pipe
+        rm "$PIPE"
+    }
+
+    function cleanup_log() {
+        # Check if the log file already exists
+        if [[ -e $LOG_FILE ]]; then
+            # Remove ANSI escape sequences from log file
+            sed -E 's/\x1B\[[0-9;]+[A-Za-z]//g' "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+        fi
+    }
+
+    function msg() {
+        printf '%b\n' "$1"
+    }
+
+    function success() {
+        msg "\33[32m[✔] ${1}\33[0m"
+    }
+
+    function warning() {
+        msg "\33[33m[✗] ${1}\33[0m"
+    }
+
+    function error() {
+        msg "\33[31m[✘] ${1}\33[0m"
+        exit 1
+    }
+
+    function title() {
+        msg "\33[34m# ${1}\33[0m"
+    }
+
+    function info() {
+        msg "[INFO] ${1}"
+    }
+
+    main $*

--- a/velero/schedule/ibm-pg/common-service-db/cs-db-role.yaml
+++ b/velero/schedule/ibm-pg/common-service-db/cs-db-role.yaml
@@ -1,0 +1,45 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cs-db-backup-role
+  namespace: <cs-db namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: cs-db-data
+rules:
+  - verbs:
+      - create
+      - get
+      - delete
+      - watch
+      - update
+      - list
+      - patch
+    apiGroups:
+      - ''
+      - batch
+      - extensions
+      - apps
+      - policy
+      - route.openshift.io
+    resources:
+      - pods
+      - pods/log
+      - deployments
+      - deployments/scale
+      - statefulsets
+      - statefulsets/scale
+      - pods/exec
+      - pods/portforward
+      - endpoints
+      - pods/status
+      - jobs
+      - secrets
+      - configmaps
+      - routes
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - clusters

--- a/velero/schedule/ibm-pg/common-service-db/cs-db-rolebinding.yaml
+++ b/velero/schedule/ibm-pg/common-service-db/cs-db-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cs-db-backup-rolebinding
+  namespace: <cs-db namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: cs-db-data
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cs-db-backup-role
+  namespace: <cs-db namespace>
+subjects:
+- kind: ServiceAccount
+  name: cs-db-backup-sa
+  namespace: <cs-db namespace>

--- a/velero/schedule/ibm-pg/common-service-db/cs-db-sa.yaml
+++ b/velero/schedule/ibm-pg/common-service-db/cs-db-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cs-db-backup-sa
+  namespace: <cs-db namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: cs-db-data

--- a/velero/schedule/ibm-pg/zen-metastore/zen5-backup-deployment.yaml
+++ b/velero/schedule/ibm-pg/zen-metastore/zen5-backup-deployment.yaml
@@ -1,0 +1,74 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: zen5-backup
+  namespace: <zenservice namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: zen5-data
+spec:
+  selector:
+    matchLabels:
+      foundationservices.cloudpak.ibm.com: zen5-data
+  template:
+    metadata:
+      annotations:
+        backup.velero.io/backup-volumes: zen5-backup
+        pre.hook.backup.velero.io/command: '["sh", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace; /zen5/backup_zen5.sh <zenservice namespace>"]'
+        pre.hook.backup.velero.io/on-error: Fail
+        pre.hook.backup.velero.io/timeout: 300s
+        post.hook.restore.velero.io/command: '["sh", "-c", "/zen5/restore_zen5.sh <zenservice namespace> <zenservice name>"]'
+        post.hook.restore.velero.io/on-error: Fail
+        post.hook.restore.velero.io/wait-timeout: 1000s
+        post.hook.restore.velero.io/exec-timeout: 1000s
+        post.hook.restore.velero.io/timeout: 1000s
+      name: zen5-backup
+      namespace: <zenservice namespace>
+      labels:
+        foundationservices.cloudpak.ibm.com: zen5-data
+    spec:
+      containers:
+      - command:
+        - sh
+        - -c
+        - sleep infinity
+        image: icr.io/cpopen/cpfs/cpfs-utils:4.6.0 #4.1.0 if using CS 4.1, 4.2.0 if using CS 4.2
+        imagePullPolicy: IfNotPresent
+        name: zen5-backup-job
+        resources:
+          limits:
+            cpu: 500m
+            ephemeral-storage: 512Mi
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            ephemeral-storage: 128Mi
+            memory: 256Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /zen5/zen-backup
+          name: zen5-backup-mount
+          readOnly: false
+        - name: scripts
+          mountPath: "/zen5"
+          readOnly: false
+        - name: logs
+          mountPath: /zen5/zen-backup/logs
+          readOnly: false
+      dnsPolicy: ClusterFirst
+      schedulerName: default-scheduler
+      securityContext:
+        runAsNonRoot: true
+      serviceAccount: zen5-backup-sa
+      serviceAccountName: zen5-backup-sa
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: zen5-backup-mount
+        persistentVolumeClaim:
+          claimName: zen5-backup-pvc
+      - name: scripts
+        configMap:
+          name: zen5-br-configmap
+          defaultMode: 0777
+      - emptyDir: {}
+        name: logs

--- a/velero/schedule/ibm-pg/zen-metastore/zen5-backup-pvc.yaml
+++ b/velero/schedule/ibm-pg/zen-metastore/zen5-backup-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: zen5-backup-pvc
+  namespace: <zenservice namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: zen5-data
+spec:
+  storageClassName: <storage class>
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+  volumeMode: Filesystem

--- a/velero/schedule/ibm-pg/zen-metastore/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/ibm-pg/zen-metastore/zen5-br-scripts-cm.yaml
@@ -1,0 +1,595 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: zen5-br-configmap
+  namespace: <zenservice namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: zen5-data
+data:
+  backup_zen5.sh: |
+    #!/usr/bin/env bash
+
+    # Licensed Materials - Property of IBM
+    # Copyright IBM Corporation 2023. All Rights Reserved
+    # US Government Users Restricted Rights -
+    # Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+    #
+    # This is an internal component, bundled with an official IBM product.
+    # Please refer to that particular license for additional information.
+
+    # ---------- Command arguments ----------
+    #should probably defualt this to zen with an optional parameter
+    
+    set -o errtrace
+    set -o errexit
+
+    ZEN_NAMESPACE=$1
+    BACKUP_DIR=/zen5/zen-backup
+
+    #Backup steps
+
+    #Setup backup location
+    function main {
+        save_log "logs" "backup_log"
+        trap cleanup_log EXIT
+        title "Beginning zen 5 backup process in namespace $ZEN_NAMESPACE."
+        info "Creating necessary directories"
+        mkdir -p $BACKUP_DIR/workspace
+        mkdir -p $BACKUP_DIR/secrets
+        mkdir -p $BACKUP_DIR/secrets/jwks 
+        mkdir -p $BACKUP_DIR/secrets/jwt 
+        mkdir -p $BACKUP_DIR/secrets/jwt-private
+        mkdir -p $BACKUP_DIR/secrets/ibmid-jwk
+        mkdir -p $BACKUP_DIR/secrets/aes-key 
+        mkdir -p $BACKUP_DIR/secrets/admin-user
+        mkdir -p $BACKUP_DIR/database
+        mkdir -p $BACKUP_DIR/objstorage
+
+        #Set zen namespace
+        #will be covered by command line argument/prereq function
+
+        #Backup zen metastore database
+        #check if this flag is true, otherwise do not proceed
+        return_value=$(oc get cm ibm-zen-metastore-cm -o jsonpath='{.data.IS_EMBEDDED_DATABASE}{"\n"}')
+        if [[ $return_value == "true" ]] || [[ $return_value == "" ]]; then
+            info "Value IS_EMBEDDED_DATABASE marked true in configmap ibm-zen-metastore-cm, backing up zen-metastore"
+            CNPG_PRIMARY_POD=`oc get cluster.pg.ibm.com zen-metastore -o jsonpath="{.status.currentPrimary}" -n $ZEN_NAMESPACE` && \
+            oc -n $ZEN_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- mkdir -p /run/zen_backup && \
+            oc -n $ZEN_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_dump -v --username=postgres --dbname=zen -f /run/zen_backup/zen_db_backup.dump --format=c
+            
+            #Move backup to backup location
+            oc cp $ZEN_NAMESPACE/$CNPG_PRIMARY_POD:/run/zen_backup/zen_db_backup.dump $BACKUP_DIR/database/zen_db_backup.dump
+        else
+            info "Value IS_EMBEDDED_DATABASE marked false in configmap ibm-zen-metastore-cm, skipping back up of zen-metastore."
+        fi
+        #Backup zen object storage
+        #check if this is true
+        return_value=""
+        return_value=$(oc -n $ZEN_NAMESPACE get cm ibm-zen-objectstore-cm -o jsonpath='{.data.IS_EMBEDDED_OBJECTSTORE}{"\n"}')
+        if [[ $return_value == "true" ]] || [[ $return_value == "" ]]; then
+            info "IS_EMBEDDED_OBJECTSTORE value true in configmap ibm-zen-objectstore-cm, backing up zen objectstore"
+            #Read object storage connection and credentials
+            OBJECTSTORE_ENDPOINT=$(oc -n $ZEN_NAMESPACE get cm ibm-zen-objectstore-cm -o jsonpath="{.data.OBJECTSTORE_ENDPOINT}")
+            oc -n $ZEN_NAMESPACE extract secret/ibm-zen-objectstore-secret --to=$BACKUP_DIR/workspace --confirm
+
+            #Backup object storage data
+            oc -n $ZEN_NAMESPACE exec -t zen-minio-0 -- bash -c "rm -rf /workdir/home/.minio/backup && mkdir -p /workdir/home/.minio/backup && export HOME=/workdir/home/.minio && /workdir/bin/mc alias set zenobjstore ${OBJECTSTORE_ENDPOINT} $(<${BACKUP_DIR}/workspace/accesskey) $(<${BACKUP_DIR}/workspace/secretkey) --config-dir=/workdir/home/.minio/.mc --insecure && /workdir/bin/mc cp --recursive zenobjstore/ /workdir/home/.minio/backup --insecure" 
+
+            #Move backup to backup location
+            oc cp $ZEN_NAMESPACE/zen-minio-0:/workdir/home/.minio/backup $BACKUP_DIR/objstorage && oc exec -t zen-minio-0 -- bash -c "rm -rf /workdir/home/.minio/backup"
+        else
+            info "IS_EMBEDDED_OBJECTSTORE value false in configmap ibm-zen-objectstore-cm, skipping backup of zen objectstore"
+        fi
+
+        #store list of extensions from source cluster to be restored later
+        ./zen5/customize-zen-extensions.sh $ZEN_NAMESPACE true
+
+        #Backup JWT configuration
+        info "Backing up JWT secrets"
+        oc extract -n ${ZEN_NAMESPACE} secret/ibm-zen-secret-jwks --to=$BACKUP_DIR/secrets/jwks || warning "Failed to backup secret/ibm-zen-secret-jwks in namespace ${ZEN_NAMESPACE}"
+        oc extract -n ${ZEN_NAMESPACE} secret/ibm-zen-secret-jwt --to=$BACKUP_DIR/secrets || warning "Failed to backup secret/ibm-zen-secret-jwt in namespace ${ZEN_NAMESPACE}"
+        oc extract -n ${ZEN_NAMESPACE} secret/ibm-zen-secret-jwt-private --to=$BACKUP_DIR/secrets || warning "Failed to backup secret/ibm-zen-secret-jwt-private in namespace ${ZEN_NAMESPACE}"
+        oc extract -n ${ZEN_NAMESPACE} secret/zen-secrets-aes-key  --to=$BACKUP_DIR/secrets || warning "Failed to backup secret/zen-secrets-aes-key in namespace ${ZEN_NAMESPACE}"
+        oc extract -n ${ZEN_NAMESPACE} secret/admin-user-details --to=$BACKUP_DIR/secrets || warning "Failed to backup secret/admin-user-details in namespace ${ZEN_NAMESPACE}"
+
+        success "Backup completed."
+    }
+
+    function save_log(){
+        local LOG_DIR="$BACKUP_DIR/$1"
+        LOG_FILE="$LOG_DIR/$2_$(date +'%Y%m%d%H%M%S').log"
+
+        if [[ ! -d $LOG_DIR ]]; then
+            mkdir -p "$LOG_DIR"
+        fi
+
+        # Create a named pipe
+        PIPE=$(mktemp -u)
+        mkfifo "$PIPE"
+
+        # Tee the output to both the log file and the terminal
+        tee "$LOG_FILE" < "$PIPE" &
+
+        # Redirect stdout and stderr to the named pipe
+        exec > "$PIPE" 2>&1
+
+        # Remove the named pipe
+        rm "$PIPE"
+    }
+
+    function cleanup_log() {
+        # Check if the log file already exists
+        if [[ -e $LOG_FILE ]]; then
+            # Remove ANSI escape sequences from log file
+            sed -E 's/\x1B\[[0-9;]+[A-Za-z]//g' "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+        fi
+    }
+
+    function msg() {
+        printf '%b\n' "$1"
+    }
+
+    function success() {
+        msg "\33[32m[✔] ${1}\33[0m"
+    }
+
+    function warning() {
+        msg "\33[33m[✗] ${1}\33[0m"
+    }
+
+    function error() {
+        msg "\33[31m[✘] ${1}\33[0m"
+        exit 1
+    }
+
+    function title() {
+        msg "\33[34m# ${1}\33[0m"
+    }
+
+    function info() {
+        msg "[INFO] ${1}"
+    }
+
+    main $*
+  restore_zen5.sh: |
+    #!/usr/bin/env bash
+
+    # Licensed Materials - Property of IBM
+    # Copyright IBM Corporation 2023. All Rights Reserved
+    # US Government Users Restricted Rights -
+    # Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+    #
+    # This is an internal component, bundled with an official IBM product.
+    # Please refer to that particular license for additional information.
+
+    set -o errtrace
+    set -o errexit
+    
+    #[2.2] Restore
+    #[2.2.1] Set Zen namespace
+    ZEN_NAMESPACE=$1 #should probably defualt this to zen with an optional parameter
+    ZENSERVICE_NAME=$2
+
+    BACKUP_DIR=/zen5/zen-backup
+
+    function main {
+        save_log "logs" "restore_log"
+        trap cleanup_log EXIT
+        title "Beginning restore process for zenservice $ZENSERVICE_NAME in namespace $ZEN_NAMESPACE."
+        info "Wait for zenservice $ZENSERVICE_NAME to be ready..."
+        wait_for_zenservice
+        info "Enabling Zen operator maintenance mode and scale down deployments"
+        #[2.2.2] Enable Zen operator maintenance mode and scale down deployments
+        oc patch zenservice ${ZENSERVICE_NAME} --namespace ${ZEN_NAMESPACE} --type=merge --patch '{"spec": {"ignoreForMaintenance": true}}'
+        
+        #suspend backup cronjob
+        oc patch cj zen-metastore-backup-cron-job --namespace ${ZEN_NAMESPACE} --type=merge --patch '{"spec": {"suspend": true}}'
+        
+        #Getting the replica count before scaling down the required pods
+        IBM_NGINX_RC=$(oc get deploy ibm-nginx -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
+        ZEN_CORE_RC=$(oc get deploy zen-core -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found )
+        USERMGMT_RC=$(oc get deploy usermgmt -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
+        ZEN_CORE_API_RC=$(oc get deploy zen-core-api -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
+        ZEN_WATCHER_RC=$(oc get deploy zen-watcher -n ${ZEN_NAMESPACE} -o=jsonpath='{.spec.replicas}' --ignore-not-found)
+
+        oc get deploy ibm-nginx zen-core usermgmt zen-watcher zen-core-api -n ${ZEN_NAMESPACE} --ignore-not-found
+        
+        oc scale deploy ibm-nginx zen-core usermgmt zen-watcher zen-core-api --replicas=0 -n ${ZEN_NAMESPACE}
+        # zen-watchdog is applicable only for CloudPak for Data 
+        zen_watchdog_present=$(oc get deploy -n ${ZEN_NAMESPACE} | grep zen-watchdog || echo "fail")
+        if [[ $zen_watchdog_present != "fail" ]]; then
+            info "Zen watchdog present, scaling down."
+            oc scale deploy zen-watchdog --replicas=0 -n ${ZEN_NAMESPACE}
+        fi
+        
+        sleep 45
+        #waiting for deployments to be cleaned up after scaling down
+        deployments_clear=$(oc get deploy -n $ZEN_NAMESPACE | grep "ibm-nginx\|zen-core\|usermgmt\|zen-watcher\|zen-core-api\|zen-watchdog" | grep -v "ibm-nginx-tester" | awk '{print $4}' | grep -v 0 || echo clear)
+        while [[ $deployments_clear != "clear" ]];
+        do
+            if [[ $deployments_clear != "clear" ]]; then
+                info "Waiting on deployments ibm-nginx zen-core usermgmt zen-watcher zen-core-api to clean up..."
+            else
+                info "Deployments ibm-nginx zen-core usermgmt zen-watcher zen-core-api successfully scaled down. Moving on..."
+            fi
+            deployments_clear=$(oc get deploy -n $ZEN_NAMESPACE | grep "ibm-nginx\|zen-core\|usermgmt\|zen-watcher\|zen-core-api\|zen-watchdog" | grep -v "ibm-nginx-tester" | awk '{print $4}' | grep -v 0 || echo clear)
+            sleep 30
+        done
+        
+        #[2.2.3] Reset platform metadata and configuration data
+        #[2.2.3.1] Remove active connections
+        CNPG_PRIMARY_POD=`oc -n ${ZEN_NAMESPACE} get cluster.pg.ibm.com zen-metastore -o jsonpath="{.status.currentPrimary}"` && \
+        oc -n ${ZEN_NAMESPACE} exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "SELECT pg_terminate_backend(pg_stat_activity.pid) FROM pg_stat_activity WHERE pg_stat_activity.datname = 'zen' AND pid <> pg_backend_pid();" && \
+        oc -n ${ZEN_NAMESPACE} exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "SELECT * FROM pg_stat_activity WHERE datname = 'zen';"
+
+        #we no longer do this step because we are using pgdump/pgrestore
+        #dropping the database like this will cause pgrestore to fail since it expects the database and its structure to already be there
+        #keeping the comment for cross referencing what is done in zen team docs
+        #[2.2.3.2] Reset database
+        # return_value=""
+        # return_value=$(oc get cm ibm-zen-metastore-cm -o jsonpath='{.data.IS_EMBEDDED_DATABASE}{"\n"}')
+        # if [[ $return_value == "true" ]] || [[ $return_value == "" ]]; then
+        #     info "Value IS_EMBEDDED_DATABASE marked true in configmap ibm-zen-metastore-cm, resetting zen-metastore"
+        #     info "Reset platform metadata and configuration data"
+        #     info "Prepping database..."
+        #     CNPG_PRIMARY_POD=`oc get cluster.pg.ibm.com zen-metastore -o jsonpath="{.status.currentPrimary}" -n $ZEN_NAMESPACE` && oc -n $ZEN_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "DROP DATABASE IF EXISTS zen;"  -c "DROP USER IF EXISTS zen_user;" -c "CREATE DATABASE zen;" -c "CREATE USER zen_user;" -c "GRANT CONNECT ON DATABASE zen TO public;" -c "ALTER DATABASE zen OWNER TO zen_user;" -c "GRANT ALL PRIVILEGES ON DATABASE zen to zen_user;"
+        # else
+        #     info "IS_EMBEDDED_DATABASE value false, skipping metastore database reset."
+        # fi
+
+        #[2.2.3.3] reset object storage
+        #[2.2.3.3.1] read object storage connection and credentials
+        return_value=""
+        return_value=$(oc -n $ZEN_NAMESPACE get cm ibm-zen-objectstore-cm -o jsonpath='{.data.IS_EMBEDDED_OBJECTSTORE}{"\n"}')
+        if [[ $return_value == "true" ]] || [[ $return_value == "" ]]; then
+            info "IS_EMBEDDED_OBJECTSTORE value true, resetting objectstore data."
+            info "Prepping objectstore..."
+            IBM_ZEN_BUCKET_NAME=$(oc get cm ibm-zen-objectstore-cm -o=jsonpath='{.data.BUCKET_ZEN_CONFIGURATION}' -n $ZEN_NAMESPACE)
+            OBJECTSTORE_ENDPOINT=$(oc get cm ibm-zen-objectstore-cm -o jsonpath="{.data.OBJECTSTORE_ENDPOINT}" -n $ZEN_NAMESPACE)
+            oc -n $ZEN_NAMESPACE extract secret/ibm-zen-objectstore-secret --to=$BACKUP_DIR/workspace --confirm
+
+            #[2.2.3.3.2] Remove and recreate Zen bucket
+            info "Remove and recreate Zen bucket."
+            oc -n $ZEN_NAMESPACE exec -t zen-minio-0 -- bash -c "rm -rf /workdir/home/.minio/backup && mkdir -p /workdir/home/.minio/backup && export HOME=/workdir/home/.minio && /workdir/bin/mc alias set zenobjstore ${OBJECTSTORE_ENDPOINT} $(<${BACKUP_DIR}/workspace/accesskey) $(<${BACKUP_DIR}/workspace/secretkey) --config-dir=/workdir/home/.minio/.mc --insecure && /workdir/bin/mc ls zenobjstore/${IBM_ZEN_BUCKET_NAME} --insecure && /workdir/bin/mc rb zenobjstore/${IBM_ZEN_BUCKET_NAME} --force --dangerous --insecure && /workdir/bin/mc mb zenobjstore/${IBM_ZEN_BUCKET_NAME} --insecure"
+        else
+            info "IS_EMBEDDED_OBJECTSTORE value false, skipping objectstore reset."
+        fi
+
+        #[2.2.4] Restore data
+        return_value=""
+        return_value=$(oc get cm ibm-zen-metastore-cm -o jsonpath='{.data.IS_EMBEDDED_DATABASE}{"\n"}')
+        if [[ $return_value == "true" ]] || [[ $return_value == "" ]]; then
+            info "Value IS_EMBEDDED_DATABASE marked true in configmap ibm-zen-metastore-cm, restoring zen-metastore database data"
+            info "Restore platform metadata."
+            #[2.2.4.1] Restore platform metadata (metastore database)
+            CNPG_PRIMARY_POD=`oc get cluster.pg.ibm.com zen-metastore -o jsonpath="{.status.currentPrimary}"`
+            oc exec $CNPG_PRIMARY_POD -n $ZEN_NAMESPACE -- mkdir -p /run/zen_backup
+            oc cp $BACKUP_DIR/database/zen_db_backup.dump $ZEN_NAMESPACE/$CNPG_PRIMARY_POD:/run/zen_backup/zen_db_backup.dump
+            oc -n $ZEN_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" -c "\dn" -c "\du"
+            oc -n $ZEN_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- pg_restore -U postgres --dbname zen --format=c --clean --exit-on-error --if-exists -v /run/zen_backup/zen_db_backup.dump
+            # oc -n $ZEN_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -d zen -f /run/zen_backup/zen_db_backup.dump
+            oc -n $ZEN_NAMESPACE exec -t $CNPG_PRIMARY_POD -c postgres -- psql -U postgres -c "\list" -c "\dn" -c "\du"
+        else
+            info "IS_EMBEDDED_DATABASE value false, skipping metastore database data restore."
+        fi
+
+        #[2.2.4.2] Restore platform configuration data (object storage)
+        return_value=""
+        return_value=$(oc -n $ZEN_NAMESPACE get cm ibm-zen-objectstore-cm -o jsonpath='{.data.IS_EMBEDDED_OBJECTSTORE}{"\n"}')
+        if [[ $return_value == "true" ]] || [[ $return_value == "" ]]; then
+            info "IS_EMBEDDED_OBJECTSTORE value true, restoring objectstore data."
+            info "Restore platform configuration data (object storage)."
+            IBM_ZEN_BUCKET_NAME=$(oc get cm ibm-zen-objectstore-cm -o=jsonpath='{.data.BUCKET_ZEN_CONFIGURATION}')
+            oc cp $BACKUP_DIR/objstorage $ZEN_NAMESPACE/zen-minio-0:/workdir/home/.minio/backup 
+            oc -n $ZEN_NAMESPACE exec -t zen-minio-0 -- bash -c "export HOME=/workdir/home/.minio && /workdir/bin/mc alias set zenobjstore ${OBJECTSTORE_ENDPOINT} $(<${BACKUP_DIR}/workspace/accesskey) $(<${BACKUP_DIR}/workspace/secretkey) --config-dir=/workdir/home/.minio/.mc --insecure && /workdir/bin/mc cp --recursive /workdir/home/.minio/backup/objstorage/${IBM_ZEN_BUCKET_NAME}/ zenobjstore/${IBM_ZEN_BUCKET_NAME}/ --insecure"
+        else
+            info "IS_EMBEDDED_OBJECTSTORE value false, skipping objectstore restore."
+        fi
+
+        #[2.2.4.3] Restore JWT configuration and keys
+        info "Restore JWT configuration and keys."
+        oc patch secret -n $ZEN_NAMESPACE ibm-zen-secret-jwks --patch="{\"data\": { \"jwks.json\": \"$(base64 -w0 $BACKUP_DIR/secrets/jwks/jwks.json)\" }}"
+        oc patch secret -n $ZEN_NAMESPACE ibm-zen-secret-jwks --patch="{\"data\": { \"key_id\": \"$(base64 -w0 $BACKUP_DIR/secrets/jwks/key_id)\" }}"
+        oc patch secret -n $ZEN_NAMESPACE ibm-zen-secret-jwt --patch="{\"data\": { \"public.pem\": \"$(base64 -w0 $BACKUP_DIR/secrets/public.pem)\" }}"
+        oc patch secret -n $ZEN_NAMESPACE ibm-zen-secret-jwt --patch="{\"data\": { \"jwt.cert\": \"$(base64 -w0 $BACKUP_DIR/secrets/jwt.cert)\" }}"
+        oc patch secret -n $ZEN_NAMESPACE ibm-zen-secret-jwt-private --patch="{\"data\": { \"private.pem\": \"$(base64 -w0 $BACKUP_DIR/secrets/private.pem)\" }}"
+        oc patch secret -n $ZEN_NAMESPACE zen-secrets-aes-key --patch="{\"data\": { \"aes_key\": \"$(base64 -w0 $BACKUP_DIR/secrets/aes_key)\" }}"
+        oc patch secret -n $ZEN_NAMESPACE admin-user-details --patch="{\"data\": { \"initial_admin_password\": \"$(base64 -w0 $BACKUP_DIR/secrets/initial_admin_password)\" }}"
+
+        #Update zen extensions
+        if [[ $ZEN_CORE_RC == "0" ]]; then
+            info "zen-core deployment not scaled up before rerunning, setting replica value to 2"
+            ZEN_CORE_RC=2
+        fi
+        if [[ $USERMGMT_RC == "0" ]]; then
+            info "usermgmt deployment not scaled up before rerunning, setting replica value to 2"
+            USERMGMT_RC=2
+        fi
+        oc scale deploy zen-core --replicas=$ZEN_CORE_RC -n $ZEN_NAMESPACE
+        oc scale deploy usermgmt --replicas=$USERMGMT_RC -n $ZEN_NAMESPACE
+        sleep 15
+        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-core --timeout=180s -n ${ZEN_NAMESPACE}
+        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=usermgmt --timeout=180s -n ${ZEN_NAMESPACE}
+        
+        ./zen5/customize-zen-extensions.sh $ZEN_NAMESPACE false
+        
+        #[2.2.5] Scale up deployments and Disable Zen operator maintenance mode
+        #[2.2.5.1] Scale up the deployments
+        info "Scale up deployments."
+        if [[ $IBM_NGINX_RC == "0" ]]; then
+            info "ibm-nginx deployment not scaled up before rerunning, setting replica value to 2"
+            IBM_NGINX_RC=2
+        fi
+        if [[ $ZEN_CORE_API_RC == "0" ]]; then
+            info "zen-core-api deployment not scaled up before rerunning, setting replica value to 2"
+            ZEN_CORE_API_RC=2
+        fi
+        if [[ $ZEN_WATCHER_RC == "0" ]]; then
+            info "zen-watcher deployment not scaled up before rerunning, setting replica value to 1"
+            ZEN_WATCHER_RC=1
+        fi
+        
+        oc scale deploy zen-watcher --replicas=$ZEN_WATCHER_RC -n $ZEN_NAMESPACE
+        oc scale deploy zen-core-api --replicas=$ZEN_CORE_API_RC -n $ZEN_NAMESPACE
+        oc scale deploy ibm-nginx --replicas=$IBM_NGINX_RC -n $ZEN_NAMESPACE
+        if [[ $zen_watchdog_present != "fail" ]]; then
+            oc scale deploy zen-watchdog --replicas=1 -n $ZEN_NAMESPACE # (Only for CloudPak for Data)
+        fi
+
+        #[2.2.5.2] Wait for deployments
+        info "Wait for deployments to come ready again."
+        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=ibm-nginx --timeout=180s -n ${ZEN_NAMESPACE}
+        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-core-api --timeout=180s -n ${ZEN_NAMESPACE}
+        oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-watcher --timeout=180s -n ${ZEN_NAMESPACE}
+        
+        if [[ $zen_watchdog_present != "fail" ]]; then # Only for CloudPak for Data
+            oc wait pod --for=condition=Ready -l app.kubernetes.io/component=zen-watchdog --timeout=180s -n ${ZEN_NAMESPACE}
+        fi
+
+        #[2.2.5.3] Restart zen-watcher
+        info "Restart zen-watcher."
+        oc delete pods -l component=zen-watcher -n ${ZEN_NAMESPACE} --ignore-not-found
+
+        #[2.2.5.4] Enable backup cronjob
+        info "Enable backup cronjob."
+        oc patch cj zen-metastore-backup-cron-job --namespace ${ZEN_NAMESPACE} --type=merge --patch '{"spec": {"suspend": false}}'
+
+        #[2.2.5.5] remove zenservice from maintenance mode
+        info "Remove zenservice from maintenance mode."
+        oc patch zenservice ${ZENSERVICE_NAME} --namespace ${ZEN_NAMESPACE} --type=merge --patch '{"spec": {"ignoreForMaintenance": false}}'
+
+        #Re-run iam config job
+        info "Rerunning IAM config job..."
+        oc -n $ZEN_NAMESPACE get job iam-config-job -o yaml > /tmp/iam-config-job.yaml
+        oc -n $ZEN_NAMESPACE delete job iam-config-job
+        yq -i 'del(.metadata.creationTimestamp) | del(.metadata.managedFields) | del(.metadata.resourceVersion) | del(.metadata.uid) | del(.spec.selector) | del(.spec.template.metadata.labels) | del(.status)' /tmp/iam-config-job.yaml || error "Failed to remove metadata fields from temp iam config job yaml for namespace ${ZEN_NAMESPACE}."
+        info "Wait for previous job to delete..."
+        sleep 30
+        oc apply -f /tmp/iam-config-job.yaml
+        rm -f /tmp/iam-config-job.yaml
+        wait_for_iam_config
+        success "Restore complete for zenservice $ZENSERVICE_NAME in namespace $ZEN_NAMESPACE."
+    }
+
+    function wait_for_zenservice {
+        info "Waiting for zenservice $ZENSERVICE_NAME to complete in namespace $ZEN_NAMESPACE."
+        zenservice_exists=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE --no-headers || echo fail)
+        if [[ $zenservice_exists != "fail" ]]; then
+            completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.progress}')
+            retry_count=60
+            while [[ $completed != "100%" ]] && [[ $retry_count > 0 ]]
+            do
+                info "Wait for zenservice $ZENSERVICE_NAME to complete. Completion % is $completed. Try again in 60s."
+                sleep 60
+                completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.progress}')
+                retry_count=$((retry_count-1))
+            done
+
+            if [[ $retry_count == 0 ]] && [[ $completed != "100%" ]]; then
+                error "Timed out waiting for zenservice $ZENSERVICE_NAME."
+            else
+                info "Zenservice $ZENSERVICE_NAME ready."
+            fi
+        else
+            error "Zenservice $ZENSERVICE_NAME not present."
+        fi
+    }
+
+    function wait_for_iam_config {
+        job_name="iam-config-job"
+        info "Waiting for job $job_name to complete in namespace $ZEN_NAMESPACE."
+        job_exists=$(oc get job $job_name -n $ZEN_NAMESPACE --no-headers || echo fail)
+        if [[ $job_exists != "fail" ]]; then
+            completed=$(oc get job $job_name -n $ZEN_NAMESPACE --no-headers | awk '{print $2}')
+            retry_count=20
+            while ([[ $completed != "1/1" ]] && [[ $completed != "Complete" ]]) && [[ $retry_count > 0 ]]
+            do
+                info "Wait for job $job_name to complete. Try again in 15s."
+                sleep 15
+                completed=$(oc get job $job_name -n $ZEN_NAMESPACE --no-headers | awk '{print $2}')
+                retry_count=$((retry_count-1))
+            done
+
+            if [[ $retry_count == 0 ]] && ([[ $completed != "1/1" ]] && [[ $completed != "Complete" ]]); then
+                error "Timed out waiting for job $job_name."
+            else
+                info "Job $job_name completed."
+            fi
+        else
+            error "Job $job_name not present."
+        fi
+    }
+
+    function save_log(){
+        local LOG_DIR="$BACKUP_DIR/$1"
+        LOG_FILE="$LOG_DIR/$2_$(date +'%Y%m%d%H%M%S').log"
+
+        if [[ ! -d $LOG_DIR ]]; then
+            mkdir -p "$LOG_DIR"
+        fi
+
+        # Create a named pipe
+        PIPE=$(mktemp -u)
+        mkfifo "$PIPE"
+
+        # Tee the output to both the log file and the terminal
+        tee "$LOG_FILE" < "$PIPE" &
+
+        # Redirect stdout and stderr to the named pipe
+        exec > "$PIPE" 2>&1
+
+        # Remove the named pipe
+        rm "$PIPE"
+    }
+
+    function cleanup_log() {
+        # Check if the log file already exists
+        if [[ -e $LOG_FILE ]]; then
+            # Remove ANSI escape sequences from log file
+            sed -E 's/\x1B\[[0-9;]+[A-Za-z]//g' "$LOG_FILE" > "$LOG_FILE.tmp" && mv "$LOG_FILE.tmp" "$LOG_FILE"
+        fi
+    }
+
+    function msg() {
+        printf '%b\n' "$1"
+    }
+
+    function success() {
+        msg "\33[32m[✔] ${1}\33[0m"
+    }
+
+    function warning() {
+        msg "\33[33m[✗] ${1}\33[0m"
+    }
+
+    function error() {
+        msg "\33[31m[✘] ${1}\33[0m"
+        exit 1
+    }
+
+    function title() {
+        msg "\33[34m# ${1}\33[0m"
+    }
+
+    function info() {
+        msg "[INFO] ${1}"
+    }
+
+    main $*
+  customize-zen-extensions.sh: |
+    #!/usr/bin/env bash
+    #
+    # Copyright 2023 IBM Corporation
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    # http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    #
+    set -o errexit
+
+    ZEN_NAMESPACE=$1
+    BACKUP=$2
+
+    function main(){
+
+        title "Begin zen extension cleanup process."
+        # Get broker secret value from secret zen-service-broker-secret
+        broker_secret=$(oc get secret zen-service-broker-secret -o yaml -n $ZEN_NAMESPACE | yq .data.token | base64 -d || echo "fail") 
+        if [[ $broker_secret == "fail" ]]; then
+            error "Failed to grab broker secret zen-service-broker-secret in namespace $ZEN_NAMESPACE, exiting."
+        else
+            info "Broker Secret obtained in namespace $ZEN_NAMESPACE"
+        fi
+        if [[ $BACKUP == "true" ]]; then
+            extension_check=$(oc get zenextension -n $ZEN_NAMESPACE -o name | grep -v "common-web-ui-zen-extension\|zen-watchdog-frontdoor-extension" || echo "empty")
+            if [[ $extension_check != "empty" ]]; then
+                extensions=""
+                for ext in $extension_check
+                do
+                    ext_name=$(oc get $ext -n $ZEN_NAMESPACE -o jsonpath={.spec.extensions} | grep extension_name | awk '{print $2}' | tr '\"\n' ' ' | tr "," " ")
+                    if [[ $extensions == "" ]]; then
+                        extensions="$ext_name,"
+                    else
+                        extensions="$extensions,$ext_name"
+                    fi
+                done
+                
+                extensions=$(echo $extensions | tr "," " ")
+                echo $extensions
+                
+                cat <<< $extensions > /zen5/zen-backup/extensions.txt
+                success "Extensions captured for backup:"
+                cat /zen5/zen-backup/extensions.txt
+            else
+                info "No extensions found in namespace $ZEN_NAMESPACE other than defaults, exiting."
+            fi
+        fi
+        
+        if [[ $BACKUP == "false" ]]; then
+            if [[ -f /zen5/zen-backup/extensions.txt ]]; then
+                extensions=$(cat /zen5/zen-backup/extensions.txt)
+                echo $extensions
+                extensions=$(echo $extensions | tr " " ",")
+                info "Extensions to cleanup in namespace $ZEN_NAMESPACE: $extensions"
+                # curl -H 'secret: <broker-secret>' -ks https://zen-core-api-svc:4444/v1/extensions?extension_name=bawtest-bas-extension,ibm-bts-zen-frontdoor,icp4adeploy-ban-zen-extension,icp4adeploy-cp4ba-zen-extension,icp4adeploy-graphql-zen-extension,icp4adeploy-cmis-zen-extension,icp4adeploy-cpe-zen-extension,icp4adeploy-rr-bawtest-zen-ext
+                #curl_output=$(curl -H "secret: ${broker_secret}" -ks https://zen-core-api-svc:4444/v1/extensions?extension_name=${extensions})
+
+                # Extract ID of each extension
+                id_list=$(curl -H "secret: ${broker_secret}" -ks https://zen-core-api-svc:4444/v1/extensions?extension_name=${extensions} | yq eval '.data[] | select(.source == "*") | .source' | tr '\n' ' ') #space separated list of ids
+                info "id_list: $id_list bookend"
+                if [[ -z $id_list ]] || [[ $id_list == "" ]]; then
+                    warning "The list of extensions provided returned an empty ID list from the database. These extensions may not be present in this database."
+                else
+                    info "List of extension IDs populated, continuing with deletion."
+                    id_list=${id_list//\//%2F}
+                    info "id_list with / replaced: $id_list"
+
+                    # Delete each extension using the ID
+                    # curl -H 'secret: <broker-secret>' -ks -X DELETE https://zen-core-api-svc:4444/v1/internal/extensions/{source_id}
+                    for id in $id_list; do
+                        info "Deleting extension with ID $id."
+                        curl -H "secret: ${broker_secret}" -ks -X DELETE https://zen-core-api-svc:4444/v1/internal/extensions/{$id}
+                    done
+
+                    success "Zen extension cleanup complete."
+                fi
+            else
+                info "File /zen5/zen-backup/extensions.txt not found, skipping zenextension cleanup."
+            fi
+        fi
+    }
+
+    function msg() {
+        printf '%b\n' "$1"
+    }
+
+    function success() {
+        msg "\33[32m[✔] ${1}\33[0m"
+    }
+
+    function warning() {
+        msg "\33[33m[✗] ${1}\33[0m"
+    }
+
+    function error() {
+        msg "\33[31m[✘] ${1}\33[0m"
+        exit 1
+    }
+
+    function title() {
+        msg "\33[34m# ${1}\33[0m"
+    }
+
+    function info() {
+        msg "[INFO] ${1}"
+    }
+
+    main $*

--- a/velero/schedule/ibm-pg/zen-metastore/zen5-role.yaml
+++ b/velero/schedule/ibm-pg/zen-metastore/zen5-role.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: zen5-backup-role
+  namespace: <zenservice namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: zen5-data
+rules:
+  - verbs:
+      - create
+      - get
+      - delete
+      - watch
+      - update
+      - list
+      - patch
+    apiGroups:
+      - ''
+      - batch
+      - extensions
+      - apps
+      - policy
+    resources:
+      - pods
+      - secrets
+      - configmaps
+      - deployments
+      - deployments/scale
+      - cronjobs
+      - pods/exec
+      - cronjob
+      - jobs
+  - verbs:
+      - get
+      - list
+      - patch
+    apiGroups:
+      - zen.cpd.ibm.com
+      - pg.ibm.com
+    resources:
+      - zenservices
+      - zenextensions
+      - clusters
+  - verbs:
+      - get
+    apiGroups:
+      - ""
+    resources:
+      - configmaps

--- a/velero/schedule/ibm-pg/zen-metastore/zen5-rolebinding.yaml
+++ b/velero/schedule/ibm-pg/zen-metastore/zen5-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: zen5-backup-rolebinding
+  namespace: <zenservice namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: zen5-data
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: zen5-backup-role
+  namespace: <zenservice namespace>
+subjects:
+- kind: ServiceAccount
+  name: zen5-backup-sa
+  namespace: <zenservice namespace>

--- a/velero/schedule/ibm-pg/zen-metastore/zen5-sa.yaml
+++ b/velero/schedule/ibm-pg/zen-metastore/zen5-sa.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: zen5-backup-sa
+  namespace: <zenservice namespace>
+  labels:
+    foundationservices.cloudpak.ibm.com: zen5-data

--- a/velero/schedule/schedule-common-services.yaml
+++ b/velero/schedule/schedule-common-services.yaml
@@ -39,8 +39,8 @@ spec:
         - crd
         - lsr #non-data license service reporter resources
         - lsr-data #license service reporter data
-        - cs-db-data #pgdump approach to BR IM EDB data
-        - cs-db #velero plugin approach to BR IM EDB data
+        - cs-db-data #pgdump approach to BR IM DB data
+        - cs-db #velero plugin approach to BR IM DB data
         - keycloak-data #pgdump approach to BR keycloak data
         - keycloak #velero plugin approach to BR keycloak data
         - user-mgmt #non-data user-management operator resources
@@ -55,6 +55,8 @@ spec:
         - zen-cluster
         - edb-chart
         - edb-cluster
+        - ibm-pg-chart
+        - ibm-pg-cluster
         - iam-chart
         - iam-cluster
         - nss-cluster

--- a/velero/spectrum-fusion/recipes/4.7-example-recipe-multi-ns-multi-zen.yaml
+++ b/velero/spectrum-fusion/recipes/4.7-example-recipe-multi-ns-multi-zen.yaml
@@ -253,7 +253,7 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      labelSelector: 'foundationservices.cloudpak.ibm.com=cs-db,role=primary'
       name: common-service-db-check
       namespace: <service namespace>
       onError: fail

--- a/velero/spectrum-fusion/recipes/4.7-example-recipe-multi-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.7-example-recipe-multi-ns.yaml
@@ -250,7 +250,7 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      labelSelector: 'foundationservices.cloudpak.ibm.com=cs-db,role=primary'
       name: common-service-db-check
       namespace: <service namespace>
       onError: fail

--- a/velero/spectrum-fusion/recipes/4.7-example-recipe-single-ns.yaml
+++ b/velero/spectrum-fusion/recipes/4.7-example-recipe-single-ns.yaml
@@ -239,7 +239,7 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      labelSelector: 'foundationservices.cloudpak.ibm.com=cs-db,role=primary'
       name: common-service-db-check
       namespace: <operator namespace>
       onError: fail

--- a/velero/spectrum-fusion/recipes/4.8-example-csdb-sync-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/4.8-example-csdb-sync-recipe.yaml
@@ -40,7 +40,7 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      labelSelector: 'foundationservices.cloudpak.ibm.com=cs-db,role=primary'
       name: common-service-db-check
       namespace: <service namespace>
       onError: fail

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/core/child-csdb-recipe-2.10.0.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/core/child-csdb-recipe-2.10.0.yaml
@@ -33,7 +33,7 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      labelSelector: 'foundationservices.cloudpak.ibm.com=cs-db,role=primary'
       name: common-service-db-check
       namespace: <child recipe namespace>
       onError: fail

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/core/child-csdb-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/core/child-csdb-recipe.yaml
@@ -45,7 +45,7 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      labelSelector: 'foundationservices.cloudpak.ibm.com=cs-db,role=primary'
       name: common-service-db-check
       namespace: <child recipe namespace>
       onError: fail

--- a/velero/spectrum-fusion/recipes/dynamic-recipes/core/child-zen-recipe-ibm-pg.yaml
+++ b/velero/spectrum-fusion/recipes/dynamic-recipes/core/child-zen-recipe-ibm-pg.yaml
@@ -1,0 +1,112 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  labels:
+    dp.isf.ibm.com/parent-recipe: cpfs-parent-recipe
+    dp.isf.ibm.com/parent-recipe-namespace: <parent recipe namespace>
+  name: zen-child-<child recipe namespace>
+  namespace: <child recipe namespace>
+spec:
+  appType: common-service
+  groups:
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen-volume
+      includedNamespaces:
+        - <child recipe namespace>
+      type: volume
+    - includeClusterResources: true
+      includedResourceTypes:
+        - zenservices.zen.cpd.ibm.com
+        - customresourcedefinitions.apiextensions.k8s.io
+      labelSelector: foundationservices.cloudpak.ibm.com=zen
+      name: zenservice
+      includedNamespaces:
+        - <child recipe namespace>
+      type: resource
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: zen-pre-deploy
+      includedNamespaces:
+        - <child recipe namespace>
+      type: resource
+    - includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      includedResourceTypes:
+        - deployments
+      name: zen-deployment
+      includedNamespaces:
+        - <child recipe namespace>
+      type: resource
+  hooks:
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 1200
+      labelSelector: 'pg.ibm.com/cluster=zen-metastore,role=primary'
+      name: zen-metastore-edb-check
+      namespace: <child recipe namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 1200
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen5-deployment
+      namespace: <child recipe namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen5-data
+      namespace: <child recipe namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace; /zen5/backup_zen5.sh <child recipe namespace>"]
+          container: zen5-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/zen5/restore_zen5.sh <child recipe namespace> <zenservice name>"]
+          container: zen5-backup-job
+          name: restore
+          timeout: 3600
+      selectResource: pod
+      type: exec
+  workflows:
+    - name: pre-backup
+      priority: 2
+      sequence:
+        #zen
+        - hook: zen5-data/backup
+    - name: post-backup
+      priority: 0
+      sequence:
+        - group: zenservice
+        - group: zen-pre-deploy
+        - group: zen-deployment
+        #volumes (should happen at the end)
+        - group: zen-volume
+    - name: data-restore
+      priority: 1
+      sequence:
+        #zen
+        - group: zenservice
+        - hook: zen-metastore-edb-check/podReady
+        - group: zen-pre-deploy
+        - group: zen-volume
+        - group: zen-deployment
+        - hook: zen5-deployment/podReady
+        - hook: zen5-data/restore
+    

--- a/velero/spectrum-fusion/recipes/no-olm/core/child-csdb-recipe-2.10.0.yaml
+++ b/velero/spectrum-fusion/recipes/no-olm/core/child-csdb-recipe-2.10.0.yaml
@@ -33,7 +33,7 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      labelSelector: 'foundationservices.cloudpak.ibm.com=cs-db,role=primary'
       name: common-service-db-check
       namespace: <child recipe namespace>
       onError: fail

--- a/velero/spectrum-fusion/recipes/no-olm/core/child-csdb-recipe.yaml
+++ b/velero/spectrum-fusion/recipes/no-olm/core/child-csdb-recipe.yaml
@@ -45,7 +45,7 @@ spec:
           name: podReady
           onError: fail
           timeout: 600
-      labelSelector: 'k8s.enterprisedb.io/cluster=common-service-db,role=primary'
+      labelSelector: 'foundationservices.cloudpak.ibm.com=cs-db,role=primary'
       name: common-service-db-check
       namespace: <child recipe namespace>
       onError: fail

--- a/velero/spectrum-fusion/recipes/no-olm/core/child-zen-recipe-ibm-pg.yaml
+++ b/velero/spectrum-fusion/recipes/no-olm/core/child-zen-recipe-ibm-pg.yaml
@@ -1,0 +1,101 @@
+apiVersion: spp-data-protection.isf.ibm.com/v1alpha1
+kind: Recipe
+metadata:
+  labels:
+    dp.isf.ibm.com/parent-recipe: cpfs-parent-recipe
+    dp.isf.ibm.com/parent-recipe-namespace: <parent recipe namespace>
+  name: zen-child-<child recipe namespace>
+  namespace: <child recipe namespace>
+spec:
+  appType: common-service
+  groups:
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen-volume
+      includedNamespaces:
+        - <child recipe namespace>
+      type: volume
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      includeClusterResources: true
+      includedResourceTypes:
+        - serviceaccount
+        - role
+        - rolebinding
+        - configmaps
+      name: zen-pre-deploy
+      includedNamespaces:
+        - <child recipe namespace>
+      type: resource
+    - includeClusterResources: true
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      includedResourceTypes:
+        - deployments
+      name: zen-deployment
+      includedNamespaces:
+        - <child recipe namespace>
+      type: resource
+  hooks:
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 1200
+      labelSelector: 'pg.ibm.com/cluster=zen-metastore,role=primary'
+      name: zen-metastore-edb-check
+      namespace: <child recipe namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 1200
+      type: check
+    - chks:
+        - condition: '{$.status.phase} == {"Running"}'
+          name: podReady
+          onError: fail
+          timeout: 600
+      labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen5-deployment
+      namespace: <child recipe namespace>
+      onError: fail
+      selectResource: pod
+      timeout: 600
+      type: check
+    - labelSelector: foundationservices.cloudpak.ibm.com=zen5-data
+      name: zen5-data
+      namespace: <child recipe namespace>
+      onError: fail
+      ops:
+        - command: |
+            ["/bin/bash", "-c", "rm -rf /zen5/zen-backup/database && rm -rf /zen5/zen-backup/objstorage && rm -rf /zen5/zen-backup/secrets && rm -rf /zen5/zen-backup/workspace; /zen5/backup_zen5.sh <child recipe namespace>"]
+          container: zen5-backup-job
+          name: backup
+          timeout: 600
+        - command: |
+            ["/bin/bash", "-c", "/zen5/restore_zen5.sh <child recipe namespace> <zenservice name>"]
+          container: zen5-backup-job
+          name: restore
+          timeout: 3600
+      selectResource: pod
+      type: exec
+  workflows:
+    - name: pre-backup
+      priority: 2
+      sequence:
+        #zen
+        - hook: zen5-data/backup
+    - name: post-backup
+      priority: 0
+      sequence:
+        - group: zen-pre-deploy
+        - group: zen-deployment
+        #volumes (should happen at the end)
+        - group: zen-volume
+    - name: data-restore
+      priority: 1
+      sequence:
+        #zen
+        - hook: zen-metastore-edb-check/podReady
+        - group: zen-pre-deploy
+        - group: zen-volume
+        - group: zen-deployment
+        - hook: zen5-deployment/podReady
+        - hook: zen5-data/restore
+    


### PR DESCRIPTION

**Overview:**
This PR adds support for backing up and restoring Cloud Pak Foundational Services (CPFS) and Zen with IBM PostgreSQL (IBM PG) on both OLM and Helm deployments using OADP (OpenShift API for Data Protection).

**Key Changes:**

### 1. **PostgreSQL Operator Detection** (`br-testing-automation/fusion-backup-setup.sh`)
- Added `detect_zen_operator()` function to automatically detect whether IBM CloudNativePG or EDB PostgreSQL operator is being used
- Implements logic to check for IBM CNPG cluster in zen-metastore namespace
- Falls back to EDB if no IBM PG cluster is found (backward compatibility)

### 2. **Dynamic Recipe Selection**
- Automatically copies appropriate recipe files based on detected operator type:
  - IBM CNPG: Uses `child-zen-recipe-ibm-pg.yaml` templates
  - EDB: Uses `child-zen-recipe-2.10.0.yaml` templates (existing behavior)
- Applies to both no-olm and dynamic-recipes directories

### 3. **Backup Configuration Updates** (`velero/backup/backup.yaml`)
- Added new backup targets:
  - `ibm-pg-chart` - IBM PostgreSQL Helm chart resources
  - `ibm-pg-cluster` - IBM PostgreSQL cluster resources

### 4. **Labeling Script Enhancements** (`velero/backup/cert-manager/label-cert-manager.sh`)
- Added logic to remove labels from zen-metastore secrets and certificates
- Prevents zen-metastore DB resources from being backed up with cert-manager
- Ensures proper separation of concerns between different backup components

### 5. **Common Service Labeling** (`velero/backup/common-service/label-common-service.sh`)
- Refactored catalog source handling for better maintainability
- Added support for IBM PG cluster resources labeling:
  - `ibm-pg-operator` deployment
  - `ibm-pg-cluster` rolebinding and webhook configurations
  - IBM PG release resources
- Improved secret labeling logic for License Service Reporter credentials

### 6. **New Recipe Files**
Multiple new recipe YAML files added for IBM PG support in Spectrum Fusion backup/restore scenarios

**Testing:**
- OLM BR test results included showing successful backup operations
- Fusion backup test results demonstrate successful backup with the new IBM PG support

**Impact:**
- Enables backup and restore for environments using IBM CloudNativePG operator
- Maintains backward compatibility with existing EDB PostgreSQL deployments
- Improves automation by detecting operator type automatically

**Which issue(s) this PR fixes**:
Fixes #  https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67586
