### PR TITLE
bump min skipRange version to 4.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ bundle-manifests: clis
 	echo "\n  # OpenShift annotations." >> bundle/metadata/annotations.yaml ;\
 	echo "  com.redhat.openshift.versions: $(OPENSHIFT_VERSIONS)" >> bundle/metadata/annotations.yaml ;\
 	$(OPERATOR_SDK) bundle validate ./bundle
-	$(YQ) eval -i '.metadata.annotations."olm.skipRange" = ">=3.3.0 <${RELEASE_VERSION}"' ${CSV_PATH}
+	$(YQ) eval -i '.metadata.annotations."olm.skipRange" = ">=4.6.0 <${RELEASE_VERSION}"' ${CSV_PATH}
 	$(YQ) eval -i '.spec.webhookdefinitions[0].deploymentName = "ibm-common-service-operator" | .spec.webhookdefinitions[1].deploymentName = "ibm-common-service-operator"' ${CSV_PATH}
 	$(YQ) eval-all -i '.spec.relatedImages = load("config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml").spec.relatedImages' bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
 

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -34,7 +34,7 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     nss.operator.ibm.com/managed-operators: ibm-common-service-operator
     nss.operator.ibm.com/managed-webhooks: ""
-    olm.skipRange: ">=3.3.0 <4.19.2"
+    olm.skipRange: ">=4.6.0 <4.19.2"
     operatorChannel: v4.19
     operatorVersion: 4.19.2
     operators.openshift.io/infrastructure-features: '["disconnected"]'


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump skipRange up to 4.6.0 to make sure OLM block upgrade from earlier CPFS versions
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69590
