### PR TITLE
refactor: simplify feature config merging by applying global features as base layer

### DIFF
--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -1158,27 +1158,6 @@ func getItemByGVKNameNamespace(opResources []interface{}, opconNs, apiVersion, k
 	return nil
 }
 
-// filterConfigsByServiceName filters out service configurations that are in the exclusion set
-func filterConfigsByServiceName(configs []interface{}, excludeServices map[string]bool) []interface{} {
-	if len(excludeServices) == 0 {
-		return configs
-	}
-
-	filtered := make([]interface{}, 0, len(configs))
-	for _, config := range configs {
-		if configMap, ok := config.(map[string]interface{}); ok {
-			if name, ok := configMap["name"].(string); ok {
-				if !excludeServices[name] {
-					filtered = append(filtered, config)
-				} else {
-					klog.Infof("Filtered out service %s from feature configs (has explicit configuration)", name)
-				}
-			}
-		}
-	}
-	return filtered
-}
-
 // buildDesiredStateFromAllCRs aggregates configurations from all CommonService CRs
 // to determine the complete desired state for OperandConfig
 func (r *CommonServiceReconciler) buildDesiredStateFromAllCRs(ctx context.Context) ([]interface{}, map[string]string, error) {
@@ -1275,29 +1254,27 @@ func (r *CommonServiceReconciler) buildDesiredStateFromAllCRs(ctx context.Contex
 		}
 	}
 
-	// PASS 2: Process service-specific configurations only (no global features)
-	klog.Info("PASS 2: Processing service-specific configurations from all CRs")
+	// PASS 2: Apply collected global features to ALL services (base layer)
+	klog.Info("PASS 2: Applying collected global features to all services as base layer")
 	var aggregatedConfigs []interface{}
 	serviceControllerMappingSummary := make(map[string]string)
-	servicesWithExplicitConfig := make(map[string]bool)
 
+	featureConfigs, _, err := ExtractCommonServiceConfigs(mergedFeatureCS, r.CSData.ServicesNs)
+	if err != nil {
+		klog.Errorf("Failed to extract feature configs: %v", err)
+	} else if len(featureConfigs) > 0 {
+		klog.Infof("Applying %d global feature configs as base layer", len(featureConfigs))
+		aggregatedConfigs = mergeCSCRs(aggregatedConfigs, featureConfigs, ruleSlice, serviceControllerMappingSummary, r.CSData.ServicesNs)
+	}
+
+	// PASS 3: Apply service-specific configurations (override layer)
+	klog.Info("PASS 3: Applying service-specific configurations as override layer")
 	for _, cs := range csObjectList.Items {
 		if cs.GetDeletionTimestamp() != nil {
 			continue
 		}
 
-		// Track services that have explicit spec or resources configurations
-		if cs.Spec.Services != nil {
-			for _, svc := range cs.Spec.Services {
-				if (svc.Spec != nil && len(svc.Spec) > 0) || (svc.Resources != nil && len(svc.Resources) > 0) {
-					servicesWithExplicitConfig[svc.Name] = true
-					klog.Infof("Service %s has explicit configuration in CR %s/%s", svc.Name, cs.Namespace, cs.Name)
-				}
-			}
-		}
-
-		// Extract only service-specific configs (no global features like storageClass)
-		// This prevents global features from one CR overwriting service-specific configs from another
+		// Extract service-specific configs (no global features like storageClass)
 		csConfigs, serviceControllerMapping, err := ExtractServiceSpecificConfigs(&cs, r.CSData.ServicesNs)
 		if err != nil {
 			klog.Errorf("Failed to extract service-specific configs from CommonService %s/%s: %v", cs.Namespace, cs.Name, err)
@@ -1306,23 +1283,6 @@ func (r *CommonServiceReconciler) buildDesiredStateFromAllCRs(ctx context.Contex
 
 		serviceControllerMappingSummary = mergeProfileController(serviceControllerMappingSummary, serviceControllerMapping)
 		aggregatedConfigs = mergeCSCRs(aggregatedConfigs, csConfigs, ruleSlice, serviceControllerMappingSummary, r.CSData.ServicesNs)
-	}
-
-	// PASS 3: Apply collected features only to services without explicit configurations
-	klog.Info("PASS 3: Applying collected features to services without explicit configurations")
-	featureConfigs, _, err := ExtractCommonServiceConfigs(mergedFeatureCS, r.CSData.ServicesNs)
-	if err != nil {
-		klog.Errorf("Failed to extract feature configs: %v", err)
-	} else if len(featureConfigs) > 0 {
-		// Filter feature configs to exclude services with explicit configurations
-		filteredFeatureConfigs := filterConfigsByServiceName(featureConfigs, servicesWithExplicitConfig)
-		if len(filteredFeatureConfigs) > 0 {
-			klog.Infof("Merging %d filtered feature configs into final state (excluded %d services with explicit config)",
-				len(filteredFeatureConfigs), len(featureConfigs)-len(filteredFeatureConfigs))
-			aggregatedConfigs = mergeCSCRs(aggregatedConfigs, filteredFeatureConfigs, ruleSlice, serviceControllerMappingSummary, r.CSData.ServicesNs)
-		} else {
-			klog.Info("All feature configs filtered out - all services have explicit configurations")
-		}
 	}
 
 	return aggregatedConfigs, serviceControllerMappingSummary, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

We observed that when creating a new CommonService CR named `im-common-service`, the OperandConfig is updated **twice in quick succession**:

1. **First Update (generation: 6)**: storageClass is **MISSING** from `common-service-cnpg`
2. **Second Update (generation: 7)**: storageClass is **PRESENT** with value `rook-ceph-block`

#### Root Cause
Over-aggressive filtering in 3-pass merge strategy:
- Services with ANY explicit config are marked as "having explicit config"
- Global features (like storageClass) are filtered out for these services
- Second reconciliation corrects the issue

#### Change
```go
// BEFORE (Buggy)
PASS 1: Collect global features
PASS 2: Process service-specific configs → Mark services with explicit config
PASS 3: Apply global features ONLY to services WITHOUT explicit config (FILTERED)

// AFTER (Fixed)
PASS 1: Collect global features
PASS 2: Apply global features to ALL services (base layer)
PASS 3: Apply service-specific configs (override layer)
```

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/98613 and https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/98634
