### PR TITLE
Adding storage size to comparable keys

### DIFF
--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -367,6 +367,7 @@ func mergeChangedMap(key string, defaultMap interface{}, changedMap interface{},
 					"instances":         true,
 					"max_connections":   true,
 					"shared_buffers":    true,
+					"size":              true,
 				}
 				if _, ok := comparableKeys[key]; ok {
 					if directAssign {

--- a/internal/controller/rules/rules.go
+++ b/internal/controller/rules/rules.go
@@ -82,6 +82,10 @@ const ConfigurationRules = `
     data:
       spec:
         instances: LARGEST_VALUE
+        storage:
+          size: LARGEST_VALUE
+        walStorage:
+          size: LARGEST_VALUE
         resources:
           limits:
             cpu: LARGEST_VALUE
@@ -103,6 +107,10 @@ const ConfigurationRules = `
     data:
       spec:
         instances: LARGEST_VALUE
+        storage:
+          size: LARGEST_VALUE
+        walStorage:
+          size: LARGEST_VALUE
         resources:
           limits:
             cpu: LARGEST_VALUE
@@ -1191,6 +1199,10 @@ const ConfigurationRules = `
     data:
       spec:
         instances: LARGEST_VALUE
+        storage:
+          size: LARGEST_VALUE
+        walStorage:
+          size: LARGEST_VALUE
         resources:
           limits:
             cpu: LARGEST_VALUE
@@ -1206,6 +1218,10 @@ const ConfigurationRules = `
     data:
       spec:
         instances: LARGEST_VALUE
+        storage:
+          size: LARGEST_VALUE
+        walStorage:
+          size: LARGEST_VALUE
         resources:
           limits:
             cpu: LARGEST_VALUE


### PR DESCRIPTION
**What this PR does / why we need it**:
When users configure custom storage sizes for PostgreSQL in the CommonService Custom Resource (CR), the specified storage.size and walStorage.size values are not being merged into the OperandConfig. The system continues to use the default 10Gi storage size instead of user-configured values (e.g., 155Gi), while other fields like storageClass are correctly applied.

The size field was missing from the comparableKeys map in the merge logic. This caused the field to be skipped during the configuration merge process, preventing user-specified storage sizes from being applied to the OperandConfig.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69209
