### PR TITLE
Change the `primaryUpdateMethod` in cs-db Cluster CR from `switchover` to `restart`

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2046,7 +2046,7 @@ spec:
               shm: 500Mi
               temporaryData: 500Mi
             primaryUpdateStrategy: unsupervised
-            primaryUpdateMethod: switchover
+            primaryUpdateMethod: restart
             enableSuperuserAccess: true
             replicationSlots:
               highAvailability:

--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2368,7 +2368,7 @@ spec:
               shm: 500Mi
               temporaryData: 500Mi
             primaryUpdateStrategy: unsupervised
-            primaryUpdateMethod: switchover
+            primaryUpdateMethod: restart
             enableSuperuserAccess: true
             replicationSlots:
               highAvailability:


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the `primaryUpdateMethod` in cs-db Cluster CR from `switchover` to `restart`
**Which issue(s) this PR fixes**:
Fixes # 
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69901
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69889
