### PR TITLE
feat: add imagePullSecrets support to pg-migration service account and job

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2488,6 +2488,9 @@ spec:
         name: common-service-db-pg-migration-sa
         labels:
           app: cpfs-pg-migrator
+        data:
+          imagePullSecrets:
+            - name: {{ .ImagePullSecret }}
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         name: common-service-db-pg-migration-role
@@ -2671,6 +2674,8 @@ spec:
               spec:
                 serviceAccountName: common-service-db-pg-migration-sa
                 restartPolicy: Never
+                imagePullSecrets:
+                  - name: {{ .ImagePullSecret }}
                 securityContext:
                   runAsNonRoot: true
                   seccompProfile:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for custom image pull secrets to the pg-migration ServiceAccount and Job, enabling the migration job to pull container images from private registries.

**Changes made**:
- Added `imagePullSecrets` configuration to the `common-service-db-pg-migration-sa` ServiceAccount
- Added `imagePullSecrets` configuration to the `common-service-db-pg-migration-job` Job spec
- Both configurations use the `{{ .ImagePullSecret }}` template variable to support custom image pull secrets

**Which issue(s) this PR fixes**:
Enables pg-migration to work with images stored in private container registries https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/94974