### PR TITLE
Update Go version to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-dockerhub-docker-remote/golang:1.26.1 AS builder
+FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-dockerhub-docker-remote/golang:1.26.2 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GOARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-common-service-operator/v4
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/IBM/ibm-namespace-scope-operator/v4 v4.2.4-0.20240501132320-6675f97bc34f


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69272
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69263

Update Go version to 1.26.2 and ran ```go mod tidy```