### PR TITLE
Update cs-db wal config value

### DIFF
--- a/internal/controller/constant/odlm.go
+++ b/internal/controller/constant/odlm.go
@@ -2082,9 +2082,9 @@ spec:
                 track_io_timing: "on"
                 pg_stat_statements.track: all
                 pg_stat_statements.max: "10000"
-                max_slot_wal_keep_size: "5GB"
-                wal_keep_size: "1GB"
-                max_wal_size: "2GB"
+                max_slot_wal_keep_size: "8GB"
+                wal_keep_size: "512MB"
+                max_wal_size: "1GB"
                 wal_sender_timeout: "30s"
                 wal_receiver_timeout: "30s"
               pg_hba:


### PR DESCRIPTION
**What this PR does / why we need it**:
Reset the `max_slot_wal_keep_size` `wal_keep_size` and `max_wal_size` to original value, 
only increase the value of `wal_receiver_timeout` and `wal_sender_timeout` 
**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69615#issuecomment-240155732