### PR TITLE
Add imagecatalog permissions to bedrock core role

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -2066,3 +2066,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - pg.ibm.com
+    resources:
+      - imagecatalogs
+    verbs:
+      - create
+      - delete
+      - get
+      - update


### PR DESCRIPTION
What this PR does / why we need it:
Add image catalog perms into nss managed file

Which issue(s) this PR fixes:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69331