### PR TITLE
Fix OperandConfig Race Condition issue

### DIFF
--- a/internal/controller/bootstrap/config_bridge.go
+++ b/internal/controller/bootstrap/config_bridge.go
@@ -27,10 +27,19 @@ import (
 // This allows bootstrap to use controller merge logic without import cycles
 type ConfigMergerFunc func(baseConfig string, cs *apiv3.CommonService, servicesNs string) (string, error)
 
+// AggregatedConfigMergerFunc merges base config with an already aggregated multi-CR view.
+// This lets bootstrap create OperandConfig in its final desired form before ODLM consumes it.
+type AggregatedConfigMergerFunc func(baseConfig string, configs []interface{}, serviceControllerMapping map[string]string, servicesNs string) (string, error)
+
 // SetConfigMerger sets the configuration merger function on the Bootstrap instance.
 // Called during reconciler initialization to inject the merge logic.
 func (b *Bootstrap) SetConfigMerger(merger ConfigMergerFunc) {
 	b.configMerger = merger
+}
+
+// SetAggregatedConfigMerger sets the aggregated configuration merger function on the Bootstrap instance.
+func (b *Bootstrap) SetAggregatedConfigMerger(merger AggregatedConfigMergerFunc) {
+	b.aggregatedConfigMerger = merger
 }
 
 // mergeConfigs calls the injected merger function if available.
@@ -60,6 +69,14 @@ func (b *Bootstrap) mergeConfigs(ctx context.Context, baseConfig string, cs *api
 		return b.configMerger(baseConfig, cs, b.CSData.ServicesNs)
 	}
 	// If no merger is set, return base config unchanged
+	return baseConfig, nil
+}
+
+// mergeAggregatedConfigs calls the injected aggregated merger function if available.
+func (b *Bootstrap) mergeAggregatedConfigs(baseConfig string, configs []interface{}, serviceControllerMapping map[string]string) (string, error) {
+	if b.aggregatedConfigMerger != nil {
+		return b.aggregatedConfigMerger(baseConfig, configs, serviceControllerMapping, b.CSData.ServicesNs)
+	}
 	return baseConfig, nil
 }
 

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -79,11 +79,12 @@ type Bootstrap struct {
 	Config *rest.Config
 	record.EventRecorder
 	*deploy.Manager
-	SaasEnable           bool
-	MultiInstancesEnable bool
-	CSOperators          []CSOperator
-	CSData               apiv3.CSData
-	configMerger         ConfigMergerFunc
+	SaasEnable             bool
+	MultiInstancesEnable   bool
+	CSOperators            []CSOperator
+	CSData                 apiv3.CSData
+	configMerger           ConfigMergerFunc
+	aggregatedConfigMerger AggregatedConfigMergerFunc
 }
 
 // CanI performs a SelfSubjectAccessReview (SSAR) to check whether the operator service account
@@ -241,7 +242,7 @@ func NewBootstrap(mgr manager.Manager) (bs *Bootstrap, err error) {
 }
 
 // InitResources initialize resources at the bootstrap of operator
