### PR TITLE
Support CNCF with kubectl commands in CPFS scripts

### DIFF
--- a/cp3pt0-deployment/common/authorize-namespace.sh
+++ b/cp3pt0-deployment/common/authorize-namespace.sh
@@ -19,6 +19,10 @@
 # Project roles and role bindings to another namespace
 #
 
+# Get script directory for sourcing cli_compat.sh
+SCRIPT_DIR=$(cd $(dirname "$0") && pwd -P)
+. ${SCRIPT_DIR}/cli_compat.sh
+
 function help() {
     echo "authorize-namespace.sh - Authorize a namespace to be manageable from another namespace through the NamespaceScope operator"
     echo "See https://www.ibm.com/docs/en/cloud-paks/foundational-services/4.0?topic=co-authorizing-foundational-services-perform-operations-workloads-in-namespace for more information."
@@ -98,9 +102,9 @@ done
 #
 
 if [ -z $TARGETNS ]; then
-    TARGETNS=$(${OC} project -q)
-    if [ $? -ne 0 ]; then
-      echo "Error: You do not seem to be logged into Openshift" >&2
+    TARGETNS=$(get_current_namespace "${OC}")
+    if [ $? -ne 0 ] || [ -z "$TARGETNS" ]; then
+      echo "Error: You do not seem to be logged into the Kubernetes cluster" >&2
       help
       exit 1
     fi

--- a/cp3pt0-deployment/common/cleanup_cp2_control.sh
+++ b/cp3pt0-deployment/common/cleanup_cp2_control.sh
@@ -25,6 +25,7 @@ STEP=0
 # ---------- Main functions ----------
 
 . ${BASE_DIR}/utils.sh
+. ${BASE_DIR}/cli_compat.sh
 
 function main() {
     parse_arguments "$@"
@@ -89,13 +90,13 @@ function print_usage() {
 function pre_req() {
     check_command "${OC}"
 
-    # checking oc command logged in
-    user=$(${OC} whoami 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        error "You must be logged into the OpenShift Cluster from the oc command line"
+    # checking cluster CLI command logged in
+    user=$(get_current_user "${OC}")
+    if [ $? -ne 0 ] || [ -z "$user" ]; then
+        error "You must be logged into the Kubernetes cluster from the ${OC} command line"
         exit 1
     else
-        success "oc command logged in as ${user}"
+        success "${OC} command logged in as ${user}"
     fi
 
     get_control_namespace

--- a/cp3pt0-deployment/common/cli_compat.sh
+++ b/cp3pt0-deployment/common/cli_compat.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Licensed Materials - Property of IBM
+# Copyright IBM Corporation 2023. All Rights Reserved
+# US Government Users Restricted Rights -
+# Use, duplication or disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+#
+# This is an internal component, bundled with an official IBM product.
+# Please refer to that particular license for additional information.
+
+# ---------- CLI Compatibility Functions ----------#
+#
+# This file provides compatibility wrappers for oc/kubectl commands
+# to allow scripts to work with both OpenShift (oc) and Kubernetes (kubectl)
+#
+
+# Get the currently logged-in user
+# Usage: get_current_user "$OC"
+# Returns: username string
+function get_current_user() {
+    local cli=$1
+    
+    if [[ "${cli}" == *"kubectl"* ]]; then
+        # kubectl doesn't have 'whoami', use config view instead
+        ${cli} config view --minify -o jsonpath='{.contexts[0].context.user}' 2>/dev/null
+    else
+        # oc has native whoami command
+        ${cli} whoami 2>/dev/null
+    fi
+}
+
+# Get the current namespace/project
+# Usage: get_current_namespace "$OC"
+# Returns: namespace/project name string
+function get_current_namespace() {
+    local cli=$1
+    
+    if [[ "${cli}" == *"kubectl"* ]]; then
+        # kubectl uses 'config view' to get current namespace
+        ${cli} config view --minify -o jsonpath='{.contexts[0].context.namespace}' 2>/dev/null
+    else
+        # oc has native project command
+        ${cli} project --short 2>/dev/null
+    fi
+}
+
+# Check if user is logged into the cluster
+# Usage: check_cluster_login "$OC"
+# Returns: 0 if logged in, 1 if not
+function check_cluster_login() {
+    local cli=$1
+    local user
+    
+    user=$(get_current_user "$cli")
+    
+    if [ -z "$user" ] || [ $? -ne 0 ]; then
+        return 1
+    else
+        return 0
+    fi
+}
+
+# Made with Bob

--- a/cp3pt0-deployment/common/delegate_cp2_cert_manager.sh
+++ b/cp3pt0-deployment/common/delegate_cp2_cert_manager.sh
@@ -28,6 +28,7 @@ STEP=0
 # ---------- Main functions ----------
 
 . ${BASE_DIR}/utils.sh
+. ${BASE_DIR}/cli_compat.sh
 
 function main() {
     parse_arguments "$@"
@@ -92,12 +93,12 @@ function pre_req() {
     check_command "${YQ}"
     check_yq_version
 
-    # checking oc command logged in
-    user=$(${OC} whoami 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        error "You must be logged into the OpenShift Cluster from the oc command line"
+    # checking cluster CLI command logged in
+    user=$(get_current_user "${OC}")
+    if [ $? -ne 0 ] || [ -z "$user" ]; then
+        error "You must be logged into the Kubernetes cluster from the ${OC} command line"
     else
-        success "oc command logged in as ${user}"
+        success "${OC} command logged in as ${user}"
     fi
 
     if [ "$CONTROL_NS" == "" ]; then

--- a/cp3pt0-deployment/common/migrate_cp2_licensing.sh
+++ b/cp3pt0-deployment/common/migrate_cp2_licensing.sh
@@ -29,6 +29,7 @@ STEP=0
 # ---------- Main functions ----------
 
 . ${BASE_DIR}/utils.sh
+. ${BASE_DIR}/cli_compat.sh
 
 function main() {
     parse_arguments "$@"
@@ -100,12 +101,12 @@ function pre_req() {
     check_command "${YQ}"
     check_yq_version
 
-    # checking oc command logged in
-    user=$(${OC} whoami 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        error "You must be logged into the OpenShift Cluster from the oc command line"
+    # checking cluster CLI command logged in
+    user=$(get_current_user "${OC}")
+    if [ $? -ne 0 ] || [ -z "$user" ]; then
+        error "You must be logged into the Kubernetes cluster from the ${OC} command line"
     else
-        success "oc command logged in as ${user}"
+        success "${OC} command logged in as ${user}"
     fi
 
     if [ "$CONTROL_NS" == "" ]; then

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -270,7 +270,7 @@ function print_usage() {
     echo "See https://www.ibm.com/docs/en/cloud-paks/foundational-services/4.0?topic=4x-in-place-migration for more information."
     echo ""
     echo "Options:"
-    echo "   --oc string                        Optional. File path to oc CLI. Default uses oc in your PATH"
+    echo "   --oc string                        Optional. File path to oc/kubectl CLI. Default uses oc in your PATH"
     echo "   --yq string                        Optional. File path to yq CLI. Default uses yq in your PATH"
     echo "   --operator-namespace string        Required. Namespace to migrate Foundational services operator"
     echo "   --services-namespace               Optional. Namespace to migrate operands of Foundational services, i.e. 'dataplane'. Default is the same as operator-namespace"

--- a/cp3pt0-deployment/migrate_tenant.sh
+++ b/cp3pt0-deployment/migrate_tenant.sh
@@ -57,6 +57,7 @@ STEP=0
 # ---------- Main functions ----------
 
 . ${BASE_DIR}/common/utils.sh
+. ${BASE_DIR}/common/cli_compat.sh
 
 function main() {
     parse_arguments "$@"
@@ -299,12 +300,12 @@ function pre_req() {
     check_command "${YQ}"
     check_yq_version
 
-    # Checking oc command logged in
-    user=$(${OC} whoami 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        error "You must be logged into the OpenShift Cluster from the oc command line"
+    # Checking cluster CLI command logged in
+    user=$(get_current_user "${OC}")
+    if [ $? -ne 0 ] || [ -z "$user" ]; then
+        error "You must be logged into the Kubernetes cluster from the ${OC} command line"
     else
-        success "oc command logged in as ${user}"
+        success "${OC} command logged in as ${user}"
     fi
 
     if [ $LICENSE_ACCEPT -ne 1 ]; then

--- a/cp3pt0-deployment/setup_singleton.sh
+++ b/cp3pt0-deployment/setup_singleton.sh
@@ -59,6 +59,7 @@ STEP=0
 # ---------- Main functions ----------
 
 . ${BASE_DIR}/common/utils.sh
+. ${BASE_DIR}/common/cli_compat.sh
 
 function main() {
     parse_arguments "$@"
@@ -188,7 +189,7 @@ function print_usage() {
     echo "See https://www.ibm.com/docs/en/cloud-paks/foundational-services/4.0?topic=manager-installing-cert-licensing-by-script for more information."
     echo ""
     echo "Options:"
-    echo "   --oc string                                            Optional. File path to oc CLI. Default uses oc in your PATH"
+    echo "   --oc string                                            Optional. File path to oc/kubectl CLI. Default uses oc in your PATH"
     echo "   --yq string                                            Optional. File path to yq CLI. Default uses yq in your PATH"
     echo "   --operator-namespace string                            Optional. Namespace to migrate Cloud Pak 2 Foundational services"
     echo "   -ls, --enable-licensing                                Optional. Set this flag to install ibm-licensing-operator"
@@ -604,12 +605,12 @@ function pre_req() {
     check_command "${YQ}"
     check_yq_version
 
-    # Checking oc command logged in
-    user=$(${OC} whoami 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        error "You must be logged into the OpenShift Cluster from the oc command line"
+    # Checking cluster CLI command logged in
+    user=$(get_current_user "${OC}")
+    if [ $? -ne 0 ] || [ -z "$user" ]; then
+        error "You must be logged into the Kubernetes cluster from the ${OC} command line"
     else
-        success "oc command logged in as ${user}"
+        success "${OC} command logged in as ${user}"
     fi
 
     if [ "$LICENSE_ACCEPT" -ne 1 ]; then
@@ -641,7 +642,7 @@ function pre_req() {
     is_supports_delegation "$version"
 
     if [ -z "$OPERATOR_NS" ]; then
-        OPERATOR_NS=$("$OC" project --short)
+        OPERATOR_NS=$(get_current_namespace "$OC")
     fi
 
     if [ $ENABLE_LICENSE_SERVICE_REPORTER -eq 1 ] && [ $ENABLE_LICENSING -eq 0 ]; then

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -162,7 +162,7 @@ function print_usage() {
     echo "See https://www.ibm.com/docs/en/cloud-paks/foundational-services/4.0?topic=online-installing-foundational-services-by-using-script for more information."
     echo ""
     echo "Options:"
-    echo "   --oc string                    Optional. File path to oc CLI. Default uses oc in your PATH"
+    echo "   --oc string                    Optional. File path to oc/kubectl CLI. Default uses oc in your PATH"
     echo "   --yq string                    Optional. File path to yq CLI. Default uses yq in your PATH"
     echo "   --enable-licensing             Optional. Set this flag to install ibm-licensing-operator"
     echo "   --operator-namespace string    Required. Namespace to install Foundational services operator"

--- a/cp3pt0-deployment/setup_tenant.sh
+++ b/cp3pt0-deployment/setup_tenant.sh
@@ -53,6 +53,7 @@ PREVIEW_DIR="/tmp/setup-tenant-$(date +'%Y%m%d%H%M%S')-preview"
 # ---------- Main functions ----------
 
 . ${BASE_DIR}/common/utils.sh
+. ${BASE_DIR}/common/cli_compat.sh
 
 function main() {
     parse_arguments "$@"
@@ -198,12 +199,12 @@ function pre_req() {
     check_command "${YQ}"
     check_yq_version
 
-    # Checking oc command logged in
-    user=$($OC whoami 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        error "You must be logged into the OpenShift Cluster from the oc command line"
+    # Checking cluster CLI command logged in
+    user=$(get_current_user "$OC")
+    if [ $? -ne 0 ] || [ -z "$user" ]; then
+        error "You must be logged into the Kubernetes cluster from the $OC command line"
     else
-        success "oc command logged in as ${user}"
+        success "$OC command logged in as ${user}"
     fi
 
     if [ $LICENSE_ACCEPT -ne 1 ]; then

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -127,7 +127,7 @@ function print_usage() {
     echo "The --operator-namespace must be provided."
     echo ""
     echo "Options:"
-    echo "   --oc string                    Optional. File path to oc CLI. Default uses oc in your PATH"
+    echo "   --oc string                    Optional. File path to oc/kubectl CLI. Default uses oc in your PATH"
     echo "   --yq string                    Optional. File path to yq CLI. Default uses yq in your PATH"
     echo "   --helm string                  Optional. File path to helm CLI. Default uses helm in your PATH"
     echo "   --operator-namespace string    Required. Namespace to uninstall Foundational services operators and the whole tenant."

--- a/cp3pt0-deployment/uninstall_tenant.sh
+++ b/cp3pt0-deployment/uninstall_tenant.sh
@@ -34,6 +34,7 @@ LOG_FILE="uninstall_tenant_log_$(date +'%Y%m%d%H%M%S').log"
 # ---------- Main functions ----------
 
 . ${BASE_DIR}/common/utils.sh
+. ${BASE_DIR}/common/cli_compat.sh
 
 function main() {
     parse_arguments "$@"
@@ -151,12 +152,12 @@ function pre_req() {
     fi
     check_yq_version
 
-    # Checking oc command logged in
-    user=$(${OC} whoami 2> /dev/null)
-    if [ $? -ne 0 ]; then
-        error "You must be logged into the OpenShift Cluster from the oc command line"
+    # Checking cluster CLI command logged in
+    user=$(get_current_user "${OC}")
+    if [ $? -ne 0 ] || [ -z "$user" ]; then
+        error "You must be logged into the Kubernetes cluster from the ${OC} command line"
     else
-        success "oc command logged in as ${user}"
+        success "${OC} command logged in as ${user}"
     fi
 
     if [ "$OPERATOR_NS" == "" ]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the scripts are for OCP cluster using oc commands. We need support for CNCF which uses kubectl commands instead of oc. The PR creates a common util file for commands that are not the same between oc and kubectl. Where there are unique oc commands, it has been replaced so kubectl will work as well. 


**Which issue(s) this PR fixes**:
Fixes #https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67515
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/68541

**Special notes for your reviewer**:

1. How the test is done?

Tested the 4 scripts in cp3pt0-deployment with a successful run-through for each one. 

Tested on cluster with flag ```--oc /usr/bin/kubectl``` when running the scripts.