### PR TITLE
add new rbac for postgres 28.4

### DIFF
--- a/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
+++ b/cp3pt0-deployment/common/nss-managed-bedrock-core-role.yaml
@@ -1498,6 +1498,14 @@ rules:
       - clusters
       - clusters/status
   - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+  - verbs:
       - create
       - delete
       - get


### PR DESCRIPTION
**What this PR does / why we need it**:
add new rbac for postgres 28.4
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69970