-func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLMCRs bool) error {
+func (b *Bootstrap) InitResources(ctx context.Context, instance *apiv3.CommonService, forceUpdateODLMCRs bool, aggregatedConfigs []interface{}, serviceControllerMapping map[string]string) error {
 	installPlanApproval := instance.Spec.InstallPlanApproval
 	userManagedOption := WithUserManagedOverridesFromConfigs(instance.Spec.OperatorConfigs)
 
@@ -314,7 +315,7 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 		}
 
 		klog.Info("Installing/Updating OperandConfig")
-		if err := b.InstallOrUpdateOpcon(ctx, forceUpdateODLMCRs, instance); err != nil {
+		if err := b.InstallOrUpdateOpcon(ctx, forceUpdateODLMCRs, instance, aggregatedConfigs, serviceControllerMapping); err != nil {
 			return err
 		}
 	}
@@ -364,7 +365,7 @@ func (b *Bootstrap) InitResources(instance *apiv3.CommonService, forceUpdateODLM
 		}
 
 		klog.Info("Installing/Updating OperandConfig")
-		if err := b.InstallOrUpdateOpcon(ctx, forceUpdateODLMCRs, instance); err != nil {
+		if err := b.InstallOrUpdateOpcon(ctx, forceUpdateODLMCRs, instance, aggregatedConfigs, serviceControllerMapping); err != nil {
 			return err
 		}
 	}
@@ -964,7 +965,7 @@ func (b *Bootstrap) InstallOrUpdateOpreg(ctx context.Context, installPlanApprova
 
 // InstallOrUpdateOpcon will install or update OperandConfig when Opcon CRD is existent
 // Now accepts CommonService instance with merged configurations
-func (b *Bootstrap) InstallOrUpdateOpcon(ctx context.Context, forceUpdateODLMCRs bool, csInstance *apiv3.CommonService) error {
+func (b *Bootstrap) InstallOrUpdateOpcon(ctx context.Context, forceUpdateODLMCRs bool, csInstance *apiv3.CommonService, aggregatedConfigs []interface{}, serviceControllerMapping map[string]string) error {
 	// Get base template configs using common utility
 	configs := common.GetBaseOperandConfigList()
 
@@ -977,7 +978,16 @@ func (b *Bootstrap) InstallOrUpdateOpcon(ctx context.Context, forceUpdateODLMCRs
 	// Merge CommonService configurations with base templates
 	// before rendering to create complete OperandConfig in one step
 	finalConfig := concatenatedCon
-	if csInstance != nil {
+	if len(aggregatedConfigs) > 0 {
+		klog.Info("Merging aggregated CommonService configurations with base OperandConfig")
+		mergedConfig, err := b.mergeAggregatedConfigs(concatenatedCon, aggregatedConfigs, serviceControllerMapping)
+		if err != nil {
+			klog.Errorf("Failed to merge aggregated configurations: %v", err)
+			return err
+		}
+		finalConfig = mergedConfig
+		klog.Info("Successfully merged aggregated configurations for single-stage OperandConfig creation")
+	} else if csInstance != nil {
 		klog.Info("Merging CommonService configurations with base OperandConfig")
 		mergedConfig, err := b.mergeConfigs(ctx, concatenatedCon, csInstance)
 		if err != nil {

--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -228,18 +228,9 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		return ctrl.Result{}, statusErr
 	}
 
-	// Init common service bootstrap resource
-	// Including namespace-scope configmap
-	// Deploy OperandConfig and OperandRegistry
-	if statusErr = r.Bootstrap.InitResources(instance, forceUpdateODLMCRs); statusErr != nil {
-		if statusErr := r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
-			klog.Error(statusErr)
-		}
-		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
-		return ctrl.Result{}, statusErr
-	}
-
-	// Build desired state from all CommonService CRs and update OperandConfig
+	// Build desired state from all CommonService CRs before bootstrap creates/updates OperandConfig.
+	// This closes the race where ODLM may consume an incomplete OperandConfig and create
+	// common-service-db before aggregated storageClass settings are present.
 	klog.Info("Building desired state from all CommonService CRs")
 	newConfigs, serviceControllerMapping, err := r.buildDesiredStateFromAllCRs(ctx)
 	if err != nil {
@@ -250,7 +241,19 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 		return ctrl.Result{}, err
 	}
 
-	// Update OperandConfig with the aggregated configurations
+	// Init common service bootstrap resource
+	// Including namespace-scope configmap
+	// Deploy OperandConfig and OperandRegistry with the aggregated CommonService view
+	if statusErr = r.Bootstrap.InitResources(ctx, instance, forceUpdateODLMCRs, newConfigs, serviceControllerMapping); statusErr != nil {
+		if statusErr := r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
+			klog.Error(statusErr)
+		}
+		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
+		return ctrl.Result{}, statusErr
+	}
+
+	// Reconcile OperandConfig again after bootstrap to converge any later changes and
+	// preserve the existing steady-state update path.
 	klog.Info("Updating OperandConfig with aggregated configurations")
 	if isEqual, err := r.updateOperandConfig(ctx, newConfigs, serviceControllerMapping); err != nil {
 		if statusErr := r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
@@ -547,10 +550,11 @@ func isNonNoopOperandReconcile(operandRegistry *odlm.OperandRegistry) bool {
 }
 
 func (r *CommonServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Set up configuration merger for single-stage OperandConfig creation
+	// Set up configuration mergers for single-stage OperandConfig creation
 	// This injects the merge logic into bootstrap without creating import cycles
 	r.Bootstrap.SetConfigMerger(CreateMergerFunc(r))
-	klog.Info("Configuration merger initialized for single-stage OperandConfig creation")
+	r.Bootstrap.SetAggregatedConfigMerger(MergeBaseAndCSConfigs)
+	klog.Info("Configuration mergers initialized for single-stage OperandConfig creation")
 
 	controller := ctrl.NewControllerManagedBy(mgr).
 		// AnnotationChangedPredicate is intended to be used in conjunction with the GenerationChangedPredicate

--- a/internal/controller/config_merger_test.go
+++ b/internal/controller/config_merger_test.go
@@ -17,6 +17,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -427,6 +428,95 @@ spec:
 		"merged result must contain the CS-supplied replica count (3), not the base value (1)")
 	assert.False(t, strings.Contains(result, `"replicas":1`) || strings.Contains(result, "replicas: 1"),
 		"merged result must not retain the base replica count of 1 for ibm-iam-operator")
+}
+
+// TestMergeBaseAndCSConfigs_WithAggregatedStorageClass verifies that aggregated multi-CR
+// configuration is applied during the initial single-stage OperandConfig creation so
+// ODLM sees the storageClass on first consume.
+func TestMergeBaseAndCSConfigs_WithAggregatedStorageClass(t *testing.T) {
+	baseYAML := `
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandConfig
+metadata:
+  name: common-service
+  namespace: ibm-common-services
+spec:
+  services:
+  - name: common-service-cnpg
+    resources:
+    - apiVersion: pg.ibm.com/v1
+      kind: Cluster
+      name: common-service-db
+      data:
+        spec:
+          storage:
+            size: 10Gi
+          walStorage:
+            size: 5Gi
+`
+
+	aggregatedConfigs := []interface{}{
+		map[string]interface{}{
+			"name": "common-service-cnpg",
+			"resources": []interface{}{
+				map[string]interface{}{
+					"apiVersion": "pg.ibm.com/v1",
+					"kind":       "Cluster",
+					"name":       "common-service-db",
+					"data": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"storage": map[string]interface{}{
+								"storageClass": "fast-storage",
+							},
+							"walStorage": map[string]interface{}{
+								"storageClass": "fast-storage",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := MergeBaseAndCSConfigs(
+		baseYAML,
+		aggregatedConfigs,
+		map[string]string{"profileController": "default"},
+		"ibm-common-services",
+	)
+	require.NoError(t, err)
+
+	opcon, err := parseOperandConfig(result)
+	require.NoError(t, err)
+	require.Len(t, opcon.Spec.Services, 1)
+
+	serviceBytes, err := json.Marshal(opcon.Spec.Services[0])
+	require.NoError(t, err)
+
+	var serviceMap map[string]interface{}
+	require.NoError(t, json.Unmarshal(serviceBytes, &serviceMap))
+
+	resources, ok := serviceMap["resources"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, resources, 1)
+
+	resourceMap, ok := resources[0].(map[string]interface{})
+	require.True(t, ok)
+
+	data, ok := resourceMap["data"].(map[string]interface{})
+	require.True(t, ok)
+	spec, ok := data["spec"].(map[string]interface{})
+	require.True(t, ok)
+
+	storage, ok := spec["storage"].(map[string]interface{})
+	require.True(t, ok)
+	walStorage, ok := spec["walStorage"].(map[string]interface{})
+	require.True(t, ok)
+
+	assert.Equal(t, "fast-storage", storage["storageClass"])
+	assert.Equal(t, "fast-storage", walStorage["storageClass"])
+	assert.Equal(t, "10Gi", storage["size"])
+	assert.Equal(t, "5Gi", walStorage["size"])
 }
 
 // TestMergeConfigs_EmptyCS verifies that MergeConfigs handles an empty CommonService

--- a/internal/controller/no_olm_commonservice_controller.go
+++ b/internal/controller/no_olm_commonservice_controller.go
@@ -195,7 +195,7 @@ func (r *CommonServiceReconciler) ReconcileNoOLMMasterCR(ctx context.Context, in
 		}
 
 		klog.Info("Installing/Updating OperandConfig")
-		if err := r.Bootstrap.InstallOrUpdateOpcon(ctx, forceUpdateODLMCRs, instance); err != nil {
+		if err := r.Bootstrap.InstallOrUpdateOpcon(ctx, forceUpdateODLMCRs, instance, nil, nil); err != nil {
 			klog.Errorf("Fail to Installing/Updating OperandConfig: %v", err)
 			return ctrl.Result{}, err
 		}


### PR DESCRIPTION
## Summary
Ensure aggregated CommonService configuration is applied to OperandConfig before ODLM can create common-service-db, preventing a race where the IBM PG cluster CR is created without a storage class.

## Problem
When a storage class is set on a configurable CommonService CR instead of the master `common-service` CR, cs-operator previously created or updated OperandConfig in two phases:

- bootstrap created an initial OperandConfig
- later reconciliation aggregated all CommonService CRs and patched the final storage settings

If ODLM reconciled faster than cs-operator’s second phase, it could create common-service-db without `storageClass`, leaving the DB pending.

## Fix
- Build the aggregated desired state from all CommonService CRs **before** calling Bootstrap.InitResources
- Pass aggregated configs into InstallOrUpdateOpcon so bootstrap can create the first OperandConfig in its final form
- Add aggregated merge support in bootstrap/config_bridge.go
- Wire the aggregated merger in SetupWithManager
- Keep the existing post-bootstrap updateOperandConfig reconciliation as a convergence and safety pass
- Update the no-OLM path to use the new InstallOrUpdateOpcon signature

**Which issue(s) this PR fixes**:
Fixes #  
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69720
https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/119054
