### PR TITLE
Add namespace suffix to pg migrator role and rolebinding

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2516,7 +2516,7 @@ spec:
             - name: {{ .ImagePullSecret }}
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
-        name: common-service-db-pg-migration-role
+        name: common-service-db-pg-migration-role-{{ .OperatorNs }}
         namespace: {{ .OperatorNs }}
         labels:
           app: cpfs-pg-migrator
@@ -2532,7 +2532,7 @@ spec:
                 - watch
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
-        name: common-service-db-pg-migration-rolebinding
+        name: common-service-db-pg-migration-rolebinding-{{ .OperatorNs }}
         namespace: {{ .OperatorNs }}
         labels:
           app: cpfs-pg-migrator
@@ -2540,7 +2540,7 @@ spec:
           roleRef:
             apiGroup: rbac.authorization.k8s.io
             kind: Role
-            name: common-service-db-pg-migration-role
+            name: common-service-db-pg-migration-role-{{ .OperatorNs }}
           subjects:
             - kind: ServiceAccount
               name: common-service-db-pg-migration-sa


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a namespace suffix to the pg migrator Role and RoleBinding to ensure unique RBAC resource names. Fix the issue when running in single-namespace mode, the migrator RBAC resources generated for the operator namespace and the data namespace will conflict and over-written each other.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69770
