### PR TITLE
add new permission for ibm-pg

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -1789,3 +1789,171 @@ rules:
     resources:
       - remotekuberestemplate
       - remotekuberestemplates
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - backups
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - backups/status
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - clusterimagecatalogs
+  - verbs:
+      - update
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - clusters/finalizers
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - databases
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - databases/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - failoverquorums
+  - verbs:
+      - get
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - failoverquorums/status
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - imagecatalogs
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - poolers
+  - verbs:
+      - update
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - poolers/finalizers
+  - verbs:
+      - get
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - poolers/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - publications
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - publications/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - scheduledbackups
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - scheduledbackups/status
+  - verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - subscriptions
+  - verbs:
+      - get
+      - patch
+      - update
+    apiGroups:
+      - pg.ibm.com
+    resources:
+      - subscriptions/status


### PR DESCRIPTION
adding `pg.ibm.com` permission rules to nss-managed-bedrock-core-role.yaml:
```
backups (create, delete, get, list, patch, update, watch)
backups/status (get, patch, update)
clusterimagecatalogs (get, list, watch)
clusters/finalizers (update)
databases (create, delete, get, list, patch, update, watch)
databases/status (get, patch, update)
failoverquorums (create, delete, get, list, watch)
failoverquorums/status (get, patch, update, watch)
imagecatalogs (get, list, watch)
poolers (create, delete, get, list, patch, update, watch)
poolers/finalizers (update)
poolers/status (get, patch, update, watch)
publications (create, delete, get, list, patch, update, watch)
publications/status (get, patch, update)
scheduledbackups (create, delete, get, list, patch, update, watch)
scheduledbackups/status (get, patch, update)
subscriptions (create, delete, get, list, patch, update, watch)
subscriptions/status (get, patch, update)
```