### PR TITLE
feat: add pg-migrator ODLM entries for EDB to IBM PG migration

### DIFF
--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -978,6 +978,7 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool, csInstance *ap
 		constant.KeyCloakOpCon,
 		constant.CommonServicePGOpCon,
 		constant.CommonServiceCNPGOpCon,
+		constant.CommonServicePGMigratorOpCon,
 	}
 
 	baseCon = constant.CSV4OpCon
@@ -1011,7 +1012,7 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool, csInstance *ap
 	return nil
 }
 
-// InstallOrUpdateOpcon will install or update OperandConfig when Opcon CRD is existent
+// InstallOrUpdateOperatorConfig installs or updates the OperatorConfig resource.
 func (b *Bootstrap) InstallOrUpdateOperatorConfig(config string, forceUpdateODLMCRs bool) error {
 	// clean up OperatorConfigs not in servicesNamespace every time function is called
 	opts := []client.ListOption{

--- a/internal/controller/bootstrap/operandregistry.go
+++ b/internal/controller/bootstrap/operandregistry.go
@@ -90,6 +90,7 @@ func (b *Bootstrap) buildOperandRegistry(ctx context.Context, installPlanApprova
 		constant.KeyCloakOpReg,
 		constant.CommonServicePGOpReg,
 		constant.CommonServiceCNPGOpReg,
+		constant.CommonServicePGMigratorOpReg,
 	}
 
 	if b.SaasEnable {

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -589,24 +589,24 @@ const (
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
-	 name: common-service
-	 namespace: "{{ .ServicesNs }}"
-	 labels:
-	   operator.ibm.com/managedByCsOperator: "true"
-	 annotations:
-	   version: {{ .Version }}
-	   excluded-catalogsource: {{ .ExcludedCatalog }}
-	   status-monitored-services: {{ .StatusMonitoredServices }}
+  name: common-service
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: {{ .ExcludedCatalog }}
+    status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
-	 operators:
-	 - channel: v28
-	   installPlanApproval: {{ .ApprovalMode }}
-	   name: common-service-cnpg
-	   namespace: "{{ .CPFSNs }}"
-	   packageName: ibm-pg-operator
-	   scope: public
-	   sourceName: {{ .CatalogSourceName }}
-	   sourceNamespace: "{{ .CatalogSourceNs }}"
+  operators:
+  - channel: v28
+    installPlanApproval: {{ .ApprovalMode }}
+    name: common-service-cnpg
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-pg-operator
+    scope: public
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 
 	// CommonServicePGMigratorOpReg defines the OperandRegistry for the PG migrator
@@ -615,23 +615,23 @@ spec:
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
-	 name: common-service-pg-migrator
-	 namespace: "{{ .ServicesNs }}"
-	 labels:
-	   operator.ibm.com/managedByCsOperator: "true"
-	 annotations:
-	   version: {{ .Version }}
-	   excluded-catalogsource: {{ .ExcludedCatalog }}
+  name: common-service-pg-migrator
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+    excluded-catalogsource: {{ .ExcludedCatalog }}
 spec:
-	 operators:
-	 - channel: v28
-	   installPlanApproval: {{ .ApprovalMode }}
-	   name: common-service-pg-migrator
-	   namespace: "{{ .CPFSNs }}"
-	   packageName: ibm-pg-operator
-	   scope: public
-	   sourceName: {{ .CatalogSourceName }}
-	   sourceNamespace: "{{ .CatalogSourceNs }}"
+  operators:
+  - channel: v28
+    installPlanApproval: {{ .ApprovalMode }}
+    name: common-service-pg-migrator
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-pg-operator
+    scope: public
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2467,11 +2467,11 @@ spec:
           description: "Configuration for EDB to IBM PG migration"
         data:
           data:
-            MIGRATION_NAMESPACE: "{{ .ServicesNs }}"
-            MIGRATION_CLUSTER: "common-service-db"
-            MIGRATION_TIMEOUT: "120"
-            MIGRATION_SKIP_EDB_CLEANUP: "true"
-            MIGRATION_SKIP_OPERATOR_VALIDATION: "true"
+            NAMESPACE: "{{ .ServicesNs }}"
+            CLUSTER_NAME: "common-service-db"
+            TIMEOUT: "120"
+            SKIP_EDB_CLEANUP: "true"
+            SKIP_OPERATOR_VALIDATION: "true"
       - apiVersion: v1
         kind: ServiceAccount
         name: common-service-db-pg-migration-sa
@@ -2635,6 +2635,12 @@ spec:
                         ephemeral-storage: 256Mi
                     command:
                       - /usr/local/bin/pg-migrate
+                    args:
+                      - --namespace=$(NAMESPACE)
+                      - --cluster=$(CLUSTER_NAME)
+                      - --timeout=$(TIMEOUT)
+                      - --skip-edb-cleanup=$(SKIP_EDB_CLEANUP)
+                      - --skip-operator-validation=$(SKIP_OPERATOR_VALIDATION)
                     envFrom:
                       - configMapRef:
                           name: cpfs-migration-config

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -589,24 +589,49 @@ const (
 apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
-  name: common-service
-  namespace: "{{ .ServicesNs }}"
-  labels:
-    operator.ibm.com/managedByCsOperator: "true"
-  annotations:
-    version: {{ .Version }}
-    excluded-catalogsource: {{ .ExcludedCatalog }}
-    status-monitored-services: {{ .StatusMonitoredServices }}
+	 name: common-service
+	 namespace: "{{ .ServicesNs }}"
+	 labels:
+	   operator.ibm.com/managedByCsOperator: "true"
+	 annotations:
+	   version: {{ .Version }}
+	   excluded-catalogsource: {{ .ExcludedCatalog }}
+	   status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
-  operators:
-  - channel: v28
-    installPlanApproval: {{ .ApprovalMode }}
-    name: common-service-cnpg
-    namespace: "{{ .CPFSNs }}"
-    packageName: ibm-pg-operator
-    scope: public
-    sourceName: {{ .CatalogSourceName }}
-    sourceNamespace: "{{ .CatalogSourceNs }}"
+	 operators:
+	 - channel: v28
+	   installPlanApproval: {{ .ApprovalMode }}
+	   name: common-service-cnpg
+	   namespace: "{{ .CPFSNs }}"
+	   packageName: ibm-pg-operator
+	   scope: public
+	   sourceName: {{ .CatalogSourceName }}
+	   sourceNamespace: "{{ .CatalogSourceNs }}"
+`
+
+	// CommonServicePGMigratorOpReg defines the OperandRegistry for the PG migrator
+	// This installs the IBM PG operator v28 as a prerequisite for EDB to IBM PG migration
+	CommonServicePGMigratorOpReg = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandRegistry
+metadata:
+	 name: common-service-pg-migrator
+	 namespace: "{{ .ServicesNs }}"
+	 labels:
+	   operator.ibm.com/managedByCsOperator: "true"
+	 annotations:
+	   version: {{ .Version }}
+	   excluded-catalogsource: {{ .ExcludedCatalog }}
+spec:
+	 operators:
+	 - channel: v28
+	   installPlanApproval: {{ .ApprovalMode }}
+	   name: common-service-pg-migrator
+	   namespace: "{{ .CPFSNs }}"
+	   packageName: ibm-pg-operator
+	   scope: public
+	   sourceName: {{ .CatalogSourceName }}
+	   sourceNamespace: "{{ .CatalogSourceNs }}"
 `
 )
 
@@ -2415,6 +2440,204 @@ spec:
             DATABASE_CA_CERT: ca.crt
             DATABASE_CLIENT_KEY: tls.key
             DATABASE_CLIENT_CERT: tls.crt
+`
+
+	// CommonServicePGMigratorOpCon defines the OperandConfig for the PG migrator
+	// This creates the RBAC resources and Job for EDB to IBM PG migration
+	CommonServicePGMigratorOpCon = `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service-pg-migrator
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+  annotations:
+    version: {{ .Version }}
+spec:
+  services:
+  - name: common-service-pg-migrator
+    resources:
+      - apiVersion: v1
+        kind: ConfigMap
+        name: cpfs-migration-config
+        labels:
+          app: cpfs-migrator
+        annotations:
+          description: "Configuration for EDB to IBM PG migration"
+        data:
+          data:
+            MIGRATION_NAMESPACE: "{{ .ServicesNs }}"
+            MIGRATION_CLUSTER: "common-service-db"
+            MIGRATION_TIMEOUT: "120"
+            MIGRATION_SKIP_EDB_CLEANUP: "true"
+            MIGRATION_SKIP_OPERATOR_VALIDATION: "true"
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: common-service-db-pg-migration-sa
+        labels:
+          app: cpfs-pg-migrator
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: Role
+        name: common-service-db-pg-migration-role
+        labels:
+          app: cpfs-pg-migrator
+        data:
+          rules:
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - clusters
+                - clusters/status
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - pg.ibm.com
+              resources:
+                - clusters
+                - clusters/status
+              verbs:
+                - create
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - pods/status
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumeclaims
+                - persistentvolumeclaims/status
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+                - services/status
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+                - patch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - deployments/status
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+      - apiVersion: rbac.authorization.k8s.io/v1
+        kind: RoleBinding
+        name: common-service-db-pg-migration-rolebinding
+        labels:
+          app: cpfs-pg-migrator
+        data:
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: common-service-db-pg-migration-role
+          subjects:
+            - kind: ServiceAccount
+              name: common-service-db-pg-migration-sa
+              namespace: {{ .ServicesNs }}
+      - apiVersion: batch/v1
+        kind: Job
+        name: common-service-db-pg-migration-job
+        labels:
+          app: cpfs-pg-migrator
+          app.kubernetes.io/instance: common-service-db-pg-migration-job
+          app.kubernetes.io/managed-by: common-service-db-pg-migration-job
+        annotations:
+          description: "Migrates EDB PostgreSQL cluster common-service-db to IBM PG Cluster"
+        data:
+          spec:
+            backoffLimit: 2
+            ttlSecondsAfterFinished: 3600
+            template:
+              metadata:
+                labels:
+                  app: cpfs-pg-migrator
+                  app.kubernetes.io/instance: common-service-db-pg-migration-job
+                  app.kubernetes.io/managed-by: common-service-db-pg-migration-job
+              spec:
+                serviceAccountName: common-service-db-pg-migration-sa
+                restartPolicy: Never
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                containers:
+                  - name: migrator
+                    image: {{ .UtilsImage }}
+                    imagePullPolicy: Always
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+                      readOnlyRootFilesystem: false
+                      runAsNonRoot: true
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+                        ephemeral-storage: 256Mi
+                      limits:
+                        cpu: 150m
+                        memory: 512Mi
+                        ephemeral-storage: 256Mi
+                    command:
+                      - /usr/local/bin/pg-migrate
+                    envFrom:
+                      - configMapRef:
+                          name: cpfs-migration-config
 `
 )
 

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2489,6 +2489,7 @@ spec:
               resources:
                 - clusters
                 - clusters/status
+                - clusters/finalizers
               verbs:
                 - get
                 - list
@@ -2501,6 +2502,7 @@ spec:
               resources:
                 - clusters
                 - clusters/status
+                - clusters/finalizers
               verbs:
                 - create
                 - get

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2495,6 +2495,7 @@ spec:
                 - watch
                 - update
                 - patch
+                - delete
             - apiGroups:
                 - pg.ibm.com
               resources:
@@ -2507,6 +2508,7 @@ spec:
                 - watch
                 - update
                 - patch
+                - delete
             - apiGroups:
                 - ""
               resources:
@@ -2518,6 +2520,7 @@ spec:
                 - watch
                 - update
                 - patch
+                - delete
             - apiGroups:
                 - ""
               resources:
@@ -2529,6 +2532,7 @@ spec:
                 - watch
                 - update
                 - patch
+                - delete
             - apiGroups:
                 - ""
               resources:
@@ -2540,6 +2544,7 @@ spec:
                 - watch
                 - update
                 - patch
+                - delete
             - apiGroups:
                 - ""
               resources:
@@ -2550,6 +2555,7 @@ spec:
                 - watch
                 - update
                 - patch
+                - delete
             - apiGroups:
                 - apps
               resources:

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2342,6 +2342,7 @@ spec:
             replicationSlots:
               highAvailability:
                 enabled: true
+                slotPrefix: _cnp_
             certificates:
               clientCASecret: cs-ca-certificate-secret
               replicationTLSSecret: common-service-db-replica-tls-secret


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69195

### Test
1. Install CPFS 4.19 daily drive
2. Replace operator image for common-service-operator to `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/common-service-operator-amd64:d0fddbb`
3. Replace Env variable `CPFS_UTILS_IMAGE` to `docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom/cpfs-utils-amd64:c5a6231`
4. Update CommonService CR `.spec.size: medium`, to ensure that there are multiple replicas for EDB Cluster CR.
5. Create OperandRequest to install EDB Cluster `common-service-db`
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      labels:
      name: example-service
    spec:
      requests:
        - operands:
            - name: common-service-postgresql
          registry: common-service
    ```
6.  Wait for EDB Cluster CR to be in health status
    ```console
    ➜  ~ oc get cluster.postgresql
    NAME                AGE     INSTANCES   READY   STATUS                     PRIMARY
    common-service-db   5m26s   2           2       Cluster in healthy state   common-service-db-1
    ```
7. Update OperandRequest to add additional entry `common-service-pg-migrator`
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      labels:
      name: example-service
    spec:
      requests:
        - operands:
            - name: common-service-postgresql
            - name: common-service-pg-migrator
          registry: common-service
    ```
8. Wait the job `common-service-db-pg-migration-job` to be completed.
    ```console
    ➜  ~ oc get job
    NAME                                 STATUS     COMPLETIONS   DURATION   AGE
    common-service-db-pg-migration-job   Complete   1/1           83s        2m4s
    ```
9. Wait the new IBM PG Cluster CR to be ready
    ```console
    ➜  ~ oc get cluster.pg.ibm.com
    NAME                AGE    INSTANCES   READY   STATUS                     PRIMARY
    common-service-db   103s   2           2       Cluster in healthy state   common-service-db-2
    ```
10. Update OperandRequest to replace entry `common-service-pg-migrator` with `common-service-cnpg`
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      labels:
      name: example-service
    spec:
      requests:
        - operands:
            - name: common-service-postgresql
            - name: common-service-cnpg
          registry: common-service
    ```
11. Wait for IBM PG Cluster CR to be ready again
    ```console
    ➜  ~ oc get cluster.pg.ibm.com
    NAME                AGE     INSTANCES   READY   STATUS                                       PRIMARY
    common-service-db   4m51s   2           1       Waiting for the instances to become active   common-service-db-1
    ➜  ~ oc get cluster.pg.ibm.com
    NAME                AGE     INSTANCES   READY   STATUS                     PRIMARY
    common-service-db   4m53s   2           2       Cluster in healthy state   common-service-db-1
    ```
12. After IBM PG Cluster CR is ready, update OperandRequest to remove entry `common-service-postgresql`
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      labels:
      name: example-service
    spec:
      requests:
        - operands:
            - name: common-service-cnpg
          registry: common-service
    ```
13. This concludes the migration from EDB to IBM PG.