### PR TITLE
Remove command line args from pg-migrate container

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2696,14 +2696,6 @@ spec:
                         ephemeral-storage: 256Mi
                     command:
                       - /usr/local/bin/pg-migrate
-                    args:
-                      - --namespace=$(NAMESPACE)
-                      - --cluster=$(CLUSTER_NAME)
-                      - --pg-version=$(PG_VERSION)
-                      - --ibm-pg-ns=$(IBM_PG_NS)
-                      - --timeout=$(TIMEOUT)
-                      - --skip-edb-cleanup=$(SKIP_EDB_CLEANUP)
-                      - --skip-operator-validation=$(SKIP_OPERATOR_VALIDATION)
                     envFrom:
                       - configMapRef:
                           name: cpfs-migration-config


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove cmd line from PG migration job

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69245

**How to test**:
Test with new changes in `cpfs-utils`
https://github.ibm.com/IBMPrivateCloud/cs-multi-instance-conversion/pull/122

1. Create OperandRequest to install EDB Cluster `common-service-db`
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      name: example-service
    spec:
      requests:
        - operands:
            - name: common-service-postgresql
          registry: common-service
    ```

2.  Wait for EDB Cluster CR to be in health status
    ```console
    ➜  ~ oc get cluster.postgresql
    NAME                AGE     INSTANCES   READY   STATUS                     PRIMARY
    common-service-db   5m26s   2           2       Cluster in healthy state   common-service-db-1
    ```

3. Update OperandRequest to add additional entry `common-service-pg-migrator` for migration.
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      name: example-service
    spec:
      requests:
        - operands:
            - name: common-service-postgresql
            - name: common-service-pg-migrator
          registry: common-service
    ```

4. Wait the job `common-service-db-pg-migration-job` to be completed.
    ```console
    ➜  ~ oc get job
    NAME                                 STATUS     COMPLETIONS   DURATION   AGE
    common-service-db-pg-migration-job   Complete   1/1           83s        2m4s
    ```
5. Wait the new IBM PG Cluster CR to be ready
    ```console
    ➜  ~ oc get cluster.pg.ibm.com
    NAME                AGE    INSTANCES   READY   STATUS                     PRIMARY
    common-service-db   103s   2           2       Cluster in healthy state   common-service-db-2
    ```
