### PR TITLE
keep template CommonService merge size

### DIFF
--- a/internal/controller/config_extractor.go
+++ b/internal/controller/config_extractor.go
@@ -303,11 +303,11 @@ func extractSizeTemplate(cs *apiv3.CommonService, sizeTemplate string, serviceCo
 		if controller, ok := config.(map[string]interface{})["managementStrategy"]; ok {
 			serviceControllerMapping[configSize.(map[string]interface{})["name"].(string)] = controller.(string)
 		}
-		// Merge spec - use shrinkSize with Max to select larger values
+		// Merge spec - keep size-template scaling behavior for configurable fields,
+		// then merge CommonService-only fields so non-template keys are preserved.
 		if configSize.(map[string]interface{})["spec"] != nil && config.(map[string]interface{})["spec"] != nil {
-			// shrinkSize with Max extreme will select the larger value between template and custom config
-			mergedSpec := shrinkSize(configSize.(map[string]interface{})["spec"].(map[string]interface{}), config.(map[string]interface{})["spec"].(map[string]interface{}), Max)
-			configSize.(map[string]interface{})["spec"] = mergedSpec
+			scaledSpec := shrinkSize(configSize.(map[string]interface{})["spec"].(map[string]interface{}), config.(map[string]interface{})["spec"].(map[string]interface{}), Max)
+			configSize.(map[string]interface{})["spec"] = mergeSizeProfile(scaledSpec, config.(map[string]interface{})["spec"].(map[string]interface{}))
 		}
 		// Merge resources
 		if configSize.(map[string]interface{})["resources"] != nil && config.(map[string]interface{})["resources"] != nil {

--- a/internal/controller/config_extractor.go
+++ b/internal/controller/config_extractor.go
@@ -334,8 +334,10 @@ func extractSizeTemplate(cs *apiv3.CommonService, sizeTemplate string, serviceCo
 				}
 				newResource := getItemByGVKNameNamespace(config.(map[string]interface{})["resources"].([]interface{}), opconNs, apiVersion, kind, name, namespace)
 				if newResource != nil {
-					// Use shrinkSize with Max to select larger values between template and custom resource
-					configSize.(map[string]interface{})["resources"].([]interface{})[j] = shrinkSize(res.(map[string]interface{}), newResource.(map[string]interface{}), Max)
+					// Keep size-template scaling behavior for resource values,
+					// then merge CommonService-only nested fields back into the matched resource.
+					scaledResource := shrinkSize(res.(map[string]interface{}), newResource.(map[string]interface{}), Max)
+					configSize.(map[string]interface{})["resources"].([]interface{})[j] = mergeSizeProfile(scaledResource, newResource.(map[string]interface{}))
 				}
 			}
 		}

--- a/internal/controller/config_merger.go
+++ b/internal/controller/config_merger.go
@@ -70,8 +70,6 @@ func MergeBaseAndCSConfigs(
 		return "", fmt.Errorf("failed to convert configuration rules: %v", err)
 	}
 
-	csConfigs = mergeDuplicateCSConfigs(csConfigs)
-
 	// Merge CommonService configs into base services using existing merge logic
 	mergedServices := mergeCSCRs(baseServicesInterface, csConfigs, ruleSlice, serviceControllerMapping, servicesNs)
 
