### PR TITLE
Increase postgres migration timeout and remove ttl field

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2664,7 +2664,6 @@ spec:
         data:
           spec:
             backoffLimit: 2
-            ttlSecondsAfterFinished: 3600
             template:
               metadata:
                 labels:

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2479,7 +2479,7 @@ spec:
             NAMESPACE: "{{ .ServicesNs }}"
             CLUSTER_NAME: "common-service-db"
             PG_VERSION: "16"
-            TIMEOUT: "120"
+            TIMEOUT: "300"
             SKIP_EDB_CLEANUP: "true"
             SKIP_OPERATOR_VALIDATION: "true"
             IBMPG_NAMESPACE: "{{ .OperatorNs }}"


### PR DESCRIPTION
**What this PR does / why we need it**: Fix for problem that is the migration job failed whiling waiting for Cluster CR to be ready 

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/97121#issuecomment-197748741