### PR TITLE
optional edb operator migration

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|go.mod|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-03-23T18:32:51Z",
+  "generated_at": "2026-05-12T15:44:34Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -250,7 +250,7 @@
         "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2022,
+        "line_number": 1992,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -300,7 +300,7 @@
         "hashed_secret": "68f50205b499282ae510009902c2cb0f7d7ff276",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 838,
+        "line_number": 872,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -308,7 +308,7 @@
         "hashed_secret": "646feddbf19db6769a538e1d49edeff69df6c534",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 840,
+        "line_number": 874,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -316,7 +316,7 @@
         "hashed_secret": "07313f0e320f22cbfa35cfc220508eb3ff457c7e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1127,
+        "line_number": 1166,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -324,7 +324,7 @@
         "hashed_secret": "e480ae8ee8511c4c2b52991227436bf4e862789c",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1538,
+        "line_number": 1577,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -332,7 +332,7 @@
         "hashed_secret": "294d258c5ca822b1da2ddc6d3773e93fcc5a21d1",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2239,
+        "line_number": 2255,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -340,7 +340,7 @@
         "hashed_secret": "f3cbe6a6308032f43444a3420e183ade74c75010",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2242,
+        "line_number": 2258,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -348,7 +348,7 @@
         "hashed_secret": "d2f9a6e3072c696fbdc7d379a7f2374b094764fa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2244,
+        "line_number": 2260,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -356,7 +356,7 @@
         "hashed_secret": "fc13e0a831fef49a8f23a63453affe454bae29e9",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2319,
+        "line_number": 2356,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -364,7 +364,7 @@
         "hashed_secret": "e2b3d97e8164c5c286b92734207aeab2a9acc1d4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2320,
+        "line_number": 2357,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -372,7 +372,7 @@
         "hashed_secret": "0a284863e0ae22f0e94c2a838ea7144c7881760f",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2321,
+        "line_number": 2358,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -100,14 +100,6 @@ spec:
                 echo "Deleting EDB CSV and Subscription in operator namespace $operatorNamespace..."
                 oc delete --ignore-not-found csv $edbCSV -n $operatorNamespace && oc delete --ignore-not-found subscription.operators.coreos.com $edbSub -n $operatorNamespace
               fi
-
-              echo "Deleting EDB config resources in namespace $operatorNamespace to be regenerated after migration..."
-              oc delete configmap cloud-native-postgresql-image-list --ignore-not-found -n $operatorNamespace
-
-              echo "Deleting EDB ServiceAccounts and Jobs in operator namespace $operatorNamespace..."
-              oc delete --ignore-not-found sa postgresql-operator-manager edb-license-sa -n $operatorNamespace
-              oc delete --ignore-not-found role edb-license-role -n $operatorNamespace
-              oc delete --ignore-not-found job create-postgres-license-config -n $operatorNamespace
             fi
 
             echo "Deleting IM and UI ServiceAccounts in services namespace $servicesNamespace..."

--- a/bedrock-migration/templates/bedrock-migration-job.yaml
+++ b/bedrock-migration/templates/bedrock-migration-job.yaml
@@ -33,6 +33,7 @@ spec:
             echo "Starting cleanup for OLM -> No OLM migration..."
             operatorNamespace={{ .Values.global.operatorNamespace }}
             servicesNamespace={{ .Values.global.instanceNamespace }}
+            skipEDBMigration={{ .Values.cpfs.skipEDBMigration }}
             namespaces=$(oc get cm namespace-scope -n $operatorNamespace -o jsonpath="{.data.namespaces}")
 
             
@@ -88,23 +89,29 @@ spec:
               oc delete --ignore-not-found csv $uiCSV -n $operatorNamespace && oc delete --ignore-not-found subscription.operators.coreos.com $uiSub -n $operatorNamespace
             fi
             
-            edbSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='cloud-native-postgresql')].metadata.name}")
-            if [[ -z $edbSub ]]; then
-              echo "EDB Subscription not present in operator namespace $operatorNamespace, skipping deleting Subscription and CSV."
+            if [[ "$skipEDBMigration" == "true" ]]; then
+              echo "Skipping EDB operator cleanup as skipEDBMigration is set to true."
             else