@@ -107,104 +105,6 @@ func MergeBaseAndCSConfigs(
 
 	klog.Info("Successfully merged CommonService configurations with base OperandConfig")
 	return mergedYAML, nil
-}
-
-func mergeDuplicateCSConfigs(csConfigs []interface{}) []interface{} {
-	if len(csConfigs) <= 1 {
-		return csConfigs
-	}
-
-	mergedByName := make(map[string]map[string]interface{})
-	order := make([]string, 0, len(csConfigs))
-
-	for _, cfg := range csConfigs {
-		cfgMap, ok := cfg.(map[string]interface{})
-		if !ok {
-			continue
-		}
-
-		name, _ := cfgMap["name"].(string)
-		if name == "" {
-			continue
-		}
-
-		existing, found := mergedByName[name]
-		if !found {
-			mergedByName[name] = deepCopyConfigMap(cfgMap)
-			order = append(order, name)
-			continue
-		}
-
-		mergeCSConfigMaps(existing, cfgMap)
-	}
-
-	result := make([]interface{}, 0, len(order))
-	for _, name := range order {
-		result = append(result, mergedByName[name])
-	}
-	return result
-}
-
-func deepCopyConfigMap(src map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(src))
-	for k, v := range src {
-		out[k] = deepCopyValue(v)
-	}
-	return out
-}
-
-func deepCopyValue(v interface{}) interface{} {
-	switch typed := v.(type) {
-	case map[string]interface{}:
-		copied := make(map[string]interface{}, len(typed))
-		for k, val := range typed {
-			copied[k] = deepCopyValue(val)
-		}
-		return copied
-	case []interface{}:
-		copied := make([]interface{}, len(typed))
-		for i, val := range typed {
-			copied[i] = deepCopyValue(val)
-		}
-		return copied
-	default:
-		return v
-	}
-}
-
-func mergeCSConfigMaps(dst, src map[string]interface{}) {
-	for key, srcVal := range src {
-		if key == "name" {
-			continue
-		}
-
-		dstVal, exists := dst[key]
-		if !exists || dstVal == nil {
-			dst[key] = deepCopyValue(srcVal)
-			continue
-		}
-
-		switch srcTyped := srcVal.(type) {
-		case map[string]interface{}:
-			if dstTyped, ok := dstVal.(map[string]interface{}); ok {
-				mergeCSConfigMaps(dstTyped, srcTyped)
-			} else {
-				dst[key] = deepCopyValue(srcVal)
-			}
-		case []interface{}:
-			if key == "resources" {
-				if dstResources, ok := dstVal.([]interface{}); ok {
-					dst[key] = append(dstResources, srcTyped...)
-				} else {
-					dst[key] = deepCopyValue(srcVal)
-				}
-			} else {
-				dst[key] = deepCopyValue(srcVal)
-			}
-		default:
-			dst[key] = srcVal
-		}
-	}
 }
 
 // convertMapToYAML converts a map to YAML string

--- a/internal/controller/config_merger.go
+++ b/internal/controller/config_merger.go
@@ -70,6 +70,8 @@ func MergeBaseAndCSConfigs(
 		return "", fmt.Errorf("failed to convert configuration rules: %v", err)
 	}
 
+	csConfigs = mergeDuplicateCSConfigs(csConfigs)
+
 	// Merge CommonService configs into base services using existing merge logic
 	mergedServices := mergeCSCRs(baseServicesInterface, csConfigs, ruleSlice, serviceControllerMapping, servicesNs)
 
@@ -105,6 +107,104 @@ func MergeBaseAndCSConfigs(
 
 	klog.Info("Successfully merged CommonService configurations with base OperandConfig")
 	return mergedYAML, nil
+}
+
+func mergeDuplicateCSConfigs(csConfigs []interface{}) []interface{} {
+	if len(csConfigs) <= 1 {
+		return csConfigs
+	}
+
+	mergedByName := make(map[string]map[string]interface{})
+	order := make([]string, 0, len(csConfigs))
+
+	for _, cfg := range csConfigs {
+		cfgMap, ok := cfg.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name, _ := cfgMap["name"].(string)
+		if name == "" {
+			continue
+		}
+
+		existing, found := mergedByName[name]
+		if !found {
+			mergedByName[name] = deepCopyConfigMap(cfgMap)
+			order = append(order, name)
+			continue
+		}
+
+		mergeCSConfigMaps(existing, cfgMap)
+	}
+
+	result := make([]interface{}, 0, len(order))
+	for _, name := range order {
+		result = append(result, mergedByName[name])
+	}
+	return result
+}
+
+func deepCopyConfigMap(src map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		out[k] = deepCopyValue(v)
+	}
+	return out
+}
+
+func deepCopyValue(v interface{}) interface{} {
+	switch typed := v.(type) {
+	case map[string]interface{}:
+		copied := make(map[string]interface{}, len(typed))
+		for k, val := range typed {
+			copied[k] = deepCopyValue(val)
+		}
+		return copied
+	case []interface{}:
+		copied := make([]interface{}, len(typed))
+		for i, val := range typed {
+			copied[i] = deepCopyValue(val)
+		}
+		return copied
+	default:
+		return v
+	}
+}
+
+func mergeCSConfigMaps(dst, src map[string]interface{}) {
+	for key, srcVal := range src {
+		if key == "name" {
+			continue
+		}
+
+		dstVal, exists := dst[key]
+		if !exists || dstVal == nil {
+			dst[key] = deepCopyValue(srcVal)
+			continue
+		}
+
+		switch srcTyped := srcVal.(type) {
+		case map[string]interface{}:
+			if dstTyped, ok := dstVal.(map[string]interface{}); ok {
+				mergeCSConfigMaps(dstTyped, srcTyped)
+			} else {
+				dst[key] = deepCopyValue(srcVal)
+			}
+		case []interface{}:
+			if key == "resources" {
+				if dstResources, ok := dstVal.([]interface{}); ok {
+					dst[key] = append(dstResources, srcTyped...)
+				} else {
+					dst[key] = deepCopyValue(srcVal)
+				}
+			} else {
+				dst[key] = deepCopyValue(srcVal)
+			}
+		default:
+			dst[key] = srcVal
+		}
+	}
 }
 
 // convertMapToYAML converts a map to YAML string

