### PR TITLE
add new EDB permission for SC2

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role-sc2.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role-sc2.yaml
@@ -189,6 +189,14 @@ rules:
       - clusters/status
       - poolers/status
   - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+  - verbs:
       - create
       - get
       - list


### PR DESCRIPTION
**What this PR does / why we need it**:
Saw error message in SERT's testing
```
E0807 20:18:02.011259 1 namespacescope_controller.go:142] Failed to generate rbac: roles.rbac.authorization.k8s.io "cloud-native-postgresql-1658529acfc81e" is forbidden: user "system:serviceaccount:cs-operators:ibm-namespace-scope-operator" (groups=["system:serviceaccounts" "system:serviceaccounts:cs-operators" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["discovery.k8s.io"], Resources:["endpointslices"], Verbs:["get" "list" "watch"]}
```
Add new rbac for EDB 1.28.4
