### PR TITLE
Update IBM PG Cluster configuration to remove EDB labels and align the HA setting with original EDB Cluster

### DIFF
--- a/internal/controller/constant/constant.go
+++ b/internal/controller/constant/constant.go
@@ -133,7 +133,7 @@ const (
 	// CSPGCluster is the name of the common service postgresql cluster
 	CSPGCluster = "common-service-db"
 	// PGClusterGroup is the name of the common service postgresql cluster group
-	PGClusterGroup = "postgresql.k8s.enterprisedb.io"
+	PGClusterGroup = "pg.ibm.com"
 	// PGClusterKind is the kind of the common service postgresql cluster
 	PGClusterKind = "Cluster"
 	// PostgreSQLImageConfigMap is the name of the postgresql image list ConfigMap deployed with Postgres Operator

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2190,7 +2190,7 @@ spec:
             secretName: common-service-db-replica-tls-secret
             secretTemplate:
               labels:
-                k8s.enterprisedb.io/reload: ''
+                pg.ibm.com/reload: ''
             usages:
               - client auth
       - apiVersion: cert-manager.io/v1
@@ -2312,6 +2312,17 @@ spec:
                             - amd64
                             - ppc64le
                             - s390x
+              additionalPodAntiAffinity:
+                preferredDuringSchedulingIgnoredDuringExecution:
+                  - podAffinityTerm:
+                      labelSelector:
+                        matchExpressions:
+                          - key: pg.ibm.com/cluster
+                            operator: In
+                            values:
+                              - common-service-db
+                      topologyKey: kubernetes.io/hostname
+                    weight: 50
               podAntiAffinityType: preferred
               topologyKey: topology.kubernetes.io/zone
             topologySpreadConstraints:
@@ -2320,7 +2331,16 @@ spec:
               whenUnsatisfiable: ScheduleAnyway
               labelSelector:
                 matchExpressions:
-                  - key: k8s.enterprisedb.io/cluster
+                  - key: pg.ibm.com/cluster
+                    operator: In
+                    values:
+                      - common-service-db
+            - maxSkew: 1
+              topologyKey: topology.kubernetes.io/region
+              whenUnsatisfiable: ScheduleAnyway
+              labelSelector:
+                matchExpressions:
+                  - key: pg.ibm.com/cluster
                     operator: In
                     values:
                       - common-service-db
@@ -2336,6 +2356,9 @@ spec:
             imagePullSecrets:
               - name: {{ .ImagePullSecret }}
             logLevel: info
+            ephemeralVolumesSizeLimit:
+              shm: 500Mi
+              temporaryData: 500Mi
             primaryUpdateStrategy: unsupervised
             primaryUpdateMethod: switchover
             enableSuperuserAccess: true

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2344,9 +2344,6 @@ spec:
                     operator: In
                     values:
                       - common-service-db
-            - maxSkew: 1
-              topologyKey: topology.kubernetes.io/region
-              whenUnsatisfiable: ScheduleAnyway
             imageName:
               templatingValueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the PostgreSQL cluster configuration to use IBM's custom PostgreSQL operator labels and adds enhanced pod scheduling configurations for better high availability and resource management.

The new added fields including `additionalPodAntiAffinity` and `ephemeralVolumesSizeLimit` are aligned with original EDB Cluster CR.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69254