### PR TITLE
Update migration job version to 0.0.4190

### DIFF
--- a/bedrock-migration/Chart.yaml
+++ b/bedrock-migration/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cpfs-migration
 description: A Helm chart for migrating Bedrock from OLM to No OLM
 type: application
-version: 0.0.2
-appVersion: "0.0.2"
+version: 0.0.4190
+appVersion: "0.0.4190"


### PR DESCRIPTION
**What this PR does / why we need it**:
This implies that the migration chart needs to be refreshed with new image for every release, and the image digest will be injected into job template while CICD is building the chart. Subsequently, migration chart version need to be bumped every release like `0.0.x`

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69228