### PR TITLE
add updateOperandConfig to reconcileMasterCR

### DIFF
--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -239,6 +239,29 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		return ctrl.Result{}, statusErr
 	}
 
+	// Build desired state from all CommonService CRs and update OperandConfig
+	klog.Info("Building desired state from all CommonService CRs")
+	newConfigs, serviceControllerMapping, err := r.buildDesiredStateFromAllCRs(ctx)
+	if err != nil {
+		if statusErr := r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
+			klog.Error(statusErr)
+		}
+		klog.Errorf("Failed to build desired state from CRs: %v", err)
+		return ctrl.Result{}, err
+	}
+
+	// Update OperandConfig with the aggregated configurations
+	klog.Info("Updating OperandConfig with aggregated configurations")
+	if isEqual, err := r.updateOperandConfig(ctx, newConfigs, serviceControllerMapping); err != nil {
+		if statusErr := r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
+			klog.Error(statusErr)
+		}
+		klog.Errorf("Failed to update OperandConfig: %v", err)
+		return ctrl.Result{}, err
+	} else if isEqual {
+		klog.V(2).Info("No changes detected in OperandConfig after applying CommonService configurations")
+	}
+
 	// Generate Issuer and Certificate CR
 	if statusErr = r.Bootstrap.DeployCertManagerCR(); statusErr != nil {
 		klog.Errorf("Failed to deploy cert manager CRs: %v", statusErr)


### PR DESCRIPTION
**What this PR does / why we need it**:
When we remove field from commonservice MasterCR, cs-operator may not remove it from operandconfig
It is because missing OperandConfig update logic in Master CR reconciliation. The ReconcileMasterCR() function only creates the OperandConfig during initial bootstrap via InitResources() but never updates it on subsequent reconciliations.



