### PR TITLE
Find maximum replica count across all configs instead of first non-nil

### DIFF
--- a/internal/controller/operatorconfig.go
+++ b/internal/controller/operatorconfig.go
@@ -99,18 +99,19 @@ func (r *CommonServiceReconciler) processOperatorConfigs(ctx context.Context, co
 	}
 
 	// Use the aggregated replica value (maximum across all CRs)
-	// Find the first non-nil replica count defensively instead of assuming configs[0] is always valid.
-	var replicas *int32
+	// Find the maximum replica count across all configs
+	var maxReplicas *int32
 	for _, config := range configs {
 		if config.Replicas != nil {
-			replicas = config.Replicas
-			break
+			if maxReplicas == nil || *config.Replicas > *maxReplicas {
+				maxReplicas = config.Replicas
+			}
 		}
 	}
-	if replicas == nil {
+	if maxReplicas == nil {
 		return fmt.Errorf("invalid config for %s: replicas is nil", operatorConfigName)
 	}
-	replicaCount := *replicas
+	replicaCount := *maxReplicas
 	klog.Infof("Applying OperatorConfig for %s with %d replicas (aggregated from all CommonService CRs)", packageName, replicaCount)
 	replacer := strings.NewReplacer("placeholder-size", fmt.Sprintf("%d", replicaCount))
 	updatedConfig := replacer.Replace(configTemplate)


### PR DESCRIPTION
**What this PR does / why we need it**:
Changed the loop to iterate through all configs and track the maximum replica value

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69374

**Special notes for your reviewer**:
Test image: quay.io/yuchen_shen/cs_operator:edb
1. create two different CS CR with
    ```
    spec:
      operatorConfigs:
        - name: common-service-cnpg
          replicas: 2
    ```
    ```
    spec:
      operatorConfigs:
        - name: ibm-pg-operator-v28
          replicas: 4
   ```
2. As they are use same packagemanifest name, so the replica will go with the max of them which is 4 instead of only getting from the first config.
