### PR TITLE
Create global CPP config for cncf

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -159,7 +159,7 @@ func main() {
 		// Create CS CR
 		klog.Infof("Start go routines")
 		if os.Getenv("NO_OLM") == "true" {
-			go goroutines.WaitToCreateCsCRNoOLM(bs)
+			go goroutines.WaitToCreateCRNoOLM(bs)
 		} else {
 			go goroutines.WaitToCreateCsCR(bs)
 		}

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -55,6 +55,30 @@ metadata:
             ]
             {{- end }}
           }
+        },
+        {
+          "apiVersion": "v1",
+          "kind": "ConfigMap",
+          "metadata": {
+            "name": "ibm-cpp-config",
+            "namespace": "{{ .Values.global.operatorNamespace }}"
+          },
+          "data": {
+            "domain_name": "{{ .Values.global.domainName }}",
+            "kubernetes_cluster_type": "{{ .Values.global.clusterType }}"
+          }
+        },
+        {
+          "apiVersion": "v1",
+          "kind": "ConfigMap",
+          "metadata": {
+            "name": "ibm-cpp-config",
+            "namespace": "{{ .Values.global.instanceNamespace }}"
+          },
+          "data": {
+            "domain_name": "{{ .Values.global.domainName }}",
+            "kubernetes_cluster_type": "{{ .Values.global.clusterType }}"
+          }
         }
       ]
 spec: 

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -64,7 +64,9 @@ metadata:
             "namespace": "{{ .Values.global.operatorNamespace }}"
           },
           "data": {
+            {{- if .Values.global.domainName }}
             "domain_name": "{{ .Values.global.domainName }}",
+            {{- end }}
             "kubernetes_cluster_type": "{{ .Values.global.clusterType }}"
           }
         },
@@ -76,7 +78,9 @@ metadata:
             "namespace": "{{ .Values.global.instanceNamespace }}"
           },
           "data": {
+            {{- if .Values.global.domainName }}
             "domain_name": "{{ .Values.global.domainName }}",
+            {{- end }}
             "kubernetes_cluster_type": "{{ .Values.global.clusterType }}"
           }
         }

--- a/helm/templates/operator-deployment.yaml
+++ b/helm/templates/operator-deployment.yaml
@@ -60,20 +60,14 @@ metadata:
           "apiVersion": "v1",
           "kind": "ConfigMap",
           "metadata": {
-            "name": "ibm-cpp-config",
-            "namespace": "{{ .Values.global.operatorNamespace }}"
-          },
-          "data": {
-            {{- if .Values.global.domainName }}
-            "domain_name": "{{ .Values.global.domainName }}",
-            {{- end }}
-            "kubernetes_cluster_type": "{{ .Values.global.clusterType }}"
-          }
-        },
-        {
-          "apiVersion": "v1",
-          "kind": "ConfigMap",
-          "metadata": {
+            "labels": {
+                "component-id": "{{ .Chart.Name }}",
+                "operator.ibm.com/managedByCsOperator": "true"
+                {{- range $key, $val := .Values.cpfs.labels }}
+                ,
+                "{{ $key }}": "{{ $val }}"
+                {{- end}}
+              },
             "name": "ibm-cpp-config",
             "namespace": "{{ .Values.global.instanceNamespace }}"
           },
@@ -81,7 +75,8 @@ metadata:
             {{- if .Values.global.domainName }}
             "domain_name": "{{ .Values.global.domainName }}",
             {{- end }}
-            "kubernetes_cluster_type": "{{ .Values.global.clusterType }}"
+            "kubernetes_cluster_type": "{{ .Values.global.clusterType }}",
+            "storageclass.default": "{{ .Values.global.blockStorageClass }}"
           }
         }
       ]

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,4 +24,4 @@ global:
   imagePullSecret: ibm-entitlement-key
   instanceNamespace:
   clusterType: ocp
-  domainName: ""
+  domainName: 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -23,3 +23,5 @@ global:
   operatorNamespace: operator-ns
   imagePullSecret: ibm-entitlement-key
   instanceNamespace:
