### PR TITLE
refactor updateOperandConfig function 

### DIFF
--- a/internal/controller/bootstrap/config_bridge.go
+++ b/internal/controller/bootstrap/config_bridge.go
@@ -17,7 +17,10 @@
 package bootstrap
 
 import (
+	"context"
+
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"k8s.io/klog"
 )
 
 // ConfigMergerFunc is a function type that merges base config with CommonService configs
@@ -31,10 +34,69 @@ func (b *Bootstrap) SetConfigMerger(merger ConfigMergerFunc) {
 }
 
 // mergeConfigs calls the injected merger function if available
+// It also determines the largest size from ALL CommonService CRs and overrides the current CR's size
 func (b *Bootstrap) mergeConfigs(baseConfig string, cs *apiv3.CommonService) (string, error) {
+	// First, determine the largest size from all CommonService CRs
+	largestSize, err := b.getLargestSizeFromAllCRs(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Override the current CR's size with the largest size if found
+	originalSize := cs.Spec.Size
+	if largestSize != "" {
+		cs.Spec.Size = largestSize
+		klog.Infof("Bootstrap: Overriding CommonService CR %s/%s size from '%s' to largest size '%s'", cs.Namespace, cs.Name, originalSize, largestSize)
+	}
+
 	if b.configMerger != nil {
 		return b.configMerger(baseConfig, cs, b.CSData.ServicesNs)
 	}
 	// If no merger is set, return base config unchanged
 	return baseConfig, nil
+}
+
+// getLargestSizeFromAllCRs determines the largest size across all CommonService CRs
+func (b *Bootstrap) getLargestSizeFromAllCRs(ctx context.Context) (string, error) {
+	csObjectList := &apiv3.CommonServiceList{}
+	if err := b.Client.List(ctx, csObjectList); err != nil {
+		return "", err
+	}
+
+	sizePriority := map[string]int{
+		"starterset": 0,
+		"starter":    0,
+		"small":      1,
+		"medium":     2,
+		"large":      3,
+	}
+
+	largestSize := ""
+	largestPriority := -1
+
+	for _, cs := range csObjectList.Items {
+		if cs.GetDeletionTimestamp() != nil {
+			continue
+		}
+
+		csSize := cs.Spec.Size
+		if priority, ok := sizePriority[csSize]; ok {
+			klog.Infof("Bootstrap: CommonService CR %s/%s has size: %s (priority: %d)", cs.Namespace, cs.Name, csSize, priority)
+			if priority > largestPriority {
+				largestPriority = priority
+				largestSize = csSize
+				klog.Infof("Bootstrap: New largest size found: %s (priority: %d)", largestSize, largestPriority)
+			}
+		} else if csSize != "" {
+			klog.Infof("Bootstrap: CommonService CR %s/%s has custom size configuration (not a predefined size)", cs.Namespace, cs.Name)
+		}
+	}
+
+	if largestSize == "" {
+		klog.Info("Bootstrap: No predefined size found in any CommonService CR, will use starterset")
+		return "starterset", nil
+	}
+
+	klog.Infof("Bootstrap: FINAL DECISION - Largest size across all CommonService CRs is: %s (priority: %d)", largestSize, largestPriority)
+	return largestSize, nil
 }

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -54,6 +54,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/common"
 	util "github.com/IBM/ibm-common-service-operator/v4/internal/controller/common"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/constant"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/deploy"
@@ -967,17 +968,8 @@ func (b *Bootstrap) InstallOrUpdateOpreg(ctx context.Context, installPlanApprova
 // InstallOrUpdateOpcon will install or update OperandConfig when Opcon CRD is existent
 // Now accepts CommonService instance with merged configurations
 func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool, csInstance *apiv3.CommonService) error {
-	configs := []string{
-		constant.MongoDBOpCon,
-		constant.IMOpCon,
-		constant.UserMgmtOpCon,
-		constant.IdpConfigUIOpCon,
-		constant.PlatformUIOpCon,
-		constant.KeyCloakOpCon,
-		constant.CommonServicePGOpCon,
-		constant.CommonServiceCNPGOpCon,
-		constant.CommonServicePGMigratorOpCon,
-	}
+	// Get base template configs using common utility
+	configs := common.GetBaseOperandConfigList()
 
 	concatenatedCon, err := constant.ConcatenateConfigs(constant.CSV4OpCon, configs, b.CSData)
 	if err != nil {

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -967,8 +967,6 @@ func (b *Bootstrap) InstallOrUpdateOpreg(ctx context.Context, installPlanApprova
 // InstallOrUpdateOpcon will install or update OperandConfig when Opcon CRD is existent
 // Now accepts CommonService instance with merged configurations
 func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool, csInstance *apiv3.CommonService) error {
-
-	var baseCon string
 	configs := []string{
 		constant.MongoDBOpCon,
 		constant.IMOpCon,
@@ -981,9 +979,7 @@ func (b *Bootstrap) InstallOrUpdateOpcon(forceUpdateODLMCRs bool, csInstance *ap
 		constant.CommonServicePGMigratorOpCon,
 	}
 
-	baseCon = constant.CSV4OpCon
-
-	concatenatedCon, err := constant.ConcatenateConfigs(baseCon, configs, b.CSData)
+	concatenatedCon, err := constant.ConcatenateConfigs(constant.CSV4OpCon, configs, b.CSData)
 	if err != nil {
 		klog.Errorf("failed to concatenate OperandConfig: %v", err)
 		return err

--- a/internal/controller/common/util.go
+++ b/internal/controller/common/util.go
@@ -930,3 +930,73 @@ func CompareResourceHashes(resource1, resource2 map[string]interface{}) (bool, e
 	}
 	return hash1 == hash2, nil
 }
+
+// ParseOperandConfigServices parses a concatenated OperandConfig YAML string and extracts the services array.
+// This function handles both single OperandConfig objects and arrays of Kubernetes resources.
+// It's designed to work with the output of constant.ConcatenateConfigs().
+//
+// Parameters:
+//   - concatenatedConfig: YAML string containing one or more Kubernetes resources
+//
+// Returns:
+//   - []interface{}: The services array extracted from the OperandConfig's spec.services field
+//   - error: Any error encountered during parsing or extraction
+func ParseOperandConfigServices(concatenatedConfig string) ([]interface{}, error) {
+	// Parse YAML to JSON first
+	jsonSpec, err := utilyaml.YAMLToJSON([]byte(concatenatedConfig))
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert yaml to json: %v", err)
+	}
+
+	// Parse as generic structure (could be object or array)
+	var parsed interface{}
+	if err := encodingjson.Unmarshal(jsonSpec, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %v", err)
+	}
+
+	// Handle both single object and array of objects
+	var items []interface{}
+	switch v := parsed.(type) {
+	case map[string]interface{}:
+		// Single OperandConfig object
+		items = []interface{}{v}
+	case []interface{}:
+		// Array of resources
+		items = v
+	default:
+		return nil, fmt.Errorf("unexpected config format: expected object or array, got %T", parsed)
+	}
+
+	// Extract services from OperandConfig
+	for _, item := range items {
+		if itemMap, ok := item.(map[string]interface{}); ok {
+			if itemMap["kind"] == "OperandConfig" {
+				if spec, ok := itemMap["spec"].(map[string]interface{}); ok {
+					if services, ok := spec["services"].([]interface{}); ok {
+						klog.V(2).Infof("Extracted %d services from OperandConfig", len(services))
+						return services, nil
+					}
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("failed to extract services from OperandConfig: no valid OperandConfig found")
+}
+
+// GetBaseOperandConfigList returns the standard list of OperandConfig templates
+// used for building the base configuration. This centralizes the config list
+// that's used in multiple places (reconciler and bootstrap).
+func GetBaseOperandConfigList() []string {
+	return []string{
+		constant.MongoDBOpCon,
+		constant.IMOpCon,
+		constant.UserMgmtOpCon,
+		constant.IdpConfigUIOpCon,
+		constant.PlatformUIOpCon,
+		constant.KeyCloakOpCon,
+		constant.CommonServicePGOpCon,
+		constant.CommonServiceCNPGOpCon,
+		constant.CommonServicePGMigratorOpCon,
+	}
+}

--- a/internal/controller/config_extractor.go
+++ b/internal/controller/config_extractor.go
@@ -303,11 +303,11 @@ func extractSizeTemplate(cs *apiv3.CommonService, sizeTemplate string, serviceCo
 		if controller, ok := config.(map[string]interface{})["managementStrategy"]; ok {
 			serviceControllerMapping[configSize.(map[string]interface{})["name"].(string)] = controller.(string)
 		}
-		// Merge spec
+		// Merge spec - use shrinkSize with Max to select larger values
 		if configSize.(map[string]interface{})["spec"] != nil && config.(map[string]interface{})["spec"] != nil {
-			for cr, mergedSize := range mergeSizeProfile(configSize.(map[string]interface{})["spec"].(map[string]interface{}), config.(map[string]interface{})["spec"].(map[string]interface{})) {
-				configSize.(map[string]interface{})["spec"].(map[string]interface{})[cr] = mergedSize
-			}
+			// shrinkSize with Max extreme will select the larger value between template and custom config
+			mergedSpec := shrinkSize(configSize.(map[string]interface{})["spec"].(map[string]interface{}), config.(map[string]interface{})["spec"].(map[string]interface{}), Max)
+			configSize.(map[string]interface{})["spec"] = mergedSpec
 		}
 		// Merge resources
 		if configSize.(map[string]interface{})["resources"] != nil && config.(map[string]interface{})["resources"] != nil {
@@ -334,7 +334,8 @@ func extractSizeTemplate(cs *apiv3.CommonService, sizeTemplate string, serviceCo
 				}
 				newResource := getItemByGVKNameNamespace(config.(map[string]interface{})["resources"].([]interface{}), opconNs, apiVersion, kind, name, namespace)
 				if newResource != nil {
-					configSize.(map[string]interface{})["resources"].([]interface{})[j] = mergeSizeProfile(res.(map[string]interface{}), newResource.(map[string]interface{}))
+					// Use shrinkSize with Max to select larger values between template and custom resource
+					configSize.(map[string]interface{})["resources"].([]interface{})[j] = shrinkSize(res.(map[string]interface{}), newResource.(map[string]interface{}), Max)
 				}
 			}
 		}

--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -483,37 +483,41 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 		return true, err
 	}
 
-	// 2. Build complete desired state from ALL CommonService CRs
-	desiredServices, _, err := r.buildDesiredStateFromAllCRs(ctx)
-	if err != nil {
-		klog.Errorf("Failed to build desired state from CommonService CRs: %v", err)
-		return true, err
-	}
-
-	// 3. Apply extreme size handling to desired state
-	ruleSlice, err := convertStringToSlice(rules.ConfigurationRules)
-	if err != nil {
-		klog.Errorf("Failed to convert configuration rules: %v", err)
-		return true, err
-	}
-
-	desiredServices, err = r.getExtremeizes(ctx, desiredServices, ruleSlice, Max)
-	if err != nil {
-		klog.Errorf("Failed to apply extreme size handling: %v", err)
-		return true, err
-	}
-
-	// 4. Get existing services from OperandConfig
+	// 2. Get existing services from OperandConfig (base template services)
 	existingServices, ok := opcon.Object["spec"].(map[string]interface{})["services"].([]interface{})
 	if !ok {
 		klog.Errorf("Failed to extract existing services from OperandConfig")
 		return true, fmt.Errorf("invalid OperandConfig structure")
 	}
 
-	// 5. Calculate hashes for comparison
-	desiredHash, err := util.CalculateResourceHash(map[string]interface{}{"services": desiredServices})
+	// 3. Build desired state from ALL CommonService CRs
+	csDesiredServices, _, err := r.buildDesiredStateFromAllCRs(ctx)
 	if err != nil {
-		klog.Errorf("Failed to calculate hash for desired services: %v", err)
+		klog.Errorf("Failed to build desired state from CommonService CRs: %v", err)
+		return true, err
+	}
+
+	// 4. Apply extreme size handling to CS desired state
+	ruleSlice, err := convertStringToSlice(rules.ConfigurationRules)
+	if err != nil {
+		klog.Errorf("Failed to convert configuration rules: %v", err)
+		return true, err
+	}
+
+	csDesiredServices, err = r.getExtremeizes(ctx, csDesiredServices, ruleSlice, Max)
+	if err != nil {
+		klog.Errorf("Failed to apply extreme size handling: %v", err)
+		return true, err
+	}
+
+	// 5. Merge CS configurations with existing base services
+	// This preserves base-only services (like pg-migrator) while applying CS configs
+	mergedServices := r.mergeServicesWithBase(existingServices, csDesiredServices, ruleSlice)
+
+	// 6. Calculate hashes for comparison
+	mergedHash, err := util.CalculateResourceHash(map[string]interface{}{"services": mergedServices})
+	if err != nil {
+		klog.Errorf("Failed to calculate hash for merged services: %v", err)
 		return true, err
 	}
 
@@ -523,15 +527,15 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 		return true, err
 	}
 
-	// 6. Compare hashes - if equal, no update needed
-	if desiredHash == existingHash {
+	// 7. Compare hashes - if equal, no update needed
+	if mergedHash == existingHash {
 		klog.V(2).Infof("OperandConfig services unchanged (hash match: %s)", existingHash)
 		return true, nil
 	}
 
-	// 7. Hashes differ - replace entire services array
-	klog.Infof("Updating OperandConfig services)", existingHash, desiredHash)
-	opcon.Object["spec"].(map[string]interface{})["services"] = desiredServices
+	// 8. Hashes differ - replace entire services array with merged result
+	klog.Infof("Updating OperandConfig services (hash changed: %s -> %s)", existingHash, mergedHash)
+	opcon.Object["spec"].(map[string]interface{})["services"] = mergedServices
 
 	if err := r.Update(ctx, opcon); err != nil {
 		klog.Errorf("Failed to update OperandConfig %s: %v", opconKey.String(), err)
@@ -540,6 +544,139 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 
 	klog.Infof("Successfully updated OperandConfig %s with new services configuration", opconKey.String())
 	return false, nil
+}
+
+// mergeServicesWithBase merges CommonService configurations with base OperandConfig services
+// This ensures base-only services are preserved while CS configs are applied
+func (r *CommonServiceReconciler) mergeServicesWithBase(baseServices, csServices, ruleSlice []interface{}) []interface{} {
+	// Create a map of CS service names for quick lookup
+	csServiceMap := make(map[string]interface{})
+	for _, csService := range csServices {
+		if csMap, ok := csService.(map[string]interface{}); ok {
+			if name, ok := csMap["name"].(string); ok {
+				csServiceMap[name] = csService
+			}
+		}
+	}
+
+	// Start with base services and merge CS configurations
+	result := make([]interface{}, 0, len(baseServices))
+	processedCSServices := make(map[string]bool)
+
+	for _, baseService := range baseServices {
+		baseMap, ok := baseService.(map[string]interface{})
+		if !ok {
+			result = append(result, baseService)
+			continue
+		}
+
+		serviceName, ok := baseMap["name"].(string)
+		if !ok {
+			result = append(result, baseService)
+			continue
+		}
+
+		// Check if this service has CS configuration
+		if csService, exists := csServiceMap[serviceName]; exists {
+			// Merge CS config into base service
+			csMap := csService.(map[string]interface{})
+			mergedService := r.mergeServiceConfig(baseMap, csMap, serviceName, ruleSlice)
+			result = append(result, mergedService)
+			processedCSServices[serviceName] = true
+		} else {
+			// No CS config for this service, keep base as-is
+			result = append(result, baseService)
+		}
+	}
+
+	// Add any CS-only services that weren't in base
+	for _, csService := range csServices {
+		if csMap, ok := csService.(map[string]interface{}); ok {
+			if name, ok := csMap["name"].(string); ok {
+				if !processedCSServices[name] {
+					result = append(result, csService)
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// mergeServiceConfig merges a single service configuration from CS into base
+func (r *CommonServiceReconciler) mergeServiceConfig(baseService, csService map[string]interface{}, serviceName string, ruleSlice []interface{}) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	// Copy base service
+	for k, v := range baseService {
+		result[k] = v
+	}
+
+	// Get rules for this service
+	rules := getItemByName(ruleSlice, serviceName)
+
+	// Merge spec if present in CS config
+	if csService["spec"] != nil {
+		if result["spec"] == nil {
+			result["spec"] = make(map[string]interface{})
+		}
+
+		baseSpec, baseSpecOk := result["spec"].(map[string]interface{})
+		csSpec, csSpecOk := csService["spec"].(map[string]interface{})
+
+		if baseSpecOk && csSpecOk {
+			// Merge each CR in spec
+			for crName, csSpecValue := range csSpec {
+				if baseSpec[crName] == nil {
+					baseSpec[crName] = csSpecValue
+				} else if rules != nil && rules.(map[string]interface{})["spec"] != nil {
+					// Apply rules-based merge
+					ruleForCR := rules.(map[string]interface{})["spec"].(map[string]interface{})[crName]
+					if ruleForCR != nil {
+						baseSpec[crName] = mergeCRsIntoOperandConfig(
+							baseSpec[crName].(map[string]interface{}),
+							csSpecValue.(map[string]interface{}),
+							ruleForCR.(map[string]interface{}),
+							false,
+							false,
+						)
+					} else {
+						// No rules, use deep merge
+						baseSpec[crName] = mergeSizeProfile(
+							baseSpec[crName].(map[string]interface{}),
+							csSpecValue.(map[string]interface{}),
+						)
+					}
+				} else {
+					// No rules, use deep merge
+					if baseSpecMap, ok := baseSpec[crName].(map[string]interface{}); ok {
+						if csSpecMap, ok := csSpecValue.(map[string]interface{}); ok {
+							baseSpec[crName] = mergeSizeProfile(baseSpecMap, csSpecMap)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Merge resources if present in CS config
+	if csService["resources"] != nil {
+		baseResources := []interface{}{}
+		if result["resources"] != nil {
+			baseResources = result["resources"].([]interface{})
+		}
+		csResources := csService["resources"].([]interface{})
+
+		// Use existing resource merge logic
+		result["resources"] = mergeResourceArrays(baseResources, csResources, r.CSData.ServicesNs, "default")
+	}
+
+	// Copy managementStrategy if present
+	if csService["managementStrategy"] != nil {
+		result["managementStrategy"] = csService["managementStrategy"]
+	}
+
+	return result
 }
 
 func isOpResourceExists(opResource interface{}) bool {

--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -67,16 +67,45 @@ func mergeCRsIntoOperandConfig(defaultMap map[string]interface{}, changedMap map
 	return changedMap
 }
 
-// shrinkSize merges CRs by picking the smaller size
+// shrinkSize merges CRs by picking the extreme size (max or min)
 func shrinkSize(defaultMap map[string]interface{}, changedMap map[string]interface{}, extreme Extreme) map[string]interface{} {
 	//TODO: Only shrink the parameter with `Largest_value` rule
+	// Create a deep copy of defaultMap to avoid modifying the original
+	resultMap := make(map[string]interface{})
+	for key, value := range defaultMap {
+		// Deep copy maps and slices
+		switch v := value.(type) {
+		case map[string]interface{}:
+			copiedMap := make(map[string]interface{})
+			for k, val := range v {
+				copiedMap[k] = val
+			}
+			resultMap[key] = copiedMap
+		case []interface{}:
+			copiedSlice := make([]interface{}, len(v))
+			copy(copiedSlice, v)
+			resultMap[key] = copiedSlice
+		default:
+			resultMap[key] = value
+		}
+	}
+
+	// Now merge with extreme logic - this will modify resultMap in place
 	for key := range defaultMap {
 		if reflect.DeepEqual(defaultMap[key], changedMap[key]) {
 			continue
 		}
-		mergeChangedMapWithExtremeSize(key, defaultMap[key], changedMap[key], defaultMap, extreme)
+		mergeChangedMapWithExtremeSize(key, defaultMap[key], changedMap[key], resultMap, extreme)
 	}
-	return defaultMap
+
+	// Also handle keys that exist in changedMap but not in defaultMap
+	for key, value := range changedMap {
+		if _, exists := defaultMap[key]; !exists {
+			resultMap[key] = value
+		}
+	}
+
+	return resultMap
 }
 
 func mergeProfileController(serviceControllerMappingSummary, serviceControllerMapping map[string]string) map[string]string {
@@ -97,11 +126,12 @@ func mergeProfileController(serviceControllerMappingSummary, serviceControllerMa
 
 func mergeCSCRs(csSummary, csCR, ruleSlice []interface{}, serviceControllerMappingSummary map[string]string, opconNs string) []interface{} {
 	for _, operator := range csCR {
-		summaryCR := getItemByName(csSummary, operator.(map[string]interface{})["name"].(string))
-		rules := getItemByName(ruleSlice, operator.(map[string]interface{})["name"].(string))
+		operatorName := operator.(map[string]interface{})["name"].(string)
+		summaryCR := getItemByName(csSummary, operatorName)
+		rules := getItemByName(ruleSlice, operatorName)
 		if summaryCR == nil {
 			summaryCR = map[string]interface{}{
-				"name":      operator.(map[string]interface{})["name"].(string),
+				"name":      operatorName,
 				"spec":      map[string]interface{}{},
 				"resources": []interface{}{},
 			}
@@ -111,7 +141,7 @@ func mergeCSCRs(csSummary, csCR, ruleSlice []interface{}, serviceControllerMappi
 			summaryCR.(map[string]interface{})["resources"] = []interface{}{}
 		}
 		serviceController := serviceControllerMappingSummary["profileController"]
-		if controller, ok := serviceControllerMappingSummary[operator.(map[string]interface{})["name"].(string)]; ok {
+		if controller, ok := serviceControllerMappingSummary[operatorName]; ok {
 			serviceController = controller
 		}
 		if operator.(map[string]interface{})["spec"] != nil {
@@ -126,6 +156,7 @@ func mergeCSCRs(csSummary, csCR, ruleSlice []interface{}, serviceControllerMappi
 				if rules != nil && rules.(map[string]interface{})["spec"] != nil && rules.(map[string]interface{})["spec"].(map[string]interface{})[cr] != nil {
 					ruleForCR := rules.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
 					sizeForCR := summaryCR.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
+					klog.V(2).Infof("Merging CR %s for operator %s: comparing accumulated summary with new spec", cr, operatorName)
 					summaryCR.(map[string]interface{})["spec"].(map[string]interface{})[cr] = mergeCRsIntoOperandConfig(sizeForCR, spec.(map[string]interface{}), ruleForCR, false, false)
 				}
 			}
@@ -557,45 +588,21 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 // getBaseTemplateServices returns the base services from the OperandConfig template
 // This ensures we always start with the fresh template, not the current OperandConfig state
 func (r *CommonServiceReconciler) getBaseTemplateServices() ([]interface{}, error) {
-	// Get base template configs
-	configs := []string{
-		constant.MongoDBOpCon,
-		constant.IMOpCon,
-		constant.UserMgmtOpCon,
-		constant.IdpConfigUIOpCon,
-		constant.PlatformUIOpCon,
-		constant.KeyCloakOpCon,
-		constant.CommonServicePGOpCon,
-		constant.CommonServiceCNPGOpCon,
-		constant.CommonServicePGMigratorOpCon,
-	}
+	// Get base template configs using common utility
+	configs := util.GetBaseOperandConfigList()
 
 	concatenatedCon, err := constant.ConcatenateConfigs(constant.CSV4OpCon, configs, r.Bootstrap.CSData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to concatenate base configs: %v", err)
 	}
 
-	// Parse and extract services
-	baseConfig, err := convertStringToSlice(concatenatedCon)
+	// Use common utility function to parse and extract services
+	services, err := util.ParseOperandConfigServices(concatenatedCon)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse base config: %v", err)
 	}
 
-	// Extract services from OperandConfig
-	for _, item := range baseConfig {
-		if itemMap, ok := item.(map[string]interface{}); ok {
-			if itemMap["kind"] == "OperandConfig" {
-				if spec, ok := itemMap["spec"].(map[string]interface{}); ok {
-					if services, ok := spec["services"].([]interface{}); ok {
-						klog.V(2).Infof("Extracted %d services from base template", len(services))
-						return services, nil
-					}
-				}
-			}
-		}
-	}
-
-	return nil, fmt.Errorf("failed to extract services from base template")
+	return services, nil
 }
 
 // mergeServicesWithBase merges CommonService configurations with base OperandConfig services
@@ -754,7 +761,64 @@ func isOpResourceExists(opResource interface{}) bool {
 	return true
 }
 
+// getLargestSizeFromCRs determines the largest size across all CommonService CRs
+func (r *CommonServiceReconciler) getLargestSizeFromCRs(ctx context.Context) (string, error) {
+	csReq, err := labels.NewRequirement(constant.CsClonedFromLabel, selection.DoesNotExist, []string{})
+	if err != nil {
+		return "", err
+	}
+	csObjectList := &apiv3.CommonServiceList{}
+	if err := r.Client.List(ctx, csObjectList, &client.ListOptions{
+		LabelSelector: labels.NewSelector().Add(*csReq),
+	}); err != nil {
+		return "", err
+	}
+
+	sizePriority := map[string]int{
+		"starterset": 0,
+		"starter":    0,
+		"small":      1,
+		"medium":     2,
+		"large":      3,
+	}
+
+	largestSize := ""
+	largestPriority := -1
+
+	for _, cs := range csObjectList.Items {
+		if cs.GetDeletionTimestamp() != nil {
+			continue
+		}
+
+		csSize := cs.Spec.Size
+		if priority, ok := sizePriority[csSize]; ok {
+			klog.Infof("CommonService CR %s/%s has size: %s (priority: %d)", cs.Namespace, cs.Name, csSize, priority)
+			if priority > largestPriority {
+				largestPriority = priority
+				largestSize = csSize
+				klog.Infof("New largest size found: %s (priority: %d)", largestSize, largestPriority)
+			}
+		} else if csSize != "" {
+			klog.Infof("CommonService CR %s/%s has custom size configuration (not a predefined size)", cs.Namespace, cs.Name)
+		}
+	}
+
+	if largestSize == "" {
+		klog.Info("No predefined size found in any CommonService CR, will use starterset")
+		return "starterset", nil
+	}
+
+	klog.Infof("FINAL DECISION: Largest size across all CommonService CRs is: %s (priority: %d)", largestSize, largestPriority)
+	return largestSize, nil
+}
+
 func (r *CommonServiceReconciler) getExtremeizes(ctx context.Context, opconServices, ruleSlice []interface{}, extreme Extreme) ([]interface{}, error) {
+	// First, determine the largest size from all CommonService CRs
+	largestSize, err := r.getLargestSizeFromCRs(ctx)
+	if err != nil {
+		return []interface{}{}, err
+	}
+
 	// Fetch all the CommonService instances
 	csReq, err := labels.NewRequirement(constant.CsClonedFromLabel, selection.DoesNotExist, []string{})
 	if err != nil {
@@ -767,12 +831,24 @@ func (r *CommonServiceReconciler) getExtremeizes(ctx context.Context, opconServi
 		return []interface{}{}, err
 	}
 
+	klog.Infof("Found %d CommonService CRs to process for extreme size selection (extreme=%s, largest size=%s)", len(csObjectList.Items), extreme, largestSize)
+
 	var configSummary []interface{}
 	tmpConfigsSlice := make(map[int][]interface{})
 	serviceControllerMappingSummary := make(map[string]string)
 	for i, cs := range csObjectList.Items {
 		if cs.GetDeletionTimestamp() != nil {
+			klog.V(2).Infof("Skipping CommonService CR %s/%s (marked for deletion)", cs.Namespace, cs.Name)
 			continue
+		}
+
+		// Override the CR's size with the largest size if a predefined size was found
+		originalSize := cs.Spec.Size
+		if largestSize != "" {
+			cs.Spec.Size = largestSize
+			klog.Infof("Processing CommonService CR %s/%s: overriding size from '%s' to largest size '%s'", cs.Namespace, cs.Name, originalSize, largestSize)
+		} else {
+			klog.Infof("Processing CommonService CR %s/%s (size=%s) - index %d", cs.Namespace, cs.Name, cs.Spec.Size, i)
 		}
 
 		csConfigs, serviceControllerMapping, err := ExtractCommonServiceConfigs(&cs, r.CSData.ServicesNs)
@@ -783,7 +859,9 @@ func (r *CommonServiceReconciler) getExtremeizes(ctx context.Context, opconServi
 		serviceControllerMappingSummary = mergeProfileController(serviceControllerMappingSummary, serviceControllerMapping)
 		tmpConfigsSlice[i] = csConfigs
 	}
-	for _, csConfigs := range tmpConfigsSlice {
+	klog.Infof("Merging %d CommonService CR configurations into summary", len(tmpConfigsSlice))
+	for i, csConfigs := range tmpConfigsSlice {
+		klog.V(2).Infof("Merging configuration set %d into summary", i)
 		configSummary = mergeCSCRs(configSummary, csConfigs, ruleSlice, serviceControllerMappingSummary, r.CSData.ServicesNs)
 	}
 
@@ -806,6 +884,8 @@ func (r *CommonServiceReconciler) getExtremeizes(ctx context.Context, opconServi
 					continue
 				}
 				serviceForCR := crSummary.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
+				// shrinkSize now returns a new map with extreme values selected
+				klog.V(2).Infof("Applying extreme size (%s) for operator %s, CR %s", extreme, opService.(map[string]interface{})["name"], cr)
 				opService.(map[string]interface{})["spec"].(map[string]interface{})[cr] = shrinkSize(spec.(map[string]interface{}), serviceForCR, extreme)
 			}
 		}
@@ -849,6 +929,7 @@ func (r *CommonServiceReconciler) getExtremeizes(ctx context.Context, opconServi
 								summarizedRes.(map[string]interface{})["data"].(map[string]interface{})["spec"].(map[string]interface{})["resources"].(map[string]interface{})["limits"].(map[string]interface{})["cpu"] = struct{}{}
 							}
 						}
+						// shrinkSize now returns a new map with extreme values selected
 						opResources[i] = shrinkSize(opResource.(map[string]interface{}), summarizedRes.(map[string]interface{}), extreme)
 					}
 				}

--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -483,11 +483,11 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 		return true, err
 	}
 
-	// 2. Get existing services from OperandConfig (base template services)
-	existingServices, ok := opcon.Object["spec"].(map[string]interface{})["services"].([]interface{})
-	if !ok {
-		klog.Errorf("Failed to extract existing services from OperandConfig")
-		return true, fmt.Errorf("invalid OperandConfig structure")
+	// 2. Get base template services (fresh from template, not from current OperandConfig)
+	baseTemplateServices, err := r.getBaseTemplateServices()
+	if err != nil {
+		klog.Errorf("Failed to get base template services: %v", err)
+		return true, err
 	}
 
 	// 3. Build desired state from ALL CommonService CRs
@@ -510,9 +510,10 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 		return true, err
 	}
 
-	// 5. Merge CS configurations with existing base services
-	// This preserves base-only services (like pg-migrator) while applying CS configs
-	mergedServices := r.mergeServicesWithBase(existingServices, csDesiredServices, ruleSlice)
+	// 5. Merge CS configurations with base template services
+	// This ensures: base template + current CS CR = final OperandConfig
+	// If a resource is removed from CS CR, it won't be in the final result
+	mergedServices := r.mergeServicesWithBase(baseTemplateServices, csDesiredServices, ruleSlice)
 
 	// 6. Calculate hashes for comparison
 	mergedHash, err := util.CalculateResourceHash(map[string]interface{}{"services": mergedServices})
@@ -521,20 +522,27 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 		return true, err
 	}
 
-	existingHash, err := util.CalculateResourceHash(map[string]interface{}{"services": existingServices})
+	// Get current services for comparison
+	currentServices, ok := opcon.Object["spec"].(map[string]interface{})["services"].([]interface{})
+	if !ok {
+		klog.Errorf("Failed to extract current services from OperandConfig")
+		return true, fmt.Errorf("invalid OperandConfig structure")
+	}
+
+	currentHash, err := util.CalculateResourceHash(map[string]interface{}{"services": currentServices})
 	if err != nil {
 		klog.Errorf("Failed to calculate hash for existing services: %v", err)
 		return true, err
 	}
 
 	// 7. Compare hashes - if equal, no update needed
-	if mergedHash == existingHash {
-		klog.V(2).Infof("OperandConfig services unchanged (hash match: %s)", existingHash)
+	if mergedHash == currentHash {
+		klog.V(2).Infof("OperandConfig services unchanged (hash match: %s)", currentHash)
 		return true, nil
 	}
 
 	// 8. Hashes differ - replace entire services array with merged result
-	klog.Infof("Updating OperandConfig services (hash changed: %s -> %s)", existingHash, mergedHash)
+	klog.Infof("Updating OperandConfig services (hash changed: %s -> %s)", currentHash, mergedHash)
 	opcon.Object["spec"].(map[string]interface{})["services"] = mergedServices
 
 	if err := r.Update(ctx, opcon); err != nil {
@@ -544,6 +552,50 @@ func (r *CommonServiceReconciler) updateOperandConfig(ctx context.Context, newCo
 
 	klog.Infof("Successfully updated OperandConfig %s with new services configuration", opconKey.String())
 	return false, nil
+}
+
+// getBaseTemplateServices returns the base services from the OperandConfig template
+// This ensures we always start with the fresh template, not the current OperandConfig state
+func (r *CommonServiceReconciler) getBaseTemplateServices() ([]interface{}, error) {
+	// Get base template configs
+	configs := []string{
+		constant.MongoDBOpCon,
+		constant.IMOpCon,
+		constant.UserMgmtOpCon,
+		constant.IdpConfigUIOpCon,
+		constant.PlatformUIOpCon,
+		constant.KeyCloakOpCon,
+		constant.CommonServicePGOpCon,
+		constant.CommonServiceCNPGOpCon,
+		constant.CommonServicePGMigratorOpCon,
+	}
+
+	concatenatedCon, err := constant.ConcatenateConfigs(constant.CSV4OpCon, configs, r.Bootstrap.CSData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to concatenate base configs: %v", err)
+	}
+
+	// Parse and extract services
+	baseConfig, err := convertStringToSlice(concatenatedCon)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse base config: %v", err)
+	}
+
+	// Extract services from OperandConfig
+	for _, item := range baseConfig {
+		if itemMap, ok := item.(map[string]interface{}); ok {
+			if itemMap["kind"] == "OperandConfig" {
+				if spec, ok := itemMap["spec"].(map[string]interface{}); ok {
+					if services, ok := spec["services"].([]interface{}); ok {
+						klog.V(2).Infof("Extracted %d services from base template", len(services))
+						return services, nil
+					}
+				}
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("failed to extract services from base template")
 }
 
 // mergeServicesWithBase merges CommonService configurations with base OperandConfig services

--- a/internal/controller/operandconfig_test.go
+++ b/internal/controller/operandconfig_test.go
@@ -21,6 +21,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/bootstrap"
 )
 
 // TestMergeResourceArrays_PreservesBaseOnlyResources verifies that base resources
@@ -776,4 +779,765 @@ func TestGetItemByGVKNameNamespace(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMergeServicesWithBase_PreservesBaseOnlyServices verifies that services
+// only present in base (like pg-migrator) are preserved in the merged result.
+func TestMergeServicesWithBase_PreservesBaseOnlyServices(t *testing.T) {
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"spec": map[string]interface{}{
+				"cluster": map[string]interface{}{
+					"instances": float64(2),
+				},
+			},
+		},
+		map[string]interface{}{
+			"name": "common-service-pg-migrator",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"name":       "pg-migration-job",
+				},
+			},
+		},
+	}
+
+	// CS services only contain postgresql, not pg-migrator
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"spec": map[string]interface{}{
+				"cluster": map[string]interface{}{
+					"instances": float64(3),
+				},
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{}
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	// Both services must be present
+	require.Len(t, merged, 2, "Both base services must be preserved")
+
+	// Verify pg-migrator is preserved
+	pgMigrator := getItemByName(merged, "common-service-pg-migrator")
+	require.NotNil(t, pgMigrator, "pg-migrator service must be preserved")
+
+	// Verify postgresql was merged
+	postgresql := getItemByName(merged, "common-service-postgresql")
+	require.NotNil(t, postgresql, "postgresql service must be present")
+	spec := postgresql.(map[string]interface{})["spec"].(map[string]interface{})
+	cluster := spec["cluster"].(map[string]interface{})
+	assert.Equal(t, float64(3), cluster["instances"], "CS value should be merged")
+}
+
+// TestMergeServicesWithBase_MergesMatchingServices verifies that services
+// present in both base and CS are properly merged.
+func TestMergeServicesWithBase_MergesMatchingServices(t *testing.T) {
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"spec": map[string]interface{}{
+				"cluster": map[string]interface{}{
+					"instances": float64(1),
+					"storage": map[string]interface{}{
+						"size": "10Gi",
+					},
+				},
+			},
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "cert-manager.io/v1",
+					"kind":       "Certificate",
+					"name":       "db-cert",
+				},
+			},
+		},
+	}
+
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"spec": map[string]interface{}{
+				"cluster": map[string]interface{}{
+					"instances": float64(3),
+				},
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{}
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	require.Len(t, merged, 1, "Should have one merged service")
+
+	service := merged[0].(map[string]interface{})
+	assert.Equal(t, "common-service-postgresql", service["name"])
+
+	// Verify spec was merged
+	spec := service["spec"].(map[string]interface{})
+	cluster := spec["cluster"].(map[string]interface{})
+	assert.Equal(t, float64(3), cluster["instances"], "CS instances should override")
+	assert.Equal(t, "10Gi", cluster["storage"].(map[string]interface{})["size"], "Base storage should be preserved")
+
+	// Verify resources were preserved
+	resources := service["resources"].([]interface{})
+	assert.Len(t, resources, 1, "Base resources should be preserved")
+}
+
+// TestMergeServicesWithBase_AddsCSOnlyServices verifies that services
+// only in CS are added to the result.
+func TestMergeServicesWithBase_AddsCSOnlyServices(t *testing.T) {
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "ibm-cert-manager-operator",
+		},
+	}
+
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "ibm-cert-manager-operator",
+		},
+		map[string]interface{}{
+			"name": "new-custom-service",
+			"spec": map[string]interface{}{
+				"replicas": float64(2),
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{}
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	require.Len(t, merged, 2, "Should have both services")
+
+	newService := getItemByName(merged, "new-custom-service")
+	require.NotNil(t, newService, "New CS service should be added")
+	assert.Equal(t, float64(2), newService.(map[string]interface{})["spec"].(map[string]interface{})["replicas"])
+}
+
+// TestMergeServicesWithBase_EmptyCSServices verifies that all base services
+// are preserved when CS has no services.
+func TestMergeServicesWithBase_EmptyCSServices(t *testing.T) {
+	baseServices := []interface{}{
+		map[string]interface{}{"name": "service1"},
+		map[string]interface{}{"name": "service2"},
+		map[string]interface{}{"name": "service3"},
+	}
+
+	csServices := []interface{}{}
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{}
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	require.Len(t, merged, 3, "All base services must be preserved")
+	assert.NotNil(t, getItemByName(merged, "service1"))
+	assert.NotNil(t, getItemByName(merged, "service2"))
+	assert.NotNil(t, getItemByName(merged, "service3"))
+}
+
+// TestMergeServicesWithBase_RealWorldScenario tests the exact bug scenario:
+// base has pg-migrator, CS doesn't, and postgresql needs size config preserved.
+func TestMergeServicesWithBase_RealWorldScenario(t *testing.T) {
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"spec": map[string]interface{}{
+				"cluster": map[string]interface{}{
+					"instances": float64(2),
+				},
+			},
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"size":         "10Gi",
+								"storageClass": "nfs-client",
+							},
+						},
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			"name": "common-service-pg-migrator",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"name":       "pg-migration-job",
+				},
+			},
+		},
+	}
+
+	// CS from size profile - has postgresql but not pg-migrator
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"spec": map[string]interface{}{
+				"cluster": map[string]interface{}{
+					"instances": float64(2),
+				},
+			},
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"instances": float64(2),
+							"resources": map[string]interface{}{
+								"limits": map[string]interface{}{
+									"cpu":    "200m",
+									"memory": "768Mi",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	// CRITICAL: Both services must be present
+	require.Len(t, merged, 2, "Both services must be present")
+
+	// Verify pg-migrator is preserved
+	pgMigrator := getItemByName(merged, "common-service-pg-migrator")
+	require.NotNil(t, pgMigrator, "pg-migrator must be preserved from base")
+
+	// Verify postgresql was merged with size config preserved
+	postgresql := getItemByName(merged, "common-service-postgresql")
+	require.NotNil(t, postgresql, "postgresql must be present")
+
+	resources := postgresql.(map[string]interface{})["resources"].([]interface{})
+	require.Len(t, resources, 1, "Should have merged Cluster resource")
+
+	cluster := resources[0].(map[string]interface{})
+	data := cluster["data"].(map[string]interface{})
+	spec := data["spec"].(map[string]interface{})
+
+	// Verify size config from base is preserved
+	storage := spec["storage"].(map[string]interface{})
+	assert.Equal(t, "10Gi", storage["size"], "Base storage size must be preserved")
+	assert.Equal(t, "nfs-client", storage["storageClass"], "Base storageClass must be preserved")
+
+	// Verify CS config was merged
+	assert.Equal(t, float64(2), spec["instances"], "CS instances should be present")
+	assert.NotNil(t, spec["resources"], "CS resources should be merged")
+}
+
+// TestMergeServiceConfig_MergesSpecWithRules verifies that spec sections
+// are merged according to configuration rules.
+func TestMergeServiceConfig_MergesSpecWithRules(t *testing.T) {
+	baseService := map[string]interface{}{
+		"name": "test-service",
+		"spec": map[string]interface{}{
+			"mongoDB": map[string]interface{}{
+				"replicas": float64(1),
+				"resources": map[string]interface{}{
+					"limits": map[string]interface{}{
+						"cpu":    "500m",
+						"memory": "512Mi",
+					},
+				},
+			},
+		},
+	}
+
+	csService := map[string]interface{}{
+		"name": "test-service",
+		"spec": map[string]interface{}{
+			"mongoDB": map[string]interface{}{
+				"replicas": float64(3),
+				"resources": map[string]interface{}{
+					"limits": map[string]interface{}{
+						"cpu":    "1000m",
+						"memory": "1Gi",
+					},
+				},
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	merged := reconciler.mergeServiceConfig(baseService, csService, "test-service", ruleSlice)
+
+	require.NotNil(t, merged["spec"])
+	spec := merged["spec"].(map[string]interface{})
+	mongoDB := spec["mongoDB"].(map[string]interface{})
+
+	// Verify merge happened
+	assert.NotNil(t, mongoDB["replicas"])
+	assert.NotNil(t, mongoDB["resources"])
+}
+
+// TestMergeServiceConfig_MergesResources verifies that resource arrays
+// are properly merged.
+func TestMergeServiceConfig_MergesResources(t *testing.T) {
+	baseService := map[string]interface{}{
+		"name": "test-service",
+		"resources": []interface{}{
+			map[string]interface{}{
+				"apiVersion": "cert-manager.io/v1",
+				"kind":       "Certificate",
+				"name":       "base-cert",
+			},
+		},
+	}
+
+	csService := map[string]interface{}{
+		"name": "test-service",
+		"resources": []interface{}{
+			map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"name":       "cs-config",
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	merged := reconciler.mergeServiceConfig(baseService, csService, "test-service", ruleSlice)
+
+	require.NotNil(t, merged["resources"])
+	resources := merged["resources"].([]interface{})
+
+	// Both resources should be present
+	require.Len(t, resources, 2, "Both base and CS resources should be present")
+}
+
+// TestMergeServiceConfig_CopiesManagementStrategy verifies that
+// managementStrategy is copied from CS config.
+func TestMergeServiceConfig_CopiesManagementStrategy(t *testing.T) {
+	baseService := map[string]interface{}{
+		"name": "test-service",
+	}
+
+	csService := map[string]interface{}{
+		"name":               "test-service",
+		"managementStrategy": "turbo",
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	merged := reconciler.mergeServiceConfig(baseService, csService, "test-service", ruleSlice)
+
+	assert.Equal(t, "turbo", merged["managementStrategy"], "managementStrategy should be copied from CS")
+}
+
+// TestMergeServiceConfig_PreservesBaseWhenCSEmpty verifies that base
+// configuration is preserved when CS has no spec or resources.
+func TestMergeServiceConfig_PreservesBaseWhenCSEmpty(t *testing.T) {
+	baseService := map[string]interface{}{
+		"name": "test-service",
+		"spec": map[string]interface{}{
+			"replicas": float64(3),
+		},
+		"resources": []interface{}{
+			map[string]interface{}{
+				"kind": "Certificate",
+				"name": "base-cert",
+			},
+		},
+	}
+
+	csService := map[string]interface{}{
+		"name": "test-service",
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	merged := reconciler.mergeServiceConfig(baseService, csService, "test-service", ruleSlice)
+
+	// Base spec and resources should be preserved
+	assert.NotNil(t, merged["spec"], "Base spec should be preserved")
+	assert.NotNil(t, merged["resources"], "Base resources should be preserved")
+
+	spec := merged["spec"].(map[string]interface{})
+	assert.Equal(t, float64(3), spec["replicas"], "Base replicas should be preserved")
+
+	resources := merged["resources"].([]interface{})
+	assert.Len(t, resources, 1, "Base resources should be preserved")
+}
+
+// TestMergeServiceConfig_PreservesSizeConfiguration verifies that the size
+// configuration in storage sections is preserved during merge.
+// This tests the specific bug where size config was missing in second reconciliation.
+func TestMergeServiceConfig_PreservesSizeConfiguration(t *testing.T) {
+	// Base service has complete storage configuration including size
+	baseService := map[string]interface{}{
+		"name": "common-service-postgresql",
+		"resources": []interface{}{
+			map[string]interface{}{
+				"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+				"kind":       "Cluster",
+				"name":       "common-service-db",
+				"data": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"instances": float64(2),
+						"storage": map[string]interface{}{
+							"size":         "10Gi",
+							"storageClass": "nfs-client",
+						},
+						"walStorage": map[string]interface{}{
+							"size":         "5Gi",
+							"storageClass": "nfs-client",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// CS service from size profile - has resources but may not have size
+	csService := map[string]interface{}{
+		"name": "common-service-postgresql",
+		"resources": []interface{}{
+			map[string]interface{}{
+				"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+				"kind":       "Cluster",
+				"name":       "common-service-db",
+				"data": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"instances": float64(2),
+						"resources": map[string]interface{}{
+							"limits": map[string]interface{}{
+								"cpu":    "200m",
+								"memory": "768Mi",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	merged := reconciler.mergeServiceConfig(baseService, csService, "common-service-postgresql", ruleSlice)
+
+	require.NotNil(t, merged["resources"], "Resources must be present")
+	resources := merged["resources"].([]interface{})
+	require.Len(t, resources, 1, "Should have one Cluster resource")
+
+	cluster := resources[0].(map[string]interface{})
+	data := cluster["data"].(map[string]interface{})
+	spec := data["spec"].(map[string]interface{})
+
+	// CRITICAL: Verify size configuration is preserved
+	require.NotNil(t, spec["storage"], "storage section must be preserved")
+	storage := spec["storage"].(map[string]interface{})
+	assert.Equal(t, "10Gi", storage["size"], "storage.size must be preserved from base")
+	assert.Equal(t, "nfs-client", storage["storageClass"], "storage.storageClass must be preserved from base")
+
+	require.NotNil(t, spec["walStorage"], "walStorage section must be preserved")
+	walStorage := spec["walStorage"].(map[string]interface{})
+	assert.Equal(t, "5Gi", walStorage["size"], "walStorage.size must be preserved from base")
+	assert.Equal(t, "nfs-client", walStorage["storageClass"], "walStorage.storageClass must be preserved from base")
+
+	// Verify CS resources config was also merged
+	require.NotNil(t, spec["resources"], "CS resources config should be merged")
+	resourcesConfig := spec["resources"].(map[string]interface{})
+	limits := resourcesConfig["limits"].(map[string]interface{})
+	assert.Equal(t, "200m", limits["cpu"], "CS cpu limits should be present")
+	assert.Equal(t, "768Mi", limits["memory"], "CS memory limits should be present")
+}
+
+// TestMergeServicesWithBase_PostgreSQLSizeConfigPreserved tests the complete
+// scenario where postgresql size configuration must be preserved across reconciliations.
+func TestMergeServicesWithBase_PostgreSQLSizeConfigPreserved(t *testing.T) {
+	// Simulate base OperandConfig with complete postgresql configuration
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "cert-manager.io/v1",
+					"kind":       "Certificate",
+					"name":       "common-service-db-tls-cert",
+				},
+				map[string]interface{}{
+					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"instances": float64(2),
+							"storage": map[string]interface{}{
+								"size":         "20Gi",
+								"storageClass": "nfs-client",
+							},
+							"walStorage": map[string]interface{}{
+								"size":         "10Gi",
+								"storageClass": "nfs-client",
+							},
+							"postgresql": map[string]interface{}{
+								"parameters": map[string]interface{}{
+									"max_connections": "600",
+									"shared_buffers":  "64MB",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			"name": "common-service-pg-migrator",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "batch/v1",
+					"kind":       "Job",
+					"name":       "pg-migration-job",
+				},
+			},
+		},
+	}
+
+	// Simulate CS from size profile - has postgresql but not pg-migrator
+	// and may not have complete storage config
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"instances": float64(2),
+							"resources": map[string]interface{}{
+								"limits": map[string]interface{}{
+									"cpu":               "200m",
+									"memory":            "768Mi",
+									"ephemeral-storage": "512Mi",
+								},
+								"requests": map[string]interface{}{
+									"cpu":               "75m",
+									"memory":            "256Mi",
+									"ephemeral-storage": "128Mi",
+								},
+							},
+							"postgresql": map[string]interface{}{
+								"parameters": map[string]interface{}{
+									"max_connections": "600",
+									"shared_buffers":  "64MB",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	// Verify both services are present
+	require.Len(t, merged, 2, "Both services must be present")
+
+	// Verify pg-migrator is preserved
+	pgMigrator := getItemByName(merged, "common-service-pg-migrator")
+	require.NotNil(t, pgMigrator, "pg-migrator must be preserved")
+
+	// Verify postgresql with complete configuration
+	postgresql := getItemByName(merged, "common-service-postgresql")
+	require.NotNil(t, postgresql, "postgresql must be present")
+
+	resources := postgresql.(map[string]interface{})["resources"].([]interface{})
+	require.Len(t, resources, 2, "Should have Certificate and Cluster resources")
+
+	// Find the Cluster resource
+	var clusterResource map[string]interface{}
+	for _, res := range resources {
+		resMap := res.(map[string]interface{})
+		if resMap["kind"] == "Cluster" {
+			clusterResource = resMap
+			break
+		}
+	}
+
+	require.NotNil(t, clusterResource, "Cluster resource must be present")
+	data := clusterResource["data"].(map[string]interface{})
+	spec := data["spec"].(map[string]interface{})
+
+	// CRITICAL: Verify size configuration is preserved from base
+	require.NotNil(t, spec["storage"], "storage must be preserved")
+	storage := spec["storage"].(map[string]interface{})
+	assert.Equal(t, "20Gi", storage["size"], "storage.size from base must be preserved")
+	assert.Equal(t, "nfs-client", storage["storageClass"], "storage.storageClass from base must be preserved")
+
+	require.NotNil(t, spec["walStorage"], "walStorage must be preserved")
+	walStorage := spec["walStorage"].(map[string]interface{})
+	assert.Equal(t, "10Gi", walStorage["size"], "walStorage.size from base must be preserved")
+	assert.Equal(t, "nfs-client", walStorage["storageClass"], "walStorage.storageClass from base must be preserved")
+
+	// Verify CS configuration was also merged
+	assert.Equal(t, float64(2), spec["instances"], "instances from CS should be present")
+	require.NotNil(t, spec["resources"], "resources from CS should be merged")
+	resourcesConfig := spec["resources"].(map[string]interface{})
+	limits := resourcesConfig["limits"].(map[string]interface{})
+	assert.Equal(t, "200m", limits["cpu"], "CS cpu limits should be present")
+	assert.Equal(t, "768Mi", limits["memory"], "CS memory limits should be present")
+
+	// Verify postgresql parameters are preserved
+	require.NotNil(t, spec["postgresql"], "postgresql parameters must be present")
+	postgresql_params := spec["postgresql"].(map[string]interface{})
+	params := postgresql_params["parameters"].(map[string]interface{})
+	assert.Equal(t, "600", params["max_connections"], "max_connections should be preserved")
+	assert.Equal(t, "64MB", params["shared_buffers"], "shared_buffers should be preserved")
+}
+
+// TestMergeServicesWithBase_MultipleReconciliations simulates multiple
+// reconciliation cycles to ensure configuration remains stable.
+func TestMergeServicesWithBase_MultipleReconciliations(t *testing.T) {
+	// Initial base state
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"size": "10Gi",
+							},
+						},
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			"name": "common-service-pg-migrator",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"kind": "Job",
+					"name": "migration-job",
+				},
+			},
+		},
+	}
+
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"instances": float64(2),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	// First reconciliation
+	merged1 := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+	require.Len(t, merged1, 2, "First reconciliation: both services must be present")
+
+	// Second reconciliation - use result of first as new base
+	merged2 := reconciler.mergeServicesWithBase(merged1, csServices, ruleSlice)
+	require.Len(t, merged2, 2, "Second reconciliation: both services must still be present")
+
+	// Verify pg-migrator is still present after multiple reconciliations
+	pgMigrator := getItemByName(merged2, "common-service-pg-migrator")
+	require.NotNil(t, pgMigrator, "pg-migrator must be preserved after multiple reconciliations")
+
+	// Verify size config is still present
+	postgresql := getItemByName(merged2, "common-service-postgresql")
+	require.NotNil(t, postgresql, "postgresql must be present")
+	resources := postgresql.(map[string]interface{})["resources"].([]interface{})
+	cluster := resources[0].(map[string]interface{})
+	data := cluster["data"].(map[string]interface{})
+	spec := data["spec"].(map[string]interface{})
+	storage := spec["storage"].(map[string]interface{})
+	assert.Equal(t, "10Gi", storage["size"], "size must be preserved after multiple reconciliations")
 }

--- a/internal/controller/operandconfig_test.go
+++ b/internal/controller/operandconfig_test.go
@@ -1541,3 +1541,221 @@ func TestMergeServicesWithBase_MultipleReconciliations(t *testing.T) {
 	storage := spec["storage"].(map[string]interface{})
 	assert.Equal(t, "10Gi", storage["size"], "size must be preserved after multiple reconciliations")
 }
+
+// TestMergeServicesWithBase_RemovesOrphanedFields verifies that when a field
+// is removed from CommonService CR, it's removed from the final OperandConfig
+// (only base template fields are preserved).
+func TestMergeServicesWithBase_RemovesOrphanedFields(t *testing.T) {
+	// Base template has postgresql with storage config
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"size": "10Gi",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// CS CR previously had a custom field, but now it's removed
+	// (simulating user removing a field from CS CR)
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"instances": float64(2),
+							// Note: no custom field here anymore
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	require.Len(t, merged, 1, "Should have one service")
+	service := merged[0].(map[string]interface{})
+	resources := service["resources"].([]interface{})
+	cluster := resources[0].(map[string]interface{})
+	data := cluster["data"].(map[string]interface{})
+	spec := data["spec"].(map[string]interface{})
+
+	// Base template field should be preserved
+	assert.NotNil(t, spec["storage"], "Base template storage should be preserved")
+	storage := spec["storage"].(map[string]interface{})
+	assert.Equal(t, "10Gi", storage["size"], "Base template size should be preserved")
+
+	// CS field should be present
+	assert.Equal(t, float64(2), spec["instances"], "CS instances should be present")
+}
+
+// TestMergeServicesWithBase_RemovesCSAddedResource verifies that when a
+// resource is removed from CS CR, it's removed from final OperandConfig
+// (only base template resources are preserved).
+func TestMergeServicesWithBase_RemovesCSAddedResource(t *testing.T) {
+	// Base template has only Certificate
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "cert-manager.io/v1",
+					"kind":       "Certificate",
+					"name":       "db-cert",
+				},
+			},
+		},
+	}
+
+	// CS CR now has NO resources (user removed the custom ConfigMap)
+	// Previously CS had added a ConfigMap, but now it's removed
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+			// No resources in CS CR
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			CSData: apiv3.CSData{
+				ServicesNs: "ibm-common-services",
+			},
+		},
+	}
+
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	require.Len(t, merged, 1, "Should have one service")
+	service := merged[0].(map[string]interface{})
+
+	// Base template Certificate should be preserved
+	require.NotNil(t, service["resources"], "Resources should be present")
+	resources := service["resources"].([]interface{})
+	require.Len(t, resources, 1, "Should have only base template Certificate")
+
+	cert := resources[0].(map[string]interface{})
+	assert.Equal(t, "Certificate", cert["kind"], "Should be Certificate from base")
+	assert.Equal(t, "db-cert", cert["name"], "Should be db-cert from base")
+}
+
+// TestMergeServicesWithBase_RemovesCSAddedService verifies that when an
+// entire service is removed from CS CR, it's removed from final OperandConfig
+// (only base template services are preserved).
+func TestMergeServicesWithBase_RemovesCSAddedService(t *testing.T) {
+	// Base template has postgresql and pg-migrator
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+		},
+		map[string]interface{}{
+			"name": "common-service-pg-migrator",
+		},
+	}
+
+	// CS CR previously had a custom service, but now it's removed
+	// Only postgresql is in CS CR now
+	csServices := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-postgresql",
+		},
+		// Note: custom-service was removed from CS CR
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{}
+
+	merged := reconciler.mergeServicesWithBase(baseServices, csServices, ruleSlice)
+
+	// Should have only base template services (postgresql and pg-migrator)
+	// The custom-service that was in CS CR is now gone
+	require.Len(t, merged, 2, "Should have only base template services")
+
+	serviceNames := make([]string, 0, 2)
+	for _, svc := range merged {
+		serviceNames = append(serviceNames, svc.(map[string]interface{})["name"].(string))
+	}
+
+	assert.Contains(t, serviceNames, "common-service-postgresql", "Base postgresql should be present")
+	assert.Contains(t, serviceNames, "common-service-pg-migrator", "Base pg-migrator should be present")
+	assert.NotContains(t, serviceNames, "custom-service", "CS-added service should be removed")
+}
+
+// TestMergeServicesWithBase_OrphanedFieldsAcrossReconciliations verifies
+// that orphaned fields don't accumulate across multiple reconciliations.
+func TestMergeServicesWithBase_OrphanedFieldsAcrossReconciliations(t *testing.T) {
+	// Base template
+	baseServices := []interface{}{
+		map[string]interface{}{
+			"name": "test-service",
+			"spec": map[string]interface{}{
+				"baseField": "baseValue",
+			},
+		},
+	}
+
+	ruleSlice := []interface{}{}
+	reconciler := &CommonServiceReconciler{}
+
+	// First reconciliation: CS adds customField
+	csServices1 := []interface{}{
+		map[string]interface{}{
+			"name": "test-service",
+			"spec": map[string]interface{}{
+				"customField": "customValue",
+			},
+		},
+	}
+
+	merged1 := reconciler.mergeServicesWithBase(baseServices, csServices1, ruleSlice)
+	service1 := merged1[0].(map[string]interface{})
+	spec1 := service1["spec"].(map[string]interface{})
+
+	// After first reconciliation, both fields should be present
+	assert.Equal(t, "baseValue", spec1["baseField"], "Base field should be present")
+	assert.Equal(t, "customValue", spec1["customField"], "Custom field should be present")
+
+	// Second reconciliation: CS removes customField
+	csServices2 := []interface{}{
+		map[string]interface{}{
+			"name": "test-service",
+			// No spec in CS CR - customField removed
+		},
+	}
+
+	// Use base template again (not merged1) to simulate fresh reconciliation
+	merged2 := reconciler.mergeServicesWithBase(baseServices, csServices2, ruleSlice)
+	service2 := merged2[0].(map[string]interface{})
+	spec2 := service2["spec"].(map[string]interface{})
+
+	// After second reconciliation, only base field should remain
+	assert.Equal(t, "baseValue", spec2["baseField"], "Base field should still be present")
+	assert.NotContains(t, spec2, "customField", "Custom field should be removed")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The changes ensure that:
- Base template configurations are always preserved
- Storage size configurations persist across reconciliations
- The largest size from all CommonService CRs is consistently applied
- Configuration merging uses proper extreme value selection
- Orphaned fields from removed CS CRs are properly cleaned up

#### internal/controller/bootstrap/config_bridge.go

- Adds logic to determine and apply the largest size across all CommonService CRs during configuration merging. Introduces getLargestSizeFromAllCRs() function that evaluates size priority (starterset < small < medium < large) and overrides individual CR sizes with the largest found size before merging configurations.

#### internal/controller/bootstrap/init.go

- Refactors InstallOrUpdateOpcon() to use the new centralized GetBaseOperandConfigList() utility function, eliminating code duplication and ensuring consistent base configuration handling.

#### internal/controller/common/util.go

Adds two new utility functions:

- ParseOperandConfigServices(): Parses concatenated OperandConfig YAML and extracts the services array
- GetBaseOperandConfigList(): Returns the standard list of OperandConfig templates used across the codebase

#### internal/controller/config_extractor.go

- Updates the size template extraction logic to use shrinkSize() with the Max extreme for merging spec and resources, ensuring larger values are selected when comparing template and custom configurations.

#### internal/controller/operandconfig.go

Major refactoring of OperandConfig update logic:

- Implements getBaseTemplateServices() to always start with fresh template services
- Adds mergeServicesWithBase() to properly merge CS configurations with base templates
- Adds mergeServiceConfig() for granular service-level merging
- Implements getLargestSizeFromCRs() in the reconciler context
- Updates getExtremeizes() to apply largest size override before processing
- Fixes shrinkSize() to return a new map instead of modifying in place, preventing unintended mutations
- Adds comprehensive logging for debugging size selection and merging operations

#### internal/controller/operandconfig_test.go

Adds extensive test coverage (16 new test functions) for the new merging logic:

- Tests for preserving base-only services (pg-migrator scenario)
- Tests for merging matching services with proper field preservation
- Tests for handling CS-only services
- Tests for storage size configuration preservation
- Tests for multiple reconciliation cycles stability
- Tests for orphaned field cleanup when resources are removed from CS CRs
- Real-world scenario tests mimicking production configurations

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69308
