### PR TITLE
Add ImageCatalog resource for common-service-db configuration

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2266,6 +2266,19 @@ spec:
         kind: OperandBindInfo
         name: common-service-cnpg-bindinfo
       - apiVersion: pg.ibm.com/v1
+        kind: ImageCatalog
+        name: common-service-db-imagecatalog
+        force: true
+        data:
+          spec:
+            images:
+              - major: 16
+                templatingValueFrom:
+                  configMapKeyRef:
+                    name: ibm-pg-operator-operand-images
+                    key: postgres-16
+                    namespace: {{ .OperatorNs }}
+      - apiVersion: pg.ibm.com/v1
         kind: Cluster
         name: common-service-db          
         force: true
@@ -2332,12 +2345,11 @@ spec:
                     operator: In
                     values:
                       - common-service-db
-            imageName:
-              templatingValueFrom:
-                configMapKeyRef:
-                  name: ibm-pg-operator-operand-images
-                  key: postgres-16
-                  namespace: {{ .OperatorNs }}
+            imageCatalogRef:
+              apiGroup: pg.ibm.com/v1
+              kind: ImageCatalog
+              name: common-service-db-imagecatalog
+              major: 16
             imagePullSecrets:
               - name: {{ .ImagePullSecret }}
             logLevel: info

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2267,17 +2267,18 @@ spec:
         name: common-service-cnpg-bindinfo
       - apiVersion: pg.ibm.com/v1
         kind: ImageCatalog
-        name: common-service-db-imagecatalog
+        name: common-service-db-image-catalog
         force: true
         data:
           spec:
             images:
               - major: 16
-                templatingValueFrom:
-                  configMapKeyRef:
-                    name: ibm-pg-operator-operand-images
-                    key: postgres-16
-                    namespace: {{ .OperatorNs }}
+                image:
+                  templatingValueFrom:
+                    configMapKeyRef:
+                      name: ibm-pg-operator-operand-images
+                      key: postgres-16
+                      namespace: {{ .OperatorNs }}
       - apiVersion: pg.ibm.com/v1
         kind: Cluster
         name: common-service-db          
@@ -2346,7 +2347,7 @@ spec:
                     values:
                       - common-service-db
             imageCatalogRef:
-              apiGroup: pg.ibm.com/v1
+              apiGroup: pg.ibm.com
               kind: ImageCatalog
               name: common-service-db-imagecatalog
               major: 16

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2349,7 +2349,7 @@ spec:
             imageCatalogRef:
               apiGroup: pg.ibm.com
               kind: ImageCatalog
-              name: common-service-db-imagecatalog
+              name: common-service-db-image-catalog
               major: 16
             imagePullSecrets:
               - name: {{ .ImagePullSecret }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce ImageCatalog into OperandConfig 

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69331