+  clusterType: ocp
+  domainName: ""

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -559,7 +559,7 @@ func (b *Bootstrap) CreateOrUpdateFromJson(objectTemplate string, alwaysUpdate .
 
 		spec := cr.Object["spec"]
 		data := cr.Object["data"]
-		if spec == "" || data == "" {
+		if spec == "" && data == "" {
 			continue
 		}
 

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -500,8 +500,8 @@ func (b *Bootstrap) CreateCsCR() error {
 	return nil
 }
 
-func (b *Bootstrap) CreateCsCRNoOLM() error {
-	klog.V(2).Infof("creating cs cr")
+func (b *Bootstrap) CreateCRNoOLM() error {
+	klog.V(2).Infof("creating cs cr and ibm-cpp configmap")
 
 	cs := util.NewUnstructured("operator.ibm.com", "CommonService", "v3")
 	cs.SetName("common-service")
@@ -553,7 +553,8 @@ func (b *Bootstrap) CreateOrUpdateFromJson(objectTemplate string, alwaysUpdate .
 		}
 
 		spec := cr.Object["spec"]
-		if spec == "" {
+		data := cr.Object["data"]
+		if spec == "" || data == "" {
 			continue
 		}
 

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"text/template"
 	"time"
 
@@ -500,12 +501,8 @@ func (b *Bootstrap) CreateCsCR() error {
 	return nil
 }
 
-func (b *Bootstrap) CreateCRNoOLM() error {
-	klog.V(2).Infof("creating cs cr and ibm-cpp configmap")
-
-	cs := util.NewUnstructured("operator.ibm.com", "CommonService", "v3")
-	cs.SetName("common-service")
-	cs.SetNamespace(b.CSData.OperatorNs)
+func (b *Bootstrap) CreateResourcesFromAlmExamples() error {
+	klog.Infof("creating resources from alm-examples")
 
 	deploy, err := b.GetDeployment()
 	if err != nil {
@@ -514,112 +511,77 @@ func (b *Bootstrap) CreateCRNoOLM() error {
 
 	annotations := deploy.GetAnnotations()
 	almExample := annotations["alm-examples"]
-
-	// Check if CommonService CR exists
-	csExists := true
-	if _, err := b.GetObject(cs); errors.IsNotFound(err) {
-		csExists = false
-	} else if err != nil {
-		return err
+	if almExample == "" {
+		return fmt.Errorf("alm-examples annotation is empty")
 	}
 
-	// Check if ibm-cpp-config ConfigMap exists in ServicesNs
-	cppConfigExists := true
-	cppConfig := &corev1.ConfigMap{}
-	cppConfigKey := types.NamespacedName{
-		Name:      constant.IBMCPPCONFIG,
-		Namespace: b.CSData.ServicesNs,
-	}
-	if err := b.Reader.Get(ctx, cppConfigKey, cppConfig); errors.IsNotFound(err) {
-		cppConfigExists = false
-	} else if err != nil {
-		return err
-	}
-
-	// If either CommonService CR or ibm-cpp-config ConfigMap doesn't exist, create all resources from alm-examples
-	if !csExists || !cppConfigExists {
-		klog.Infof("Creating resources from alm-examples (csExists=%v, cppConfigExists=%v)", csExists, cppConfigExists)
-		return b.CreateOrUpdateFromJson(almExample)
-	}
-
-	klog.V(2).Infof("CommonService CR and ibm-cpp-config ConfigMap already exist, skipping creation")
-	return nil
-}
-
-func (b *Bootstrap) CreateOrUpdateFromJson(objectTemplate string, alwaysUpdate ...bool) error {
-	klog.V(2).Infof("creating object from Json: %s", objectTemplate)
-
-	// Create a slice for crTemplates
 	var crTemplates []interface{}
-
-	// Convert CR template string to slice
-	if err := json.Unmarshal([]byte(objectTemplate), &crTemplates); err != nil {
+	if err := json.Unmarshal([]byte(almExample), &crTemplates); err != nil {
 		return err
 	}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var errs []error
 
 	for _, crTemplate := range crTemplates {
-		// Create an unstruct object for CR and request its value to CR template
-
-		forceUpdate := false
-		if len(alwaysUpdate) != 0 {
-			forceUpdate = alwaysUpdate[0]
+		crObject, ok := crTemplate.(map[string]interface{})
+		if !ok {
+			mu.Lock()
+			errs = append(errs, fmt.Errorf("invalid alm-example object type %T", crTemplate))
+			mu.Unlock()
+			continue
 		}
-		update := forceUpdate
 
 		var cr unstructured.Unstructured
-		cr.Object = crTemplate.(map[string]interface{})
+		cr.Object = crObject
 
 		name := cr.GetName()
 		if name == "" {
+			klog.V(2).Infof("Skipping object with empty name")
 			continue
 		}
 
 		namespace := cr.GetNamespace()
 		if namespace == "" {
+			klog.V(2).Infof("Skipping object %s: empty namespace", name)
 			continue
 		}
 
 		spec := cr.Object["spec"]
 		data := cr.Object["data"]
 		if spec == nil && data == nil {
-			klog.V(2).Infof("Skipping object %s/%s: neither spec nor data found", cr.GetNamespace(), cr.GetName())
+			klog.V(2).Infof("Skipping object %s/%s: neither spec nor data found", namespace, name)
 			continue
 		}
 
-		crInCluster := unstructured.Unstructured{}
-		crInCluster.SetGroupVersionKind(cr.GroupVersionKind())
+		wg.Add(1)
+		go func(obj unstructured.Unstructured) {
+			defer wg.Done()
 
-		if err := b.Client.Get(ctx, types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		}, &crInCluster); err != nil && !errors.IsNotFound(err) {
-			return err
-		} else if errors.IsNotFound(err) {
-			// Create Custom Resource
-			klog.Infof("creating resource with name: %s, namespace: %s, kind: %s, apiversion: %s/%s\n", cr.GetName(), cr.GetNamespace(), cr.GetKind(), cr.GetObjectKind().GroupVersionKind().Group, cr.GetObjectKind().GroupVersionKind().Version)
-			if err := b.CreateObject(&cr); err != nil {
-				return err
-			}
-			continue
-		} else {
-			// Compare version
-			v1IsLarger, convertErr := util.CompareVersion(cr.GetAnnotations()["version"], crInCluster.GetAnnotations()["version"])
-			if convertErr != nil {
-				return convertErr
-			}
-			if v1IsLarger {
-				update = true
-			}
-		}
+			gvk := obj.GetObjectKind().GroupVersionKind()
+			klog.Infof("Creating resource with name: %s, namespace: %s, kind: %s, apiversion: %s/%s", obj.GetName(), obj.GetNamespace(), gvk.Kind, gvk.Group, gvk.Version)
 
-		if update {
-			klog.Infof("Updating resource with name: %s, namespace: %s, kind: %s, apiversion: %s/%s\n", cr.GetName(), cr.GetNamespace(), cr.GetKind(), cr.GetObjectKind().GroupVersionKind().Group, cr.GetObjectKind().GroupVersionKind().Version)
-			resourceVersion := crInCluster.GetResourceVersion()
-			cr.SetResourceVersion(resourceVersion)
-			if err := b.UpdateObject(&cr); err != nil {
-				return err
+			if err := b.CreateObject(&obj); err != nil {
+				if errors.IsAlreadyExists(err) {
+					klog.Infof("Resource already exists, skipping create for %s/%s, kind: %s, apiversion: %s/%s", obj.GetNamespace(), obj.GetName(), gvk.Kind, gvk.Group, gvk.Version)
+					return
+				}
+
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("failed to create resource %s/%s, kind: %s, apiversion: %s/%s: %w", obj.GetNamespace(), obj.GetName(), gvk.Kind, gvk.Group, gvk.Version, err))
+				mu.Unlock()
+				return
 			}
-		}
+
+			klog.Infof("Successfully created resource %s/%s, kind: %s, apiversion: %s/%s", obj.GetNamespace(), obj.GetName(), gvk.Kind, gvk.Group, gvk.Version)
+		}(cr)
+	}
+
+	wg.Wait()
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed to create resources from alm-examples: %v", errs)
 	}
 
 	return nil

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -573,6 +573,7 @@ func (b *Bootstrap) CreateOrUpdateFromJson(objectTemplate string, alwaysUpdate .
 			return err
 		} else if errors.IsNotFound(err) {
 			// Create Custom Resource
+			klog.Infof("creating resource with name: %s, namespace: %s, kind: %s, apiversion: %s/%s\n", cr.GetName(), cr.GetNamespace(), cr.GetKind(), cr.GetObjectKind().GroupVersionKind().Group, cr.GetObjectKind().GroupVersionKind().Version)
 			if err := b.CreateObject(&cr); err != nil {
 				return err
 			}

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -515,12 +515,34 @@ func (b *Bootstrap) CreateCRNoOLM() error {
 	annotations := deploy.GetAnnotations()
 	almExample := annotations["alm-examples"]
 
-	if _, err := b.GetObject(cs); errors.IsNotFound(err) { // Only if it's a fresh install
-		// Fresh Intall: No ODLM and NO CR
-		return b.CreateOrUpdateFromJson(almExample)
+	// Check if CommonService CR exists
+	csExists := true
+	if _, err := b.GetObject(cs); errors.IsNotFound(err) {
+		csExists = false
 	} else if err != nil {
 		return err
 	}
+
+	// Check if ibm-cpp-config ConfigMap exists in ServicesNs
+	cppConfigExists := true
+	cppConfig := &corev1.ConfigMap{}
+	cppConfigKey := types.NamespacedName{
+		Name:      constant.IBMCPPCONFIG,
+		Namespace: b.CSData.ServicesNs,
+	}
+	if err := b.Reader.Get(ctx, cppConfigKey, cppConfig); errors.IsNotFound(err) {
+		cppConfigExists = false
+	} else if err != nil {
+		return err
+	}
+
+	// If either CommonService CR or ibm-cpp-config ConfigMap doesn't exist, create all resources from alm-examples
+	if !csExists || !cppConfigExists {
+		klog.Infof("Creating resources from alm-examples (csExists=%v, cppConfigExists=%v)", csExists, cppConfigExists)
+		return b.CreateOrUpdateFromJson(almExample)
+	}
+
+	klog.V(2).Infof("CommonService CR and ibm-cpp-config ConfigMap already exist, skipping creation")
 	return nil
 }
 
@@ -559,7 +581,8 @@ func (b *Bootstrap) CreateOrUpdateFromJson(objectTemplate string, alwaysUpdate .
 
 		spec := cr.Object["spec"]
 		data := cr.Object["data"]
-		if spec == "" && data == "" {
+		if spec == nil && data == nil {
+			klog.V(2).Infof("Skipping object %s/%s: neither spec nor data found", cr.GetNamespace(), cr.GetName())
 			continue
 		}
 

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -552,6 +552,11 @@ func (b *Bootstrap) CreateOrUpdateFromJson(objectTemplate string, alwaysUpdate .
 			continue
 		}
 
+		namespace := cr.GetNamespace()
+		if namespace == "" {
+			continue
+		}
+
 		spec := cr.Object["spec"]
 		data := cr.Object["data"]
 		if spec == "" || data == "" {
@@ -563,7 +568,7 @@ func (b *Bootstrap) CreateOrUpdateFromJson(objectTemplate string, alwaysUpdate .
 
 		if err := b.Client.Get(ctx, types.NamespacedName{
 			Name:      name,
-			Namespace: b.CSData.OperatorNs,
+			Namespace: namespace,
 		}, &crInCluster); err != nil && !errors.IsNotFound(err) {
 			return err
 		} else if errors.IsNotFound(err) {

--- a/internal/controller/goroutines/waitToCreateCsCrNoOLM.go
+++ b/internal/controller/goroutines/waitToCreateCsCrNoOLM.go
@@ -30,13 +30,13 @@ import (
 // WaitToCreateCsCR waits for the creation of the CommonService CR in the operator namespace.
 func WaitToCreateCRNoOLM(bs *bootstrap.Bootstrap) {
 	for {
-		klog.Infof("Start to Create CommonService CR and configmap in the namespace %s", bs.CSData.OperatorNs)
-		if err := bs.CreateCRNoOLM(); err != nil {
+		klog.Infof("Start to create resources from alm-examples in the namespace %s", bs.CSData.OperatorNs)
+		if err := bs.CreateResourcesFromAlmExamples(); err != nil {
 			if strings.Contains(fmt.Sprint(err), "failed to call webhook") {
 				klog.Infof("Webhook Server not ready, waiting for it to be ready : %v", err)
 				time.Sleep(time.Second * 20)
 			} else {
-				klog.Errorf("Failed to create CommonService resources : %v", err)
+				klog.Errorf("Failed to create resources from alm-examples: %v", err)
 				os.Exit(1)
 			}
 		} else {

--- a/internal/controller/goroutines/waitToCreateCsCrNoOLM.go
+++ b/internal/controller/goroutines/waitToCreateCsCrNoOLM.go
@@ -30,7 +30,7 @@ import (
 // WaitToCreateCsCR waits for the creation of the CommonService CR in the operator namespace.
 func WaitToCreateCRNoOLM(bs *bootstrap.Bootstrap) {
 	for {
-		klog.Infof("Start to Create CommonService CR in the namespace %s", bs.CSData.OperatorNs)
+		klog.Infof("Start to Create CommonService CR and configmap in the namespace %s", bs.CSData.OperatorNs)
 		if err := bs.CreateCRNoOLM(); err != nil {
 			if strings.Contains(fmt.Sprint(err), "failed to call webhook") {
 				klog.Infof("Webhook Server not ready, waiting for it to be ready : %v", err)

--- a/internal/controller/goroutines/waitToCreateCsCrNoOLM.go
+++ b/internal/controller/goroutines/waitToCreateCsCrNoOLM.go
@@ -28,15 +28,15 @@ import (
 )
 
 // WaitToCreateCsCR waits for the creation of the CommonService CR in the operator namespace.
-func WaitToCreateCsCRNoOLM(bs *bootstrap.Bootstrap) {
+func WaitToCreateCRNoOLM(bs *bootstrap.Bootstrap) {
 	for {
 		klog.Infof("Start to Create CommonService CR in the namespace %s", bs.CSData.OperatorNs)
-		if err := bs.CreateCsCRNoOLM(); err != nil {
+		if err := bs.CreateCRNoOLM(); err != nil {
 			if strings.Contains(fmt.Sprint(err), "failed to call webhook") {
 				klog.Infof("Webhook Server not ready, waiting for it to be ready : %v", err)
 				time.Sleep(time.Second * 20)
 			} else {
-				klog.Errorf("Failed to create CommonService CR : %v", err)
+				klog.Errorf("Failed to create CommonService resources : %v", err)
 				os.Exit(1)
 			}
 		} else {

--- a/internal/controller/no_olm_commonservice_controller.go
+++ b/internal/controller/no_olm_commonservice_controller.go
@@ -83,6 +83,25 @@ func (r *CommonServiceReconciler) ReconcileNoOLMMasterCR(ctx context.Context, in
 		}
 	}()
 
+	typeCorrect, err := r.Bootstrap.CheckClusterType(util.GetServicesNamespace(r.Reader))
+	if err != nil {
+		klog.Errorf("Failed to verify cluster type  %v", err)
+		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
+			klog.Error(err)
+		}
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
+		return ctrl.Result{}, err
+	}
+
+	if !typeCorrect {
+		klog.Error("Cluster type specificed in the ibm-cpp-config isn't correct")
+		if statusErr = r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
+			klog.Error(statusErr)
+		}
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
+		return ctrl.Result{}, statusErr
+	}
+
 	operatorDeployed, servicesDeployed := r.Bootstrap.CheckDeployStatus(ctx)
 	instance.UpdateConfigStatus(&r.Bootstrap.CSData, operatorDeployed, servicesDeployed)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
create ibm-cpp-config cm if it is not exist
Read `Values.global.domainName` and `.Values.global.clusterType` from value file, and use those two value to create `ibm-cpp-config` configmap
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69508
