### PR TITLE
Add tolerations to commonservice CR

### DIFF
--- a/api/v3/commonservice_types.go
+++ b/api/v3/commonservice_types.go
@@ -139,6 +139,9 @@ type CommonServiceSpec struct {
 	// for pulling images. Defaults to "ibm-entitlement-key" if not specified.
 	// +optional
 	ImagePullSecret string `json:"imagePullSecret,omitempty"`
+	// Tolerations specifies pod tolerations to propagate to selected downstream operands.
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// CSPostgreSQLReplica configures common-service-db as a replica cluster
 	// When specified, enables streaming replication from primary cluster
 	// Storage, certificates, and other settings remain CS operator defaults

--- a/api/v3/zz_generated.deepcopy.go
+++ b/api/v3/zz_generated.deepcopy.go
@@ -21,7 +21,8 @@
 package v3
 
 import (
-	"github.ibm.com/ibm-pg/ibm-pg-types/pkg/api/v1"
+	v1 "github.ibm.com/ibm-pg/ibm-pg-types/pkg/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -234,6 +235,13 @@ func (in *CommonServiceSpec) DeepCopyInto(out *CommonServiceSpec) {
 		}
 	}
 	out.License = in.License
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.CSPostgreSQLReplica != nil {
 		in, out := &in.CSPostgreSQLReplica, &out.CSPostgreSQLReplica
 		*out = new(CSPostgreSQLReplicaConfig)

--- a/api/v3/zz_generated.deepcopy.go
+++ b/api/v3/zz_generated.deepcopy.go
@@ -21,8 +21,8 @@
 package v3
 
 import (
-	v1 "github.ibm.com/ibm-pg/ibm-pg-types/pkg/api/v1"
-	corev1 "k8s.io/api/core/v1"
+	apiv1 "github.ibm.com/ibm-pg/ibm-pg-types/pkg/api/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -108,7 +108,7 @@ func (in *CSPostgreSQLReplicaConfig) DeepCopyInto(out *CSPostgreSQLReplicaConfig
 	in.Replica.DeepCopyInto(&out.Replica)
 	if in.ExternalClusters != nil {
 		in, out := &in.ExternalClusters, &out.ExternalClusters
-		*out = make([]v1.ExternalCluster, len(*in))
+		*out = make([]apiv1.ExternalCluster, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -235,9 +235,14 @@ func (in *CommonServiceSpec) DeepCopyInto(out *CommonServiceSpec) {
 		}
 	}
 	out.License = in.License
+	if in.AutoScaleConfig != nil {
+		in, out := &in.AutoScaleConfig, &out.AutoScaleConfig
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
-		*out = make([]corev1.Toleration, len(*in))
+		*out = make([]v1.Toleration, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-common-service-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     cloudPakThemesVersion: styles4100.css
     containerImage: icr.io/cpopen/common-service-operator:4.19.3
-    createdAt: "2026-03-19T15:03:09Z"
+    createdAt: "2026-08-24T17:16:49Z"
     description: The IBM Cloud Pak foundational services operator is used to deploy IBM foundational services.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"

--- a/config/crd/bases/operator.ibm.com_commonservices.yaml
+++ b/config/crd/bases/operator.ibm.com_commonservices.yaml
@@ -1398,6 +1398,47 @@ spec:
                   StorageClass describes the storage class to use for the foundational
                   services PVCs
                 type: string
+              tolerations:
+                description: Tolerations specifies pod tolerations to propagate to
+                  selected downstream operands.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
             type: object
             x-kubernetes-preserve-unknown-fields: true
           status:

--- a/config/ibm-common-service-operator.yaml
+++ b/config/ibm-common-service-operator.yaml
@@ -219,6 +219,42 @@ spec:
                   StorageClass describes the storage class to use for the foundational
                   services PVCs
                 type: string
+              tolerations:
+                description: Tolerations specifies pod tolerations to propagate to selected downstream operands.
+                items:
+                  description: The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
             type: object
             x-kubernetes-preserve-unknown-fields: true
           status:

--- a/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/ibm-common-service-operator.clusterserviceversion.yaml
@@ -194,7 +194,7 @@ spec:
      - Linux on IBM Z and LinuxONE
 
     ## Operator versions
-    
+
      - 4.19.3
 
     ## Prerequisites

--- a/helm-cluster-scoped/templates/crd.yaml
+++ b/helm-cluster-scoped/templates/crd.yaml
@@ -1411,6 +1411,47 @@ spec:
                   StorageClass describes the storage class to use for the foundational
                   services PVCs
                 type: string
+              tolerations:
+                description: Tolerations specifies pod tolerations to propagate to
+                  selected downstream operands.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
             type: object
             x-kubernetes-preserve-unknown-fields: true
           status:

--- a/internal/controller/config_extractor.go
+++ b/internal/controller/config_extractor.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"text/template"
 
+	utilyaml "github.com/ghodss/yaml"
 	"k8s.io/klog"
 
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
@@ -204,6 +205,24 @@ func extractFeatureConfigs(cs *apiv3.CommonService) ([]interface{}, error) {
 			}
 			configs = append(configs, labelConfig...)
 		}
+	}
+
+	// Extract tolerations configuration
+	if len(cs.Spec.Tolerations) > 0 {
+		klog.Info("Extracting tolerations configuration")
+		tolerationBytes, err := json.Marshal(cs.Spec.Tolerations)
+		if err != nil {
+			return nil, err
+		}
+		tolerationYAML, err := utilyaml.JSONToYAML(tolerationBytes)
+		if err != nil {
+			return nil, err
+		}
+		tolerationConfig, err := convertStringToSlice(strings.ReplaceAll(constant.ServiceTolerationsTemplate, "placeholder", strings.TrimSpace(string(tolerationYAML))))
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, tolerationConfig...)
 	}
 
 	// Extract CSPostgreSQLReplica configuration

--- a/internal/controller/config_extractor.go
+++ b/internal/controller/config_extractor.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"text/template"
 
-	utilyaml "github.com/ghodss/yaml"
 	"k8s.io/klog"
 
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
@@ -210,15 +209,14 @@ func extractFeatureConfigs(cs *apiv3.CommonService) ([]interface{}, error) {
 	// Extract tolerations configuration
 	if len(cs.Spec.Tolerations) > 0 {
 		klog.Info("Extracting tolerations configuration")
+		// Use compact JSON instead of multi-line YAML block to avoid "block sequence
+		// entries are not allowed in this context" when the JSON array is substituted
+		// inline into "tolerations: placeholder" in the template.
 		tolerationBytes, err := json.Marshal(cs.Spec.Tolerations)
 		if err != nil {
 			return nil, err
 		}
-		tolerationYAML, err := utilyaml.JSONToYAML(tolerationBytes)
-		if err != nil {
-			return nil, err
-		}
-		tolerationConfig, err := convertStringToSlice(strings.ReplaceAll(constant.ServiceTolerationsTemplate, "placeholder", strings.TrimSpace(string(tolerationYAML))))
+		tolerationConfig, err := convertStringToSlice(strings.ReplaceAll(constant.ServiceTolerationsTemplate, "placeholder", string(tolerationBytes)))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/controller/config_extractor_test.go
+++ b/internal/controller/config_extractor_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	pgv1 "github.ibm.com/ibm-pg/ibm-pg-types/pkg/api/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
@@ -342,6 +343,53 @@ func TestExtractCommonServiceConfigs_MultipleFeatures(t *testing.T) {
 	// All three features should contribute entries
 	assert.GreaterOrEqual(t, len(configs), 3,
 		"three feature flags should produce at least 3 config entries")
+}
+
+// TestExtractCommonServiceConfigs_Tolerations verifies that tolerations are
+// extracted into selected downstream service configs.
+func TestExtractCommonServiceConfigs_Tolerations(t *testing.T) {
+	cs := newCS()
+	cs.Spec.Tolerations = []corev1.Toleration{
+		{
+			Key:      "dedicated",
+			Operator: corev1.TolerationOpEqual,
+			Value:    "common-service",
+			Effect:   corev1.TaintEffectNoSchedule,
+		},
+	}
+
+	configs, _, err := ExtractCommonServiceConfigs(cs, testServicesNs)
+	require.NoError(t, err)
+	require.NotEmpty(t, configs)
+
+	foundMongoDB := false
+	foundAuthentication := false
+	foundCommonWebUI := false
+	for _, c := range configs {
+		b, _ := json.Marshal(c)
+		configStr := string(b)
+		if strings.Contains(configStr, "\"name\":\"ibm-im-mongodb-operator\"") &&
+			strings.Contains(configStr, "\"mongoDB\"") &&
+			strings.Contains(configStr, "\"tolerations\"") &&
+			strings.Contains(configStr, "\"dedicated\"") {
+			foundMongoDB = true
+		}
+		if strings.Contains(configStr, "\"name\":\"ibm-im-operator\"") &&
+			strings.Contains(configStr, "\"authentication\"") &&
+			strings.Contains(configStr, "\"tolerations\"") &&
+			strings.Contains(configStr, "\"common-service\"") {
+			foundAuthentication = true
+		}
+		if strings.Contains(configStr, "\"name\":\"ibm-idp-config-ui-operator-v4.0\"") &&
+			strings.Contains(configStr, "\"commonWebUI\"") &&
+			strings.Contains(configStr, "\"tolerations\"") {
+			foundCommonWebUI = true
+		}
+	}
+
+	assert.True(t, foundMongoDB, "mongodb service should receive tolerations")
+	assert.True(t, foundAuthentication, "authentication service should receive tolerations")
+	assert.True(t, foundCommonWebUI, "commonWebUI service should receive tolerations")
 }
 
 // TestExtractCommonServiceConfigs_PostgreSQLReplica verifies that CSPostgreSQLReplica

--- a/internal/controller/constant/tolerations.go
+++ b/internal/controller/constant/tolerations.go
@@ -17,22 +17,6 @@
 package constant
 
 const ServiceTolerationsTemplate = `
-- name: ibm-im-mongodb-operator
-  spec:
-    mongoDB:
-      tolerations: placeholder
-- name: ibm-im-mongodb-operator-v4.0
-  spec:
-    mongoDB:
-      tolerations: placeholder
-- name: ibm-im-mongodb-operator-v4.1
-  spec:
-    mongoDB:
-      tolerations: placeholder
-- name: ibm-im-mongodb-operator-v4.2
-  spec:
-    mongoDB:
-      tolerations: placeholder
 - name: ibm-im-operator
   spec:
     authentication:

--- a/internal/controller/constant/tolerations.go
+++ b/internal/controller/constant/tolerations.go
@@ -1,0 +1,194 @@
+//
+// Copyright 2026 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package constant
+
+const ServiceTolerationsTemplate = `
+- name: ibm-im-mongodb-operator
+  spec:
+    mongoDB:
+      tolerations: placeholder
+- name: ibm-im-mongodb-operator-v4.0
+  spec:
+    mongoDB:
+      tolerations: placeholder
+- name: ibm-im-mongodb-operator-v4.1
+  spec:
+    mongoDB:
+      tolerations: placeholder
+- name: ibm-im-mongodb-operator-v4.2
+  spec:
+    mongoDB:
+      tolerations: placeholder
+- name: ibm-im-operator
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.0
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.1
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.2
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.3
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.4
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.5
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.6
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.7
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.8
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.9
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.10
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.11
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.12
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.13
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.14
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.15
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.16
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.17
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-im-operator-v4.18
+  spec:
+    authentication:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.0
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.1
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.2
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.3
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.4
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.5
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.6
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.7
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.8
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.9
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.10
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.11
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.12
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.13
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.14
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: ibm-idp-config-ui-operator-v4.15
+  spec:
+    commonWebUI:
+      tolerations: placeholder
+- name: common-service-cnpg
+  resources:
+    - apiVersion: pg.ibm.com/v1
+      kind: Cluster
+      name: common-service-db
+      data:
+        spec:
+          tolerations: placeholder
+`
+
+// Made with Bob

--- a/internal/controller/constant/tolerations.go
+++ b/internal/controller/constant/tolerations.go
@@ -188,5 +188,6 @@ const ServiceTolerationsTemplate = `
       name: common-service-db
       data:
         spec:
-          tolerations: placeholder
+          affinity:
+            tolerations: placeholder
 `

--- a/internal/controller/constant/tolerations.go
+++ b/internal/controller/constant/tolerations.go
@@ -190,5 +190,3 @@ const ServiceTolerationsTemplate = `
         spec:
           tolerations: placeholder
 `
-
-// Made with Bob

--- a/internal/controller/render_template.go
+++ b/internal/controller/render_template.go
@@ -33,6 +33,7 @@ import (
 	util "github.com/IBM/ibm-common-service-operator/v4/internal/controller/common"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/constant"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/size"
+	utilyaml "github.com/ghodss/yaml"
 )
 
 func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured) ([]interface{}, map[string]string, error) {
@@ -180,6 +181,23 @@ func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured) (
 			}
 			newConfigs = append(newConfigs, labelConfig...)
 		}
+	}
+
+	if tolerations := cs.Object["spec"].(map[string]interface{})["tolerations"]; tolerations != nil {
+		klog.Info("Applying tolerations configuration")
+		tolerationBytes, err := json.Marshal(tolerations)
+		if err != nil {
+			return nil, nil, err
+		}
+		tolerationYAML, err := utilyaml.JSONToYAML(tolerationBytes)
+		if err != nil {
+			return nil, nil, err
+		}
+		tolerationConfig, err := convertStringToSlice(strings.ReplaceAll(constant.ServiceTolerationsTemplate, "placeholder", strings.TrimSpace(string(tolerationYAML))))
+		if err != nil {
+			return nil, nil, err
+		}
+		newConfigs = append(newConfigs, tolerationConfig...)
 	}
 
 	klog.Info("Applying size configuration")

--- a/internal/controller/render_template.go
+++ b/internal/controller/render_template.go
@@ -33,7 +33,6 @@ import (
 	util "github.com/IBM/ibm-common-service-operator/v4/internal/controller/common"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/constant"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/size"
-	utilyaml "github.com/ghodss/yaml"
 )
 
 func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured) ([]interface{}, map[string]string, error) {
@@ -185,15 +184,14 @@ func (r *CommonServiceReconciler) getNewConfigs(cs *unstructured.Unstructured) (
 
 	if tolerations := cs.Object["spec"].(map[string]interface{})["tolerations"]; tolerations != nil {
 		klog.Info("Applying tolerations configuration")
+		// Use compact JSON instead of multi-line YAML block to avoid "block sequence
+		// entries are not allowed in this context" when the JSON array is substituted
+		// inline into "tolerations: placeholder" in the template.
 		tolerationBytes, err := json.Marshal(tolerations)
 		if err != nil {
 			return nil, nil, err
 		}
-		tolerationYAML, err := utilyaml.JSONToYAML(tolerationBytes)
-		if err != nil {
-			return nil, nil, err
-		}
-		tolerationConfig, err := convertStringToSlice(strings.ReplaceAll(constant.ServiceTolerationsTemplate, "placeholder", strings.TrimSpace(string(tolerationYAML))))
+		tolerationConfig, err := convertStringToSlice(strings.ReplaceAll(constant.ServiceTolerationsTemplate, "placeholder", string(tolerationBytes)))
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for propagating Kubernetes pod tolerations from the CommonService CR to downstream operands: IAM Authentication, CommonWebUI, and the IBM PostgreSQL Cluster .
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69784