--- a/internal/controller/config_merger_test.go
+++ b/internal/controller/config_merger_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
 	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
@@ -252,6 +253,59 @@ func TestMergeBaseAndCSConfigs_PreservesUnchangedServices(t *testing.T) {
 	assert.Contains(t, names, "ibm-management-ingress-operator")
 }
 
+func TestMergeBaseAndCSConfigs_PreservesCommonServiceOnlyFieldsDuringSizeTemplateMerge(t *testing.T) {
+	baseConfig := `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service
+  namespace: ibm-common-services
+spec:
+  services:
+  - name: ibm-im-operator
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: true
+`
+
+	cs := &apiv3.CommonService{}
+	cs.Spec.Size = "medium"
+	cs.Spec.Services = []apiv3.ServiceConfig{
+		{
+			Name: "ibm-im-operator",
+			Spec: map[string]apiv3.ExtensionWithMarker{
+				"authentication": {
+					RawExtension: runtime.RawExtension{
+						Raw: []byte(`{
+							"config": {"zenFrontDoor": true},
+							"labels": {
+								"icpdsupport/addOnId": "cpfs",
+								"icpdsupport/app": "im"
+							}
+						}`),
+					},
+				},
+			},
+		},
+	}
+
+	csConfigs, serviceControllerMapping, err := ExtractCommonServiceConfigs(cs, "ibm-common-services")
+	require.NoError(t, err)
+
+	result, err := MergeBaseAndCSConfigs(
+		baseConfig,
+		csConfigs,
+		serviceControllerMapping,
+		"ibm-common-services",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, result, "zenFrontDoor: true")
+	assert.Contains(t, result, "icpdsupport/addOnId: cpfs")
+	assert.Contains(t, result, "onPremMultipleDeploy: true")
+	assert.Contains(t, result, "replicas: 2")
+}
+
 // TestMergeBaseAndCSConfigs_OutputIsValidYAML verifies that the merged result is
 // valid YAML that round-trips through JSON without data loss.
 func TestMergeBaseAndCSConfigs_OutputIsValidYAML(t *testing.T) {
@@ -435,4 +489,65 @@ spec:
 	result, err := MergeConfigs(customNsYAML, cs, "custom-ns")
 	require.NoError(t, err)
 	assert.NotEmpty(t, result)
+}
+
+func TestMergeBaseAndCSConfigs_MergesDuplicateServiceEntriesBeforeBaseMerge(t *testing.T) {
+	baseYAML := `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service
+  namespace: ibm-common-services
+spec:
+  services:
+  - name: ibm-im-operator
+    spec:
+      authentication:
+        config:
+          onPremMultipleDeploy: true
+`
+	csConfigs := []interface{}{
+		map[string]interface{}{
+			"name": "ibm-im-operator",
+			"spec": map[string]interface{}{
+				"authentication": map[string]interface{}{
+					"config": map[string]interface{}{
+						"zenFrontDoor": true,
+					},
+					"labels": map[string]interface{}{
+						"icpdsupport/addOnId": "cpfs",
+						"icpdsupport/app":     "im",
+					},
+				},
+			},
+		},
+		map[string]interface{}{
+			"name": "ibm-im-operator",
+			"spec": map[string]interface{}{
+				"authentication": map[string]interface{}{
+					"replicas": float64(2),
+					"authService": map[string]interface{}{
+						"resources": map[string]interface{}{
+							"requests": map[string]interface{}{
+								"cpu": "200m",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := MergeBaseAndCSConfigs(
+		baseYAML,
+		csConfigs,
+		map[string]string{"profileController": "default"},
+		"ibm-common-services",
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, result, "zenFrontDoor: true")
+	assert.Contains(t, result, "icpdsupport/addOnId: cpfs")
+	assert.Contains(t, result, "replicas: 2")
+	assert.Contains(t, result, "cpu: 200m")
 }

--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -866,10 +866,6 @@ func (r *CommonServiceReconciler) getExtremeizes(ctx context.Context, opconServi
 	for i, csConfigs := range tmpConfigsSlice {
 		klog.V(2).Infof("Merging configuration set %d into summary", i)
 		configSummary = mergeCSCRs(configSummary, csConfigs, ruleSlice, serviceControllerMappingSummary, r.CSData.ServicesNs)
-		if summary := getItemByName(configSummary, "ibm-im-operator"); summary != nil {
-			summaryBytes, _ := json.Marshal(summary)
-			klog.Infof("getExtremeizes: configSummary ibm-im-operator after set %d = %s", i, string(summaryBytes))
-		}
 	}
 
 	for _, opService := range opconServices {
@@ -1144,10 +1140,6 @@ func (r *CommonServiceReconciler) buildDesiredStateFromAllCRs(ctx context.Contex
 
 		serviceControllerMappingSummary = mergeProfileController(serviceControllerMappingSummary, serviceControllerMapping)
 		aggregatedConfigs = mergeCSCRs(aggregatedConfigs, csConfigs, ruleSlice, serviceControllerMappingSummary, r.CSData.ServicesNs)
-		if summary := getItemByName(aggregatedConfigs, "ibm-im-operator"); summary != nil {
-			summaryBytes, _ := json.Marshal(summary)
-			klog.Infof("aggregateCommonServiceConfigs: ibm-im-operator summary after merging %s/%s = %s", cs.Namespace, cs.Name, string(summaryBytes))
-		}
 	}
 
 	return aggregatedConfigs, serviceControllerMappingSummary, nil

--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -158,6 +158,9 @@ func mergeCSCRs(csSummary, csCR, ruleSlice []interface{}, serviceControllerMappi
 					sizeForCR := summaryCR.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
 					klog.V(2).Infof("Merging CR %s for operator %s: comparing accumulated summary with new spec", cr, operatorName)
 					summaryCR.(map[string]interface{})["spec"].(map[string]interface{})[cr] = mergeCRsIntoOperandConfig(sizeForCR, spec.(map[string]interface{}), ruleForCR, false, false)
+				} else {
+					sizeForCR := summaryCR.(map[string]interface{})["spec"].(map[string]interface{})[cr].(map[string]interface{})
+					summaryCR.(map[string]interface{})["spec"].(map[string]interface{})[cr] = mergeSizeProfile(sizeForCR, spec.(map[string]interface{}))
 				}
 			}
 			csSummary = setSpecByName(csSummary, operator.(map[string]interface{})["name"].(string), summaryCR.(map[string]interface{})["spec"])
@@ -863,6 +866,10 @@ func (r *CommonServiceReconciler) getExtremeizes(ctx context.Context, opconServi
 	for i, csConfigs := range tmpConfigsSlice {
 		klog.V(2).Infof("Merging configuration set %d into summary", i)
 		configSummary = mergeCSCRs(configSummary, csConfigs, ruleSlice, serviceControllerMappingSummary, r.CSData.ServicesNs)
+		if summary := getItemByName(configSummary, "ibm-im-operator"); summary != nil {
+			summaryBytes, _ := json.Marshal(summary)
+			klog.Infof("getExtremeizes: configSummary ibm-im-operator after set %d = %s", i, string(summaryBytes))
+		}
 	}
 
 	for _, opService := range opconServices {
@@ -1137,6 +1144,10 @@ func (r *CommonServiceReconciler) buildDesiredStateFromAllCRs(ctx context.Contex
 
 		serviceControllerMappingSummary = mergeProfileController(serviceControllerMappingSummary, serviceControllerMapping)
 		aggregatedConfigs = mergeCSCRs(aggregatedConfigs, csConfigs, ruleSlice, serviceControllerMappingSummary, r.CSData.ServicesNs)
+		if summary := getItemByName(aggregatedConfigs, "ibm-im-operator"); summary != nil {
+			summaryBytes, _ := json.Marshal(summary)
+			klog.Infof("aggregateCommonServiceConfigs: ibm-im-operator summary after merging %s/%s = %s", cs.Namespace, cs.Name, string(summaryBytes))
+		}
 	}
 
 	return aggregatedConfigs, serviceControllerMappingSummary, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
When bootstrap merged a size template with CommonService service overrides, the merge path in extractSizeTemplate() relied on shrinkSize() alone. That worked for size-managed fields such as replicas and resource settings, but it dropped CommonService-only fields that are not part of the template, such as authentication.config.zenFrontDoor and authentication.labels.

Update extractSizeTemplate() to perform the merge in two steps:
1. apply shrinkSize() first to preserve size-template behavior for configurable fields
2. then apply mergeSizeProfile() so CommonService-only fields that are explicitly set remain in the merged OperandConfig

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/94971