### PR TITLE
add events v7.0 to operandregistry

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2956,6 +2956,14 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+  - channel: v7.0
+    name: ibm-events-operator-v7.0
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-events-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
     channel: v6.10


### PR DESCRIPTION
**What this PR does / why we need it**:
add events operator v7.0 to operandregistry
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69502
