### PR TITLE
Set default value for autoScaleConfig

### DIFF
--- a/internal/controller/config_extractor.go
+++ b/internal/controller/config_extractor.go
@@ -114,25 +114,27 @@ func extractFeatureConfigs(cs *apiv3.CommonService) ([]interface{}, error) {
 	}
 
 	// Extract AutoScaleConfig configuration
-	// Check if autoScaleConfig field was explicitly set in the spec
+	// If autoScaleConfig is not set, treat it as false
+	autoScaleConfigValue := false
 	if cs.Spec.AutoScaleConfig != nil {
-		klog.Infof("Extracting autoScaleConfig configuration with value %t", *cs.Spec.AutoScaleConfig)
-		t := template.Must(template.New("template AutoScaleConfigTemplate").Parse(constant.AutoScaleConfigTemplate))
-		var tmplWriter bytes.Buffer
-		autoScaleConfigEnable := struct {
-			AutoScaleConfigEnable bool
-		}{
-			AutoScaleConfigEnable: *cs.Spec.AutoScaleConfig,
-		}
-		if err := t.Execute(&tmplWriter, autoScaleConfigEnable); err != nil {
-			return nil, err
-		}
-		autoScaleConfig, err := convertStringToSlice(tmplWriter.String())
-		if err != nil {
-			return nil, err
-		}
-		configs = append(configs, autoScaleConfig...)
+		autoScaleConfigValue = *cs.Spec.AutoScaleConfig
 	}
+	klog.Infof("Extracting autoScaleConfig configuration with value %t", autoScaleConfigValue)
+	t := template.Must(template.New("template AutoScaleConfigTemplate").Parse(constant.AutoScaleConfigTemplate))
+	var tmplWriter bytes.Buffer
+	autoScaleConfigEnable := struct {
+		AutoScaleConfigEnable bool
+	}{
+		AutoScaleConfigEnable: autoScaleConfigValue,
+	}
+	if err := t.Execute(&tmplWriter, autoScaleConfigEnable); err != nil {
+		return nil, err
+	}
+	autoScaleConfig, err := convertStringToSlice(tmplWriter.String())
+	if err != nil {
+		return nil, err
+	}
+	configs = append(configs, autoScaleConfig...)
 
 	// Extract routeHost configuration
 	if cs.Spec.RouteHost != "" {

--- a/internal/controller/config_extractor_test.go
+++ b/internal/controller/config_extractor_test.go
@@ -45,13 +45,33 @@ func rawJSON(t *testing.T, v interface{}) apiv3.ExtensionWithMarker {
 }
 
 // TestExtractCommonServiceConfigs_EmptyCS verifies that an empty CommonService CR
-// produces no configs and a default profileController mapping.
+// produces only autoScaleConfig with default value false and a default profileController mapping.
 func TestExtractCommonServiceConfigs_EmptyCS(t *testing.T) {
 	cs := newCS()
 	configs, mapping, err := ExtractCommonServiceConfigs(cs, testServicesNs)
 	require.NoError(t, err)
-	assert.Empty(t, configs, "empty CS should produce no configs")
+	require.NotEmpty(t, configs, "empty CS should produce autoScaleConfig with default false")
 	assert.Equal(t, "default", mapping["profileController"])
+
+	// Verify that autoScaleConfig is set to false by default
+	foundAutoScale := false
+	for _, c := range configs {
+		b, _ := json.Marshal(c)
+		if strings.Contains(string(b), "\"autoScaleConfig\":false") {
+			foundAutoScale = true
+			break
+		}
+	}
+	assert.True(t, foundAutoScale, "empty CS should produce autoScaleConfig=false by default")
+
+	// Verify that no other feature configs are present (storageClass, routeHost, etc.)
+	configJSON, _ := json.Marshal(configs)
+	configStr := string(configJSON)
+	assert.NotContains(t, configStr, "storageClass", "empty CS should not contain storageClass config")
+	assert.NotContains(t, configStr, "routeHost", "empty CS should not contain routeHost config")
+	assert.NotContains(t, configStr, "defaultAdminUser", "empty CS should not contain defaultAdminUser config")
+	assert.NotContains(t, configStr, "fipsEnabled", "empty CS should not contain fipsEnabled config")
+	assert.NotContains(t, configStr, "hugepages", "empty CS should not contain hugepages config")
 }
 
 // TestExtractCommonServiceConfigs_StorageClass verifies that a storageClass value
@@ -137,6 +157,24 @@ func TestExtractCommonServiceConfigs_FipsEnabled(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "extracted configs should contain fipsEnabled=true")
+}
+
+func TestExtractCommonServiceConfigs_AutoScaleConfigEmpty(t *testing.T) {
+	cs := newCS()
+
+	configs, _, err := ExtractCommonServiceConfigs(cs, testServicesNs)
+	require.NoError(t, err)
+	require.NotEmpty(t, configs)
+
+	found := false
+	for _, c := range configs {
+		b, _ := json.Marshal(c)
+		if strings.Contains(string(b), "\"autoScaleConfig\":false") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "extracted configs should contain autoScaleConfig=false")
 }
 
 func TestExtractCommonServiceConfigs_AutoScaleConfigFalse(t *testing.T) {

--- a/internal/controller/operandconfig.go
+++ b/internal/controller/operandconfig.go
@@ -1237,6 +1237,12 @@ func (r *CommonServiceReconciler) buildDesiredStateFromAllCRs(ctx context.Contex
 			klog.Infof("Collected enableInstanaMetricCollection=%t from CR %s/%s", cs.Spec.EnableInstanaMetricCollection, cs.Namespace, cs.Name)
 		}
 
+		// Collect autoScaleConfig (first non-nil wins, or first true if set)
+		if mergedFeatureCS.Spec.AutoScaleConfig == nil && cs.Spec.AutoScaleConfig != nil {
+			mergedFeatureCS.Spec.AutoScaleConfig = cs.Spec.AutoScaleConfig
+			klog.Infof("Collected autoScaleConfig=%t from CR %s/%s", *cs.Spec.AutoScaleConfig, cs.Namespace, cs.Name)
+		}
+
 		// Collect hugepages (first non-nil wins)
 		if mergedFeatureCS.Spec.HugePages == nil && cs.Spec.HugePages != nil {
 			mergedFeatureCS.Spec.HugePages = cs.Spec.HugePages.DeepCopy()


### PR DESCRIPTION
**What this PR does / why we need it**:
Set a default `autoScaleConfig: false` if it is not set, 
So when user remove this field from commonservice, cs-operator will change the value to false and ODLM will update the CR base on this
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/68616
