### PR TITLE
Update only annotations and spec for cs-ca-certificate

### DIFF
--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -660,8 +660,23 @@ func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, alwaysUpdate ...b
 
 			resourceVersion := objInCluster.GetResourceVersion()
 			obj.SetResourceVersion(resourceVersion)
-			if err := b.UpdateObject(obj); err != nil {
-				errMsg = err
+
+			// Special handling for cs-ca-certificate: only update annotations and spec
+			if gvk.Kind == "Certificate" && obj.GetName() == "cs-ca-certificate" {
+				// Preserve existing object and only update annotations and spec
+				if newAnnotations := obj.GetAnnotations(); newAnnotations != nil {
+					objInCluster.SetAnnotations(newAnnotations)
+				}
+				if newSpec, found := obj.Object["spec"]; found {
+					objInCluster.Object["spec"] = newSpec
+				}
+				if err := b.UpdateObject(objInCluster); err != nil {
+					errMsg = err
+				}
+			} else {
+				if err := b.UpdateObject(obj); err != nil {
+					errMsg = err
+				}
 			}
 		}
 	}

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -662,7 +662,7 @@ func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, alwaysUpdate ...b
 			obj.SetResourceVersion(resourceVersion)
 
 			// Special handling for cs-ca-certificate: only update annotations and spec
-			if gvk.Kind == "Certificate" && obj.GetName() == "cs-ca-certificate" {
+			if gvk.Kind == "Certificate" && obj.GetName() == constant.CSCACertificate {
 				// Preserve existing object and only update annotations and spec
 				if newAnnotations := obj.GetAnnotations(); newAnnotations != nil {
 					objInCluster.SetAnnotations(newAnnotations)

--- a/internal/controller/constant/certmanager.go
+++ b/internal/controller/constant/certmanager.go
@@ -70,6 +70,7 @@ spec:
 `
 
 // CSCACert is the CR of cs-ca-certificate
+// update the version annotation to trigger cert update
 const CSCACert = `
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -81,6 +82,8 @@ metadata:
     operator.ibm.com/managedByCsOperator: 'true'
     ibm-cert-manager-operator/refresh-ca-chain: 'true'
     manage-cert-rotation: 'true'
+  annotations:
+    version: 0.0.1
   name: cs-ca-certificate
   namespace: "placeholder"
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update cs-ca-certificate when there is a change in annotation or spec. Also ensures that when the version annotation is updated in the cert, only the annotations and spec are modified during the update operation, preventing unintended changes to other fields

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69136
