### PR TITLE
Aggregate OperatorConfigs from all CommonService CRs

### DIFF
--- a/internal/controller/common/util_hash_test.go
+++ b/internal/controller/common/util_hash_test.go
@@ -313,5 +313,3 @@ func TestCompareResourceHashes_OrderIndependence(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, result, "Resources with same content should match regardless of key order in code")
 }
-
-// Made with Bob

--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -472,6 +472,26 @@ func (r *CommonServiceReconciler) mappingToCsRequestForConfigMaps(ctx context.Co
 	return nil
 }
 
+func (r *CommonServiceReconciler) mappingToCsRequestForCommonService(ctx context.Context, object client.Object) []reconcile.Request {
+	cs, ok := object.(*apiv3.CommonService)
+	if !ok {
+		return nil
+	}
+
+	// When any CommonService CR changes, trigger reconciliation of the master CR
+	// This ensures OperatorConfigs are aggregated from all CRs
+	if cs.Name != constant.MasterCR || cs.Namespace != r.Bootstrap.CSData.OperatorNs {
+		klog.Infof("CommonService CR %s/%s changed, triggering master CR reconciliation for OperatorConfig aggregation", cs.Namespace, cs.Name)
+		return []reconcile.Request{
+			{NamespacedName: types.NamespacedName{
+				Name:      constant.MasterCR,
+				Namespace: r.Bootstrap.CSData.OperatorNs,
+			}},
+		}
+	}
+	return nil
+}
+
 func (r *CommonServiceReconciler) mappingToCsRequestForOperandRegistry(ctx context.Context, object client.Object) []reconcile.Request {
 	operandRegistry, ok := object.(*odlm.OperandRegistry)
 	if !ok {
@@ -539,6 +559,14 @@ func (r *CommonServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(r.mappingToCsRequestForConfigMaps),
+			builder.WithPredicates(predicate.Funcs{
+				CreateFunc: func(e event.CreateEvent) bool { return true },
+				UpdateFunc: func(e event.UpdateEvent) bool { return true },
+				DeleteFunc: func(e event.DeleteEvent) bool { return !e.DeleteStateUnknown },
+			})).
+		Watches(
+			&apiv3.CommonService{},
+			handler.EnqueueRequestsFromMapFunc(r.mappingToCsRequestForCommonService),
 			builder.WithPredicates(predicate.Funcs{
 				CreateFunc: func(e event.CreateEvent) bool { return true },
 				UpdateFunc: func(e event.UpdateEvent) bool { return true },

--- a/internal/controller/operatorconfig.go
+++ b/internal/controller/operatorconfig.go
@@ -34,14 +34,20 @@ import (
 func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, configList []v3.OperatorConfig) (bool, error) {
 	klog.Info("Applying OperatorConfig")
 
-	if configList == nil {
+	// Aggregate OperatorConfigs from all CommonService CRs in the cluster
+	aggregatedConfigs, err := r.aggregateOperatorConfigsFromAllCRs(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	if len(aggregatedConfigs) == 0 {
+		klog.Info("No OperatorConfigs found across all CommonService CRs")
 		return true, nil
 	}
 
 	// TODO: remove when this feature is generalized to all other operators
-	replicasProvided := true
-	for _, c := range configList {
-		config := c
+	replicasProvided := false
+	for _, config := range aggregatedConfigs {
 		packageName, err := r.fetchPackageNameFromOpReg(ctx, config.Name)
 		if err != nil {
 			return false, err
@@ -49,18 +55,19 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 		if packageName != "cloud-native-postgresql" {
 			return false, errors.New("failed to update OperatorConfig. This feature is only available for cloud-native-postgresql operator")
 		}
-		if config.Replicas == nil {
-			replicasProvided = false
+		if config.Replicas != nil {
+			replicasProvided = true
 		}
 	}
 
 	if !replicasProvided {
+		klog.Info("No replicas specified in any CommonService CR OperatorConfigs")
 		return true, nil
 	}
 
 	operatorConfig := &odlm.OperatorConfig{}
 	if err := r.Reader.Get(ctx, types.NamespacedName{
-		Name:      "test-operator-config",
+		Name:      "cloud-native-postgresql-operator-config",
 		Namespace: r.Bootstrap.CSData.ServicesNs,
 	}, operatorConfig); err != nil {
 		if !apierrors.IsNotFound(err) {
@@ -68,7 +75,10 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 			return true, err
 		}
 	}
-	replicas := *configList[0].Replicas
+
+	// Use the aggregated replica value (maximum across all CRs)
+	replicas := *aggregatedConfigs[0].Replicas
+	klog.Infof("Applying OperatorConfig with %d replicas (aggregated from all CommonService CRs)", replicas)
 	replacer := strings.NewReplacer("placeholder-size", fmt.Sprintf("%d", replicas))
 	updatedConfig := replacer.Replace(constant.PostGresOperatorConfig)
 	klog.V(2).Infof("OperatorConfig to be applied will be: %v", updatedConfig)
@@ -77,6 +87,64 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 		return false, err
 	}
 	return false, nil
+}
+
+// aggregateOperatorConfigsFromAllCRs collects and merges OperatorConfigs from all CommonService CRs
+// For replica values, it takes the maximum value across all CRs
+func (r *CommonServiceReconciler) aggregateOperatorConfigsFromAllCRs(ctx context.Context) ([]v3.OperatorConfig, error) {
+	csObjectList := &v3.CommonServiceList{}
+	if err := r.Client.List(ctx, csObjectList); err != nil {
+		klog.Errorf("Failed to list CommonService CRs: %v", err)
+		return nil, err
+	}
+
+	// Map to track the maximum replica value for each operator
+	operatorConfigMap := make(map[string]*v3.OperatorConfig)
+
+	for _, cs := range csObjectList.Items {
+		// Skip CRs that are being deleted
+		if cs.GetDeletionTimestamp() != nil {
+			klog.V(2).Infof("Skipping CommonService CR %s/%s (being deleted)", cs.Namespace, cs.Name)
+			continue
+		}
+
+		if cs.Spec.OperatorConfigs == nil {
+			continue
+		}
+
+		klog.Infof("Processing OperatorConfigs from CommonService CR %s/%s", cs.Namespace, cs.Name)
+		for _, config := range cs.Spec.OperatorConfigs {
+			if config.Replicas == nil {
+				klog.V(2).Infof("Skipping OperatorConfig %s from CR %s/%s (no replicas specified)", config.Name, cs.Namespace, cs.Name)
+				continue
+			}
+
+			existingConfig, exists := operatorConfigMap[config.Name]
+			if !exists {
+				// First time seeing this operator config
+				configCopy := config
+				operatorConfigMap[config.Name] = &configCopy
+				klog.Infof("Added OperatorConfig %s with %d replicas from CR %s/%s", config.Name, *config.Replicas, cs.Namespace, cs.Name)
+			} else {
+				// Take the maximum replica value
+				if *config.Replicas > *existingConfig.Replicas {
+					existingConfig.Replicas = config.Replicas
+					klog.Infof("Updated OperatorConfig %s to %d replicas (from CR %s/%s)", config.Name, *config.Replicas, cs.Namespace, cs.Name)
+				} else {
+					klog.V(2).Infof("Keeping existing replica value %d for OperatorConfig %s (CR %s/%s has %d)", *existingConfig.Replicas, config.Name, cs.Namespace, cs.Name, *config.Replicas)
+				}
+			}
+		}
+	}
+
+	// Convert map to slice
+	result := make([]v3.OperatorConfig, 0, len(operatorConfigMap))
+	for _, config := range operatorConfigMap {
+		result = append(result, *config)
+	}
+
+	klog.Infof("Aggregated %d OperatorConfig(s) from %d CommonService CR(s)", len(result), len(csObjectList.Items))
+	return result, nil
 }
 
 func (r *CommonServiceReconciler) fetchPackageNameFromOpReg(ctx context.Context, name string) (string, error) {

--- a/internal/controller/operatorconfig.go
+++ b/internal/controller/operatorconfig.go
@@ -45,7 +45,6 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 		return true, nil
 	}
 
-	// TODO: remove when this feature is generalized to all other operators
 	replicasProvided := false
 	for _, config := range aggregatedConfigs {
 		packageName, err := r.fetchPackageNameFromOpReg(ctx, config.Name)
@@ -102,7 +101,6 @@ func (r *CommonServiceReconciler) aggregateOperatorConfigsFromAllCRs(ctx context
 	operatorConfigMap := make(map[string]*v3.OperatorConfig)
 
 	for _, cs := range csObjectList.Items {
-		// Skip CRs that are being deleted
 		if cs.GetDeletionTimestamp() != nil {
 			klog.V(2).Infof("Skipping CommonService CR %s/%s (being deleted)", cs.Namespace, cs.Name)
 			continue
@@ -121,7 +119,6 @@ func (r *CommonServiceReconciler) aggregateOperatorConfigsFromAllCRs(ctx context
 
 			existingConfig, exists := operatorConfigMap[config.Name]
 			if !exists {
-				// First time seeing this operator config
 				configCopy := config
 				operatorConfigMap[config.Name] = &configCopy
 				klog.Infof("Added OperatorConfig %s with %d replicas from CR %s/%s", config.Name, *config.Replicas, cs.Namespace, cs.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Users can now specify `operatorConfigs` with replica settings in any CommonService CRs, and the OperatorConfig will be properly created and updated with the aggregated configuration across all CRs in the cluster


**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69165

**How to test**:
Test image: quay.io/yuchen_shen/cs_operator:operatorconfig
1. Create a non-master CS CR with the custom replica like
```
spec:
  operatorConfigs:
    - name: cloud-native-postgresql-v1.25
      replicas: 3
```
2. Observe there would be three EDB pods shown up
