### PR TITLE
add new rbac for events v7.0

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -806,6 +806,13 @@ rules:
     resources:
       - deployments/scale
   - verbs:
+      - patch
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - pods/resize
+  - verbs:
       - create
       - patch
     apiGroups:


### PR DESCRIPTION
Error message:
```
E0619 14:50:55.509272       1 namespacescope_controller.go:785] Failed to create role cs-data/ibm-events-operator-a6adcd6e0b7699: roles.rbac.authorization.k8s.io "ibm-events-operator-a6adcd6e0b7699" is forbidden: user "system:serviceaccount:cs-operators:ibm-namespace-scope-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:cs-operators" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["pods/resize"], Verbs:["patch" "update"]}
```

Need to add new rbac for Events operator v7.0