### PR TITLE
Add cloud-native-postgresql v1.28 configuration

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2684,6 +2684,20 @@ spec:
     configName: cloud-native-postgresql
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+  - channel: stable-v1.28
+    fallbackChannels:
+      - stable-v1.25
+      - stable-v1.22
+      - stable
+    name: cloud-native-postgresql-v1.28
+    namespace: "{{ .CPFSNs }}"
+    packageName: cloud-native-postgresql
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    operatorConfig: cloud-native-postgresql-operator-config
+    configName: cloud-native-postgresql
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - channel: v1.28
     name: ibm-pg-operator-v1.28
     namespace: "{{ .CPFSNs }}"

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -552,8 +552,9 @@ metadata:
     status-monitored-services: {{ .StatusMonitoredServices }}
 spec:
   operators:
-  - channel: stable-v1.25
+  - channel: stable-v1.28
     fallbackChannels:
+      - stable-v1.25
       - stable-v1.22
       - stable
     installPlanApproval: {{ .ApprovalMode }}


### PR DESCRIPTION
**What this PR does / why we need it**: add edb 1.28 entry in operandconfig

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69600