### PR TITLE
Enable IBM PG Operator HA Configuration

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -605,6 +605,7 @@ spec:
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-pg-operator
     scope: public
+    operatorConfig: ibm-pg-operator-config
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
 `
@@ -630,6 +631,7 @@ spec:
     namespace: "{{ .CPFSNs }}"
     packageName: ibm-pg-operator
     scope: public
+    operatorConfig: ibm-pg-operator-config
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
 `
@@ -3033,6 +3035,7 @@ spec:
     packageName: ibm-pg-operator
     scope: public
     installPlanApproval: {{ .ApprovalMode }}
+    operatorConfig: ibm-pg-operator-config
     configName: ibm-pg-operator
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"

--- a/internal/controller/constant/odlm_operatorconfig.go
+++ b/internal/controller/constant/odlm_operatorconfig.go
@@ -19,8 +19,9 @@ package constant
 import "fmt"
 
 var PostGresOperatorConfig string
+var IBMPGOperatorConfig string
 
-// Populate PostGresOperatorConfig at package initialization
+// Populate PostGresOperatorConfig and IBMPGOperatorConfig at package initialization
 func init() {
 	services := []string{
 		"edb-keycloak",
@@ -48,6 +49,31 @@ metadata:
     version: {{ .Version }}
 spec:
   services:` + servicesConfig
+
+	// IBM PG operator services (using operator entry names from OperandRegistry)
+	ibmPGServices := []string{
+		"ibm-pg-operator-v28",
+		"common-service-cnpg",
+		"common-service-pg-migrator",
+	}
+
+	ibmPGServicesConfig := ""
+	for _, service := range ibmPGServices {
+		ibmPGServicesConfig += fmt.Sprintf(ibmPGServiceTemplate, service)
+	}
+
+	IBMPGOperatorConfig = `apiVersion: operator.ibm.com/v1alpha1
+kind: OperatorConfig
+metadata:
+  name: ibm-pg-operator-config
+  namespace: "{{ .ServicesNs }}"
+  labels:
+    operator.ibm.com/managedByCsOperator: "true"
+    operator.ibm.com/experimental: "true"
+  annotations:
+    version: {{ .Version }}
+spec:
+  services:` + ibmPGServicesConfig
 }
 
 const postgresServiceTemplate = `
@@ -97,3 +123,52 @@ const postgresServiceTemplate = `
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: cloud-native-postgresql`
+
+
+const ibmPGServiceTemplate = `
+    - name: %s
+      replicas: placeholder-size
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - ppc64le
+                - s390x
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 90
+            podAffinityTerm:
+              topologyKey: topology.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - ibm-pg-operator
+          - weight: 50
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - ibm-pg-operator
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: ibm-pg-operator
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/region
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: ibm-pg-operator`

--- a/internal/controller/constant/odlm_operatorconfig.go
+++ b/internal/controller/constant/odlm_operatorconfig.go
@@ -18,29 +18,68 @@ package constant
 
 import "fmt"
 
+// Package names for PostgreSQL operators
+const (
+	CloudNativePostgreSQLPackage = "cloud-native-postgresql"
+	IBMPGOperatorPackage         = "ibm-pg-operator"
+)
+
+// OperatorConfig names for PostgreSQL operators
+const (
+	CloudNativePostgreSQLOperatorConfigName = "cloud-native-postgresql-operator-config"
+	IBMPGOperatorConfigName                 = "ibm-pg-operator-config"
+)
+
+// EDBOperatorServices lists all EDB PostgreSQL operator services.
+// This is the single source of truth for EDB operator service names used across:
+// - OperatorConfig templates (init function)
+// - Operator grouping logic (operatorconfig.go)
+// - Size profiles (size/*.go)
+var EDBOperatorServices = []string{
+	"edb-keycloak",
+	"cloud-native-postgresql",
+	"common-service-postgresql",
+	"cloud-native-postgresql-v1.22",
+	"cloud-native-postgresql-v1.25",
+	"cloud-native-postgresql-v1.28",
+}
+
+// IBMPGOperatorServices lists all IBM PG operator services.
+// This is the single source of truth for IBM PG operator service names used across:
+// - OperatorConfig templates (init function)
+// - Operator grouping logic (operatorconfig.go)
+// - Size profiles (size/*.go)
+var IBMPGOperatorServices = []string{
+	"ibm-pg-operator-v28",
+	"common-service-cnpg",
+	"common-service-pg-migrator",
+}
+
+// PostGresOperatorConfig contains the OperatorConfig template for EDB PostgreSQL operators.
+// This is used for the cloud-native-postgresql package which includes EDB-based PostgreSQL services.
 var PostGresOperatorConfig string
+
+// IBMPGOperatorConfig contains the OperatorConfig template for IBM PostgreSQL operators.
+// This is used for the ibm-pg-operator package which includes IBM's PostgreSQL implementation.
+// The IBM PG operator is the successor to EDB and provides enhanced features and support.
 var IBMPGOperatorConfig string
 
-// Populate PostGresOperatorConfig and IBMPGOperatorConfig at package initialization
+// Populate PostGresOperatorConfig and IBMPGOperatorConfig at package initialization.
+// These templates define HA topology constraints including:
+// - Node affinity for multi-architecture support (amd64, ppc64le, s390x)
+// - Pod anti-affinity to spread replicas across zones and hosts
+// - Topology spread constraints for zone and region distribution
 func init() {
-	services := []string{
-		"edb-keycloak",
-		"cloud-native-postgresql",
-		"common-service-postgresql",
-		"cloud-native-postgresql-v1.22",
-		"cloud-native-postgresql-v1.25",
-		"cloud-native-postgresql-v1.28",
-	}
-
+	// Build EDB PostgreSQL operator config from the service list
 	servicesConfig := ""
-	for _, service := range services {
+	for _, service := range EDBOperatorServices {
 		servicesConfig += fmt.Sprintf(postgresServiceTemplate, service)
 	}
 
 	PostGresOperatorConfig = `apiVersion: operator.ibm.com/v1alpha1
 kind: OperatorConfig
 metadata:
-  name: cloud-native-postgresql-operator-config
+  name: ` + CloudNativePostgreSQLOperatorConfigName + `
   namespace: "{{ .ServicesNs }}"
   labels:
     operator.ibm.com/managedByCsOperator: "true"
@@ -50,22 +89,16 @@ metadata:
 spec:
   services:` + servicesConfig
 
-	// IBM PG operator services (using operator entry names from OperandRegistry)
-	ibmPGServices := []string{
-		"ibm-pg-operator-v28",
-		"common-service-cnpg",
-		"common-service-pg-migrator",
-	}
-
+	// Build IBM PG operator config from the service list
 	ibmPGServicesConfig := ""
-	for _, service := range ibmPGServices {
+	for _, service := range IBMPGOperatorServices {
 		ibmPGServicesConfig += fmt.Sprintf(ibmPGServiceTemplate, service)
 	}
 
 	IBMPGOperatorConfig = `apiVersion: operator.ibm.com/v1alpha1
 kind: OperatorConfig
 metadata:
-  name: ibm-pg-operator-config
+  name: ` + IBMPGOperatorConfigName + `
   namespace: "{{ .ServicesNs }}"
   labels:
     operator.ibm.com/managedByCsOperator: "true"
@@ -123,7 +156,6 @@ const postgresServiceTemplate = `
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: cloud-native-postgresql`
-
 
 const ibmPGServiceTemplate = `
     - name: %s

--- a/internal/controller/constant/odlm_operatorconfig.go
+++ b/internal/controller/constant/odlm_operatorconfig.go
@@ -31,10 +31,6 @@ const (
 )
 
 // EDBOperatorServices lists all EDB PostgreSQL operator services.
-// This is the single source of truth for EDB operator service names used across:
-// - OperatorConfig templates (init function)
-// - Operator grouping logic (operatorconfig.go)
-// - Size profiles (size/*.go)
 var EDBOperatorServices = []string{
 	"edb-keycloak",
 	"cloud-native-postgresql",
@@ -45,10 +41,6 @@ var EDBOperatorServices = []string{
 }
 
 // IBMPGOperatorServices lists all IBM PG operator services.
-// This is the single source of truth for IBM PG operator service names used across:
-// - OperatorConfig templates (init function)
-// - Operator grouping logic (operatorconfig.go)
-// - Size profiles (size/*.go)
 var IBMPGOperatorServices = []string{
 	"ibm-pg-operator-v28",
 	"common-service-cnpg",
@@ -56,19 +48,11 @@ var IBMPGOperatorServices = []string{
 }
 
 // PostGresOperatorConfig contains the OperatorConfig template for EDB PostgreSQL operators.
-// This is used for the cloud-native-postgresql package which includes EDB-based PostgreSQL services.
 var PostGresOperatorConfig string
 
 // IBMPGOperatorConfig contains the OperatorConfig template for IBM PostgreSQL operators.
-// This is used for the ibm-pg-operator package which includes IBM's PostgreSQL implementation.
-// The IBM PG operator is the successor to EDB and provides enhanced features and support.
 var IBMPGOperatorConfig string
 
-// Populate PostGresOperatorConfig and IBMPGOperatorConfig at package initialization.
-// These templates define HA topology constraints including:
-// - Node affinity for multi-architecture support (amd64, ppc64le, s390x)
-// - Pod anti-affinity to spread replicas across zones and hosts
-// - Topology spread constraints for zone and region distribution
 func init() {
 	// Build EDB PostgreSQL operator config from the service list
 	servicesConfig := ""

--- a/internal/controller/operatorconfig.go
+++ b/internal/controller/operatorconfig.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -45,47 +44,72 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 		return true, nil
 	}
 
-	replicasProvided := false
+	// Group configs by package name
+	configsByPackage := make(map[string][]v3.OperatorConfig)
 	for _, config := range aggregatedConfigs {
 		packageName, err := r.fetchPackageNameFromOpReg(ctx, config.Name)
 		if err != nil {
 			return false, err
 		}
-		if packageName != "cloud-native-postgresql" {
-			return false, errors.New("failed to update OperatorConfig. This feature is only available for cloud-native-postgresql operator")
+		if packageName != "cloud-native-postgresql" && packageName != "ibm-pg-operator" {
+			return false, fmt.Errorf("failed to update OperatorConfig. This feature is only available for cloud-native-postgresql and ibm-pg-operator operators, got: %s", packageName)
 		}
 		if config.Replicas != nil {
-			replicasProvided = true
+			configsByPackage[packageName] = append(configsByPackage[packageName], config)
 		}
 	}
 
-	if !replicasProvided {
+	if len(configsByPackage) == 0 {
 		klog.Info("No replicas specified in any CommonService CR OperatorConfigs")
 		return true, nil
 	}
 
+	// Process each package type
+	for packageName, configs := range configsByPackage {
+		if err := r.applyOperatorConfigForPackage(ctx, packageName, configs); err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+func (r *CommonServiceReconciler) applyOperatorConfigForPackage(ctx context.Context, packageName string, configs []v3.OperatorConfig) error {
+	var configName, configTemplate string
+
+	switch packageName {
+	case "cloud-native-postgresql":
+		configName = "cloud-native-postgresql-operator-config"
+		configTemplate = constant.PostGresOperatorConfig
+	case "ibm-pg-operator":
+		configName = "ibm-pg-operator-config"
+		configTemplate = constant.IBMPGOperatorConfig
+	default:
+		return fmt.Errorf("unsupported package name: %s", packageName)
+	}
+
 	operatorConfig := &odlm.OperatorConfig{}
 	if err := r.Reader.Get(ctx, types.NamespacedName{
-		Name:      "cloud-native-postgresql-operator-config",
+		Name:      configName,
 		Namespace: r.Bootstrap.CSData.ServicesNs,
 	}, operatorConfig); err != nil {
 		if !apierrors.IsNotFound(err) {
 			klog.Errorf("failed to get OperatorConfig %s/%s: %v", operatorConfig.GetNamespace(), operatorConfig.GetName(), err)
-			return true, err
+			return err
 		}
 	}
 
 	// Use the aggregated replica value (maximum across all CRs)
-	replicas := *aggregatedConfigs[0].Replicas
-	klog.Infof("Applying OperatorConfig with %d replicas (aggregated from all CommonService CRs)", replicas)
+	replicas := *configs[0].Replicas
+	klog.Infof("Applying OperatorConfig for %s with %d replicas (aggregated from all CommonService CRs)", packageName, replicas)
 	replacer := strings.NewReplacer("placeholder-size", fmt.Sprintf("%d", replicas))
-	updatedConfig := replacer.Replace(constant.PostGresOperatorConfig)
-	klog.V(2).Infof("OperatorConfig to be applied will be: %v", updatedConfig)
+	updatedConfig := replacer.Replace(configTemplate)
+	klog.V(2).Infof("OperatorConfig to be applied for %s will be: %v", packageName, updatedConfig)
 
 	if err := r.Bootstrap.InstallOrUpdateOperatorConfig(updatedConfig, true); err != nil {
-		return false, err
+		return err
 	}
-	return false, nil
+	return nil
 }
 
 // aggregateOperatorConfigsFromAllCRs collects and merges OperatorConfigs from all CommonService CRs
@@ -156,5 +180,16 @@ func (r *CommonServiceReconciler) fetchPackageNameFromOpReg(ctx context.Context,
 			return operator.PackageName, nil
 		}
 	}
+	
+	// If exact name not found, check if the name matches a known package name
+	// This allows users to specify "ibm-pg-operator" as a shorthand for all operators
+	// with packageName "ibm-pg-operator" (e.g., ibm-pg-operator-v28, common-service-cnpg, etc.)
+	for _, r := range registry.Spec.Operators {
+		operator := r
+		if operator.PackageName == name {
+			return operator.PackageName, nil
+		}
+	}
+	
 	return "", nil
 }

--- a/internal/controller/operatorconfig.go
+++ b/internal/controller/operatorconfig.go
@@ -1,4 +1,3 @@
-
 //
 // Copyright 2024 IBM Corporation
 //
@@ -22,13 +21,11 @@ import (
 	"fmt"
 	"strings"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 
 	v3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/common"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/constant"
-	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
 )
 
 func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, configList []v3.OperatorConfig) (bool, error) {
@@ -45,35 +42,17 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 		return true, nil
 	}
 
-	// Define supported operators and their corresponding OperatorConfig
-	// EDB operators (cloud-native-postgresql package)
-	edbOperators := map[string]bool{
-		"edb-keycloak":                  true,
-		"cloud-native-postgresql":       true,
-		"common-service-postgresql":     true,
-		"cloud-native-postgresql-v1.22": true,
-		"cloud-native-postgresql-v1.25": true,
-		"cloud-native-postgresql-v1.28": true,
-	}
-
-	// IBM PG operators (ibm-pg-operator package)
-	ibmPGOperators := map[string]bool{
-		"ibm-pg-operator-v28":        true,
-		"common-service-cnpg":        true,
-		"common-service-pg-migrator": true,
-	}
-
-	// Group configs by operator type
+	// Group configs by operator type using the service lists from constant package
 	var edbConfigs, ibmPGConfigs []v3.OperatorConfig
 	for _, config := range aggregatedConfigs {
 		if config.Replicas == nil {
 			continue
 		}
 
-		if edbOperators[config.Name] {
+		if common.Contains(constant.EDBOperatorServices, config.Name) {
 			edbConfigs = append(edbConfigs, config)
 			klog.Infof("Found EDB operator config: %s with %d replicas", config.Name, *config.Replicas)
-		} else if ibmPGOperators[config.Name] {
+		} else if common.Contains(constant.IBMPGOperatorServices, config.Name) {
 			ibmPGConfigs = append(ibmPGConfigs, config)
 			klog.Infof("Found IBM PG operator config: %s with %d replicas", config.Name, *config.Replicas)
 		} else {
@@ -88,19 +67,52 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 
 	// Process EDB operators
 	if len(edbConfigs) > 0 {
-		return err
+		if err := r.processOperatorConfigs(ctx, edbConfigs, constant.PostGresOperatorConfig, constant.CloudNativePostgreSQLPackage); err != nil {
+			return false, err
+		}
 	}
 
 	// Process IBM PG operators
 	if len(ibmPGConfigs) > 0 {
-			return err
+		if err := r.processOperatorConfigs(ctx, ibmPGConfigs, constant.IBMPGOperatorConfig, constant.IBMPGOperatorPackage); err != nil {
+			return false, err
 		}
 	}
 
+	return false, nil
+}
+
+// processOperatorConfigs processes a group of operator configs and applies them
+func (r *CommonServiceReconciler) processOperatorConfigs(ctx context.Context, configs []v3.OperatorConfig, configTemplate string, packageName string) error {
+	if len(configs) == 0 {
+		return nil
+	}
+
+	// Validate package name and get corresponding OperatorConfig name
+	var operatorConfigName string
+	if packageName == constant.CloudNativePostgreSQLPackage {
+		operatorConfigName = constant.CloudNativePostgreSQLOperatorConfigName
+	} else if packageName == constant.IBMPGOperatorPackage {
+		operatorConfigName = constant.IBMPGOperatorConfigName
+	} else {
+		return fmt.Errorf("unsupported package name: %s", packageName)
+	}
+
 	// Use the aggregated replica value (maximum across all CRs)
-	replicas := *configs[0].Replicas
-	klog.Infof("Applying OperatorConfig for %s with %d replicas (aggregated from all CommonService CRs)", packageName, replicas)
-	replacer := strings.NewReplacer("placeholder-size", fmt.Sprintf("%d", replicas))
+	// Find the first non-nil replica count defensively instead of assuming configs[0] is always valid.
+	var replicas *int32
+	for _, config := range configs {
+		if config.Replicas != nil {
+			replicas = config.Replicas
+			break
+		}
+	}
+	if replicas == nil {
+		return fmt.Errorf("invalid config for %s: replicas is nil", operatorConfigName)
+	}
+	replicaCount := *replicas
+	klog.Infof("Applying OperatorConfig for %s with %d replicas (aggregated from all CommonService CRs)", packageName, replicaCount)
+	replacer := strings.NewReplacer("placeholder-size", fmt.Sprintf("%d", replicaCount))
 	updatedConfig := replacer.Replace(configTemplate)
 	klog.V(2).Infof("OperatorConfig to be applied for %s will be: %v", packageName, updatedConfig)
 
@@ -164,20 +176,4 @@ func (r *CommonServiceReconciler) aggregateOperatorConfigsFromAllCRs(ctx context
 
 	klog.Infof("Aggregated %d OperatorConfig(s) from %d CommonService CR(s)", len(result), len(csObjectList.Items))
 	return result, nil
-}
-
-func (r *CommonServiceReconciler) fetchPackageNameFromOpReg(ctx context.Context, name string) (string, error) {
-	registry, err := r.GetOperandRegistry(ctx, "common-service", r.CSData.ServicesNs)
-	if err != nil {
-		return "", err
-	}
-
-	for _, r := range registry.Spec.Operators {
-		operator := r
-		if operator.Name == name {
-			return operator.PackageName, nil
-		}
-	}
-	
-	return "", nil
 }

--- a/internal/controller/operatorconfig.go
+++ b/internal/controller/operatorconfig.go
@@ -1,3 +1,4 @@
+
 //
 // Copyright 2024 IBM Corporation
 //
@@ -44,57 +45,56 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 		return true, nil
 	}
 
-	// Group configs by package name
-	configsByPackage := make(map[string][]v3.OperatorConfig)
+	// Define supported operators and their corresponding OperatorConfig
+	// EDB operators (cloud-native-postgresql package)
+	edbOperators := map[string]bool{
+		"edb-keycloak":                  true,
+		"cloud-native-postgresql":       true,
+		"common-service-postgresql":     true,
+		"cloud-native-postgresql-v1.22": true,
+		"cloud-native-postgresql-v1.25": true,
+		"cloud-native-postgresql-v1.28": true,
+	}
+
+	// IBM PG operators (ibm-pg-operator package)
+	ibmPGOperators := map[string]bool{
+		"ibm-pg-operator-v28":        true,
+		"common-service-cnpg":        true,
+		"common-service-pg-migrator": true,
+	}
+
+	// Group configs by operator type
+	var edbConfigs, ibmPGConfigs []v3.OperatorConfig
 	for _, config := range aggregatedConfigs {
-		packageName, err := r.fetchPackageNameFromOpReg(ctx, config.Name)
-		if err != nil {
-			return false, err
+		if config.Replicas == nil {
+			continue
 		}
-		if packageName != "cloud-native-postgresql" && packageName != "ibm-pg-operator" {
-			return false, fmt.Errorf("failed to update OperatorConfig. This feature is only available for cloud-native-postgresql and ibm-pg-operator operators, got: %s", packageName)
-		}
-		if config.Replicas != nil {
-			configsByPackage[packageName] = append(configsByPackage[packageName], config)
+
+		if edbOperators[config.Name] {
+			edbConfigs = append(edbConfigs, config)
+			klog.Infof("Found EDB operator config: %s with %d replicas", config.Name, *config.Replicas)
+		} else if ibmPGOperators[config.Name] {
+			ibmPGConfigs = append(ibmPGConfigs, config)
+			klog.Infof("Found IBM PG operator config: %s with %d replicas", config.Name, *config.Replicas)
+		} else {
+			return false, fmt.Errorf("failed to update OperatorConfig. Operator '%s' is not supported for HA configuration", config.Name)
 		}
 	}
 
-	if len(configsByPackage) == 0 {
+	if len(edbConfigs) == 0 && len(ibmPGConfigs) == 0 {
 		klog.Info("No replicas specified in any CommonService CR OperatorConfigs")
 		return true, nil
 	}
 
-	// Process each package type
-	for packageName, configs := range configsByPackage {
-		if err := r.applyOperatorConfigForPackage(ctx, packageName, configs); err != nil {
+	// Process EDB operators
+	if len(edbConfigs) > 0 {
+		if err := r.applyOperatorConfigForType(ctx, "cloud-native-postgresql-operator-config", constant.PostGresOperatorConfig, edbConfigs, "EDB"); err != nil {
 			return false, err
 		}
 	}
 
-	return false, nil
-}
-
-func (r *CommonServiceReconciler) applyOperatorConfigForPackage(ctx context.Context, packageName string, configs []v3.OperatorConfig) error {
-	var configName, configTemplate string
-
-	switch packageName {
-	case "cloud-native-postgresql":
-		configName = "cloud-native-postgresql-operator-config"
-		configTemplate = constant.PostGresOperatorConfig
-	case "ibm-pg-operator":
-		configName = "ibm-pg-operator-config"
-		configTemplate = constant.IBMPGOperatorConfig
-	default:
-		return fmt.Errorf("unsupported package name: %s", packageName)
-	}
-
-	operatorConfig := &odlm.OperatorConfig{}
-	if err := r.Reader.Get(ctx, types.NamespacedName{
-		Name:      configName,
-		Namespace: r.Bootstrap.CSData.ServicesNs,
-	}, operatorConfig); err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.Errorf("failed to get OperatorConfig %s/%s: %v", operatorConfig.GetNamespace(), operatorConfig.GetName(), err)
+	// Process IBM PG operators
+	if len(ibmPGConfigs) > 0 {
 			return err
 		}
 	}
@@ -177,16 +177,6 @@ func (r *CommonServiceReconciler) fetchPackageNameFromOpReg(ctx context.Context,
 	for _, r := range registry.Spec.Operators {
 		operator := r
 		if operator.Name == name {
-			return operator.PackageName, nil
-		}
-	}
-	
-	// If exact name not found, check if the name matches a known package name
-	// This allows users to specify "ibm-pg-operator" as a shorthand for all operators
-	// with packageName "ibm-pg-operator" (e.g., ibm-pg-operator-v28, common-service-cnpg, etc.)
-	for _, r := range registry.Spec.Operators {
-		operator := r
-		if operator.PackageName == name {
 			return operator.PackageName, nil
 		}
 	}

--- a/internal/controller/operatorconfig.go
+++ b/internal/controller/operatorconfig.go
@@ -88,9 +88,7 @@ func (r *CommonServiceReconciler) updateOperatorConfig(ctx context.Context, conf
 
 	// Process EDB operators
 	if len(edbConfigs) > 0 {
-		if err := r.applyOperatorConfigForType(ctx, "cloud-native-postgresql-operator-config", constant.PostGresOperatorConfig, edbConfigs, "EDB"); err != nil {
-			return false, err
-		}
+		return err
 	}
 
 	// Process IBM PG operators


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables High Availability configuration for IBM PG operators through the CommonService CR, similar to the existing EDB operator support. Users can now configure replica counts for IBM PG operators using the operatorConfigs field in the CommonService CR.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69374

**How to test**:
1. test image: quay.io/yuchen_shen/cs_operator:edb
2. create a non-master cs cr with the config:
    ```
     spec:
        operatorConfigs:
          - name: ibm-pg-operator
            replicas: <number-of-replicas>
    ```
3. operatorConfig will be created with related replica, and pg pods are shown up.
