### PR TITLE
add debug log for getServiceNamespace

### DIFF
--- a/internal/controller/common/util.go
+++ b/internal/controller/common/util.go
@@ -253,21 +253,28 @@ func GetCPFSNamespace(r client.Reader) (cpfsNamespace string) {
 func GetServicesNamespace(r client.Reader) (servicesNamespace string) {
 	servicesNamespace, err := GetOperatorNamespace()
 	if err != nil {
+		klog.Warningf("GetServicesNamespace: failed to get operator namespace: %v, returning empty value", err)
 		return
 	}
+	klog.V(2).Infof("GetServicesNamespace: initial operator namespace: %s", servicesNamespace)
 
 	defaultCsCR := &apiv3.CommonService{}
 	csName := "common-service"
 	if err := r.Get(context.TODO(), types.NamespacedName{Name: csName, Namespace: servicesNamespace}, defaultCsCR); err != nil {
+		klog.Warningf("GetServicesNamespace: failed to get CommonService CR %s/%s: %v, returning operator namespace", servicesNamespace, csName, err)
 		return
 	}
+	klog.V(2).Infof("GetServicesNamespace: successfully read CommonService CR %s/%s", servicesNamespace, csName)
 
 	if string(defaultCsCR.Spec.ServicesNamespace) != "" {
 		servicesNamespace = string(defaultCsCR.Spec.ServicesNamespace)
+		klog.V(2).Infof("GetServicesNamespace: updated from spec.servicesNamespace: %s", servicesNamespace)
 	}
 	if string(defaultCsCR.Status.ConfigStatus.ServicesNamespace) != "" {
 		servicesNamespace = string(defaultCsCR.Status.ConfigStatus.ServicesNamespace)
+		klog.V(2).Infof("GetServicesNamespace: updated from status.configStatus.servicesNamespace: %s", servicesNamespace)
 	}
+	klog.Infof("GetServicesNamespace: final services namespace: %s", servicesNamespace)
 	return
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Failed to deploy CPFS 4.19.2 on Rancher (with RHEL 10.0 OS), with error message
```
E0714 01:38:35.073608       1 init.go:1852] Configmap cpfs-operators/ibm-cpp-config is required
```
CommonService CR set with servicesNamespace correctly, but cs-operator still looking for `ibm-cpp-config` CM in the operator namespace instead of service namespace. Adding more log for diagnosis.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69617#issuecomment-220652557
