### PR TITLE
Add cloud-native-postgresql v1.28 to SC2 release

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -1788,6 +1788,20 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     operatorConfig: cloud-native-postgresql-operator-config
     configName: cloud-native-postgresql
+  - channel: stable-v1.28
+    fallbackChannels:
+      - stable-v1.25
+      - stable-v1.22
+      - stable
+    name: cloud-native-postgresql-v1.28
+    namespace: "{{ .CPFSNs }}"
+    packageName: cloud-native-postgresql
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    operatorConfig: cloud-native-postgresql-operator-config
+    configName: cloud-native-postgresql
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: alpha
     name: ibm-user-data-services-operator
     namespace: "{{ .CPFSNs }}"

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -284,8 +284,9 @@ metadata:
     status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
-  - channel: stable-v1.25
+  - channel: stable-v1.28
     fallbackChannels:
+      - stable-v1.25
       - stable-v1.22
       - stable
     installPlanApproval: {{ .ApprovalMode }}


### PR DESCRIPTION
**What this PR does / why we need it**: Add EDB 1.28 into SC2 release
Slack: https://ibm-cloudplatform.slack.com/archives/C027VSWBU1F/p1780505949219789