-              edbCSV=$(oc get --ignore-not-found subscription.operators.coreos.com $edbSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
-              echo "Deleting EDB CSV and Subscription in operator namespace $operatorNamespace..."
-              oc delete --ignore-not-found csv $edbCSV -n $operatorNamespace && oc delete --ignore-not-found subscription.operators.coreos.com $edbSub -n $operatorNamespace
+              edbSub=$(oc get subscription.operators.coreos.com -n "$operatorNamespace" -o jsonpath="{.items[?(@.spec.name=='cloud-native-postgresql')].metadata.name}")
+              if [[ -z $edbSub ]]; then
+                echo "EDB Subscription not present in operator namespace $operatorNamespace, skipping deleting Subscription and CSV."
+              else
+                edbCSV=$(oc get --ignore-not-found subscription.operators.coreos.com $edbSub -n $operatorNamespace -o jsonpath='{.status.currentCSV}')
+                echo "Deleting EDB CSV and Subscription in operator namespace $operatorNamespace..."
+                oc delete --ignore-not-found csv $edbCSV -n $operatorNamespace && oc delete --ignore-not-found subscription.operators.coreos.com $edbSub -n $operatorNamespace
+              fi
+
+              echo "Deleting EDB config resources in namespace $operatorNamespace to be regenerated after migration..."
+              oc delete configmap cloud-native-postgresql-image-list --ignore-not-found -n $operatorNamespace
+
+              echo "Deleting EDB ServiceAccounts and Jobs in operator namespace $operatorNamespace..."
+              oc delete --ignore-not-found sa postgresql-operator-manager edb-license-sa -n $operatorNamespace
+              oc delete --ignore-not-found role edb-license-role -n $operatorNamespace
+              oc delete --ignore-not-found job create-postgres-license-config -n $operatorNamespace
             fi
 
-            echo "Deleting EDB config resources in namespace $operatorNamespace to be regenerated after migration..."
-            oc delete configmap cloud-native-postgresql-image-list --ignore-not-found -n $operatorNamespace
-
-            echo "Deleting IM, UI, and EDB ServiceAccounts and Jobs in operator namespace $operatorNamespace and services namespace $servicesNamespace..."
-            oc delete --ignore-not-found sa postgresql-operator-manager edb-license-sa -n $operatorNamespace
+            echo "Deleting IM and UI ServiceAccounts in services namespace $servicesNamespace..."
             oc delete --ignore-not-found sa ibm-iam-operand-restricted ibm-commonui-operand -n $servicesNamespace
-            oc delete --ignore-not-found role edb-license-role -n $operatorNamespace
-            oc delete --ignore-not-found job create-postgres-license-config -n $operatorNamespace
 
             #loop for removing roles from services and tethered namespace
             echo "Cleaning up roles and rolebindings in namespaces $namespaces..."
@@ -122,15 +129,17 @@ spec:
                 #get ui roles
                 roles="${roles} $(oc get roles -n $ns | grep ibm-commonui | awk '{print $1}' | tr "\n" " ")"
                 
-                #get edb roles
-                roles="${roles} $(oc get roles -n $ns | grep postgresql-operator-controller-manager | awk '{print $1}' | tr "\n" " ")"
-                roles="${roles} $(oc get roles -n $ns | grep cloud-native-postgresql | awk '{print $1}' | tr "\n" " ")"
+                #get edb roles (skip if skipEDBMigration is true)
+                if [[ "$skipEDBMigration" != "true" ]]; then
+                  roles="${roles} $(oc get roles -n $ns | grep postgresql-operator-controller-manager | awk '{print $1}' | tr "\n" " ")"
+                  roles="${roles} $(oc get roles -n $ns | grep cloud-native-postgresql | awk '{print $1}' | tr "\n" " ")"
 
-                if [[ $ns != $servicesNamespace ]]; then
-                    edbSA=$(oc get sa -n $ns --ignore-not-found | grep postgresql-operator-controller-manager | awk '{print $1}' | tr "\n" " ")
-                    if [[ ${edbSA// /} != "" ]]; then
-                      oc delete sa $edbSA -n $ns --ignore-not-found
-                    fi
+                  if [[ $ns != $servicesNamespace ]]; then
+                      edbSA=$(oc get sa -n $ns --ignore-not-found | grep postgresql-operator-controller-manager | awk '{print $1}' | tr "\n" " ")
+                      if [[ ${edbSA// /} != "" ]]; then
+                        oc delete sa $edbSA -n $ns --ignore-not-found
+                      fi
+                  fi
                 fi
 
                 if [[ -z ${roles// /} ]]; then

--- a/bedrock-migration/values.yaml
+++ b/bedrock-migration/values.yaml
@@ -10,3 +10,5 @@ global:
 
 cpfs:
   imageRegistryNamespaceOperand: cpopen/cpfs
+  # skipEDBMigration: Controls whether to skip cleanup of the OLM-based EDB operator during bedrock migration.
+  skipEDBMigration: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an variable `skipEDBMigration` to valuse.yaml, if it is true, we skip migrate EDB 
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69365
