### PR TITLE
Add permision to ibm-pg-migator role to get operator image

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2541,6 +2541,14 @@ spec:
                 - get
                 - list
                 - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - watch
       - apiVersion: rbac.authorization.k8s.io/v1
         kind: RoleBinding
         name: common-service-db-pg-migration-rolebinding-{{ .OperatorNs }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Add permision to ibm-pg-migator role in Operator Namespace to get operator image
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69991
