### PR TITLE
skip if changeMap is longer than default map

### DIFF
--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -295,6 +295,10 @@ func mergeChangedMapWithExtremeSize(key string, defaultMap interface{}, changedM
 				defaultMapRef := defaultMap.([]interface{})
 				changedMapRef := changedMap.([]interface{})
 				for i := range changedMapRef {
+					// Check if defaultMapRef has enough elements to avoid index out of range panic
+					if i >= len(defaultMapRef) {
+						continue
+					}
 					for newKey := range changedMapRef[i].(map[string]interface{}) {
 						if _, ok := defaultMapRef[i].(map[string]interface{}); ok {
 							mergeChangedMapWithExtremeSize(newKey, defaultMapRef[i].(map[string]interface{})[newKey], changedMapRef[i].(map[string]interface{})[newKey], finalMap[key].([]interface{})[i].(map[string]interface{}), extreme)

--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -295,8 +295,8 @@ func mergeChangedMapWithExtremeSize(key string, defaultMap interface{}, changedM
 				defaultMapRef := defaultMap.([]interface{})
 				changedMapRef := changedMap.([]interface{})
 				for i := range changedMapRef {
-					// Check if defaultMapRef has enough elements to avoid index out of range panic
-					if i >= len(defaultMapRef) {
+					// Check bounds for both arrays before accessing
+					if i >= len(defaultMapRef) || i >= len(finalMap[key].([]interface{})) {
 						continue
 					}
 					for newKey := range changedMapRef[i].(map[string]interface{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:
skip the extra key when changedMap long than defaultMap to avoid panic issue.
This kind of issue could happened when user manually patch the operandconfig.
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69248
