### PR TITLE
feat: add PostgreSQL version support to EDB-to-IBM-PG migration

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2470,6 +2470,7 @@ spec:
           data:
             NAMESPACE: "{{ .ServicesNs }}"
             CLUSTER_NAME: "common-service-db"
+            PG_VERSION: "16"
             TIMEOUT: "120"
             SKIP_EDB_CLEANUP: "true"
             SKIP_OPERATOR_VALIDATION: "true"
@@ -2647,6 +2648,7 @@ spec:
                     args:
                       - --namespace=$(NAMESPACE)
                       - --cluster=$(CLUSTER_NAME)
+                      - --pg-version=$(PG_VERSION)
                       - --timeout=$(TIMEOUT)
                       - --skip-edb-cleanup=$(SKIP_EDB_CLEANUP)
                       - --skip-operator-validation=$(SKIP_OPERATOR_VALIDATION)


### PR DESCRIPTION
## Summary

This PR adds support for specifying PostgreSQL major version during EDB to IBM PG migration in the ODLM configuration. This aligns with the enhancement in the `cpfs-utils` image that enables version-specific image updates during migration per https://github.ibm.com/IBMPrivateCloud/cs-multi-instance-conversion/pull/119

### Key Changes
1. **ConfigMap Enhancement**: Added `PG_VERSION` environment variable with default value of `"16"` (minimum supported PostgreSQL version)
2. **Migration Job Update**: Added `--pg-version` flag to the migration job arguments to pass the version to the migrator
