### PR TITLE
Fix certificate secret label issue

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -191,6 +191,7 @@ func main() {
 			}
 			if err = (&certmanagerv1controllers.V1AddLabelReconciler{
 				Client: mgr.GetClient(),
+				Reader: mgr.GetAPIReader(),
 				Scheme: mgr.GetScheme(),
 			}).SetupWithManager(mgr); err != nil {
 				klog.Error(err, "unable to create controller", "controller", "V1AddLabel")

--- a/internal/controller/cert-manager/v1_add_label_controller.go
+++ b/internal/controller/cert-manager/v1_add_label_controller.go
@@ -36,6 +36,7 @@ import (
 // V1AddLabelReconciler reconciles a Certificate object
 type V1AddLabelReconciler struct {
 	client.Client
+	client.Reader
 	Scheme *runtime.Scheme
 }
 
@@ -97,7 +98,7 @@ func (r *V1AddLabelReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *V1AddLabelReconciler) getSecret(cert *certmanagerv1.Certificate) (*corev1.Secret, error) {
 	secretName := cert.Spec.SecretName
 	secret := &corev1.Secret{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: cert.Namespace}, secret)
+	err := r.Reader.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: cert.Namespace}, secret)
 
 	return secret, err
 }

--- a/internal/controller/common/cache.go
+++ b/internal/controller/common/cache.go
@@ -30,7 +30,7 @@ import (
 // NewCSCache implements a customized cache with a for CS
 func NewCSCache(watchNamespaceList []string, opts ctrl.Options) ctrl.Options {
 	configmapSelector := labels.Set{constant.CsManagedLabel: "true"}
-	secretSelector := labels.Set{constant.SecretWatchLabel: "true"}
+	secretSelector := labels.Set{constant.SecretWatchLabel: ""}
 	// set DefaultNamespaces based on watchNamespaces
 	// if watchNamespaces is empty, then cache resource in all namespaces
 	var cacheDefaultNamespaces map[string]cache.Config


### PR DESCRIPTION
**What this PR does / why we need it**:
The certificate secret was not labeled with `operator.ibm.com/watched-by-cert-manager` because it was created directly by cert-manager without this label. As a result, the cs-operator does not add the secret to its cache, making it unavailable through `client.Get()`. To retrieve the secret in this case, use `reader.Get()` instead.
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69759
