### PR TITLE
Add support for EDB v1.28 in OperatorConfig

### DIFF
--- a/internal/controller/constant/odlm_operatorconfig.go
+++ b/internal/controller/constant/odlm_operatorconfig.go
@@ -28,6 +28,7 @@ func init() {
 		"common-service-postgresql",
 		"cloud-native-postgresql-v1.22",
 		"cloud-native-postgresql-v1.25",
+		"cloud-native-postgresql-v1.28",
 	}
 
 	servicesConfig := ""


### PR DESCRIPTION
**What this PR does / why we need it**:
Added `cloud-native-postgresql-v1.28` to the services list in the OperatorConfig template, then use could specified EDB 1.28 replica though CommonService CR operatorConfigs

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69211