### PR TITLE
Add AGENTS.md and internal wiki for AI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent Rules
+
+## Start with the wiki
+
+At the start of each task, check `_context/wiki/index.md` to decide
+whether wiki context is needed before acting. Don't read the wiki in
+full. Use the index and follow links only when they are relevant to
+the task.
+
+## Update the wiki
+
+After completing a task, offer to update the wiki if the task yielded durable knowledge that could benefit future work, then wait for user approval. This includes new processes, architecture decisions, or insights that go beyond the immediate task.

--- a/_context/wiki/index.md
+++ b/_context/wiki/index.md
@@ -1,0 +1,18 @@
+# ibm-common-service-operator Wiki
+
+Entry point operator for installing IBM Cloud Pak foundational services (CPfs). Acts as a meta operator and the sole intended source of configuration for all CPfs components.
+
+## Contents
+
+| File | What's in it |
+|------|-------------|
+| [project.md](project.md) | Project overview, goals, key modules, architecture notes |
+| [preferences.md](preferences.md) | Working standards, coding style, AI collaboration preferences |
+
+## Quick orientation
+
+- This operator is the **entry point** for CPfs installation — Cloud Paks install this to get all other CPfs operators.
+- It installs and manages **ODLM** (`operand-deployment-lifecycle-manager`) as its primary operand.
+- The `CommonService` CR is the **sole intended configuration source** for all CPfs services — config here propagates downstream.
+- There is a key distinction between a **master/configurable** `CommonService` CR and **non-configurable** ones (which can only set CPU/memory sizing).
+- Also contains certificate rotation controllers moved out of `ibm-cert-manager-operator` to simplify that operator.

--- a/_context/wiki/preferences.md
+++ b/_context/wiki/preferences.md
@@ -1,0 +1,30 @@
+# Working Preferences & Standards
+
+## How I use AI
+
+- **Debugging live cluster issues** — the most common use case. Help trace root causes across operators and CRDs.
+- **Understanding unfamiliar code** — orientation to areas of the codebase not recently touched.
+- **Bug fixes** — targeted, minimal changes. Understand the issue before suggesting a fix.
+- **Occasional feature work** — adding new fields to the `CommonService` CR or new configuration propagation logic.
+
+## Communication preferences
+
+- Be direct and technical. No filler phrases ("Great!", "Certainly!", etc.).
+- Investigate before answering — never speculate about code you haven't read.
+- When explaining unfamiliar code: start with what it *does*, then how it works.
+- Flag assumptions and caveats explicitly, especially around the master vs. non-configurable CR distinction.
+- If a change could affect downstream Cloud Pak teams or break backwards compatibility, say so upfront.
+
+## Code style & engineering standards
+
+- **Minimal changes.** Produce the smallest diff that solves the problem. No opportunistic refactors.
+- **Trace every changed line** back to the stated requirement.
+- **Go conventions.** Follow standard Go idioms and the existing style in the file being edited.
+- **Backwards compatibility is the top constraint.** A change that breaks a downstream Cloud Pak consumer is worse than not making the change at all.
+
+## What to be careful about
+
+- **Master vs. non-configurable `CommonService` CR.** Always clarify which is in scope before making configuration-related changes.
+- **Configuration propagation.** Changes to `CommonService` CR fields must be traced through to wherever they are consumed downstream — a field added but not propagated does nothing.
+- **Legacy configuration sources.** Some config still originates outside the `CommonService` CR. Do not assume the CR is the only source without checking.
+- **Certificate rotation controllers.** These live here, not in `ibm-cert-manager-operator`. Be aware when tracing cert-related issues.

--- a/_context/wiki/project.md
+++ b/_context/wiki/project.md
@@ -1,0 +1,50 @@
+# Project Overview
+
+## What this project is
+
+`ibm-common-service-operator` is the **entry point operator** for IBM Cloud Pak foundational services (CPfs). It is a meta operator (per the operator-sdk framework) whose primary job is to install and lifecycle-manage `operand-deployment-lifecycle-manager` (ODLM), which in turn installs all other CPfs operators.
+
+It is also the **sole intended source of configuration** for CPfs — configuration placed in the `CommonService` CR propagates to the appropriate downstream CPfs services. Some legacy configuration sources exist outside of the `CommonService` CR, but these are exceptions.
+
+Additionally, it owns a set of **certificate rotation controllers** that were moved out of `ibm-cert-manager-operator` to simplify that operator's scope.
+
+## Main goals
+
+1. **Installation entry point** — provide Cloud Paks with a single operator to install that brings up all of CPfs.
+2. **Configuration propagation** — act as the single source of truth for CPfs configuration via the `CommonService` CR.
+3. **Backwards compatibility** — changes must not break downstream Cloud Pak consumers.
+
+## Key stakeholders / users
+
+- **IBM Cloud Pak teams** — primary consumers; they install this operator to get CPfs.
+- **End customers** — not expected to install this standalone; their exposure to CPfs is typically through a Cloud Pak. When a Cloud Pak service has issues, the root cause may trace back here.
+
+## Important architecture notes
+
+### CommonService CR — master vs. non-configurable
+There are two kinds of `CommonService` CRs in a cluster:
+- **Master / configurable CR** — the authoritative source of configuration. Changes here propagate downstream.
+- **Non-configurable CRs** — read-only in terms of most configuration, but can still set CPU/memory sizing for operands.
+
+This distinction is a common source of confusion and a frequent area of bugs. Always clarify which kind of CR is involved when debugging configuration issues.
+
+### Certificate rotation controllers
+Controllers for certificate rotation live here (not in `ibm-cert-manager-operator`) as a deliberate simplification. Be aware of this when tracing certificate-related issues.
+
+### Legacy configuration sources
+Some CPfs configuration still comes from sources outside the `CommonService` CR. These are legacy and should not be expanded.
+
+## Key workflows
+
+- **Bug fixes** — most common; often traced from a Cloud Pak team reporting an issue with a CPfs service.
+- **Adding new configuration** to the `CommonService` CR — as requested by Cloud Pak teams.
+- **Debugging live cluster issues** — primary day-to-day mode of work.
+- **Occasional new features** — requested by Cloud Paks.
+
+## Important modules / areas
+
+| Area | Notes |
+|------|-------|
+| `api/v3/commonservice_types.go` | `CommonService` CRD type definitions — primary configuration surface |
+| Certificate rotation controllers | Moved here from `ibm-cert-manager-operator` |
+| ODLM installation logic | This operator installs and manages ODLM as its primary operand |


### PR DESCRIPTION
Adds AGENTS.md agent rules file and internal wiki under _context/wiki/ to support AI-assisted development.