### PR TITLE
Add events operator v7.1.0 to operandregistry

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2972,6 +2972,14 @@ spec:
     installPlanApproval: {{ .ApprovalMode }}
     sourceName: {{ .CatalogSourceName }}
     sourceNamespace: "{{ .CatalogSourceNs }}"
+  - channel: v7.1
+    name: ibm-events-operator-v7.1
+    namespace: "{{ .CPFSNs }}"
+    packageName: ibm-events-operator
+    scope: public
+    installPlanApproval: {{ .ApprovalMode }}
+    sourceName: {{ .CatalogSourceName }}
+    sourceNamespace: "{{ .CatalogSourceNs }}"
   - name: ibm-platformui-operator
     namespace: "{{ .CPFSNs }}"
     channel: v6.10


### PR DESCRIPTION
**What this PR does / why we need it**:
Add events operator v7.1.0 to operandregistry
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69922
