### PR TITLE
Enforce master CR as sole controller owner

### DIFF
--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -631,9 +631,14 @@ func (b *Bootstrap) shouldAddOwnerReference(
 	return false
 }
 
-// addOwnerReference ensures that obj is controlled by instance. It returns true
-// when the object was changed. The caller is responsible for persisting the
-// change and logging only after that persistence succeeds.
+// addOwnerReference ensures that obj is controlled by the master CommonService
+// CR (named constant.MasterCR).  When the reconciling instance is not the
+// master CR itself, the master CR is fetched from the API server so that its
+// UID is always used.  This guarantees that only one, well-known CR can ever
+// become the controller owner regardless of which CR triggered reconciliation.
+//
+// It returns true when the object was changed.  The caller is responsible for
+// persisting the change and logging only after that persistence succeeds.
 func (b *Bootstrap) addOwnerReference(
 	obj *unstructured.Unstructured,
 	instance *apiv3.CommonService,
@@ -642,13 +647,36 @@ func (b *Bootstrap) addOwnerReference(
 		return false, nil
 	}
 
+	// Resolve the master CR that will be recorded as the owner.
+	masterName := instance.Name
+	masterUID := instance.UID
+	masterNs := instance.Namespace
+	if instance.Name != constant.MasterCR {
+		master := &apiv3.CommonService{}
+		if err := b.Reader.Get(ctx, types.NamespacedName{
+			Name:      constant.MasterCR,
+			Namespace: instance.Namespace,
+		}, master); err != nil {
+			// Master CR not present yet; skip adding an owner reference rather
+			// than blocking the reconcile.
+			klog.V(2).Infof(
+				"Skipping owner ref for %s/%s: master CR %s not found in namespace %s: %v",
+				obj.GetNamespace(), obj.GetName(), constant.MasterCR, instance.Namespace, err,
+			)
+			return false, nil
+		}
+		masterName = master.Name
+		masterUID = master.UID
+		masterNs = master.Namespace
+	}
+
 	// Kubernetes does not allow cross-namespace owner references.
-	if obj.GetNamespace() != "" && obj.GetNamespace() != instance.Namespace {
+	if obj.GetNamespace() != "" && obj.GetNamespace() != masterNs {
 		klog.V(2).Infof(
 			"Skipping cross-namespace owner ref for %s/%s (owner is in %s)",
 			obj.GetNamespace(),
 			obj.GetName(),
-			instance.Namespace,
+			masterNs,
 		)
 		return false, nil
 	}
@@ -656,8 +684,8 @@ func (b *Bootstrap) addOwnerReference(
 	ownerRef := metav1.OwnerReference{
 		APIVersion: constant.APIVersion,
 		Kind:       constant.KindCR,
-		Name:       instance.Name,
-		UID:        instance.UID,
+		Name:       masterName,
+		UID:        masterUID,
 	}
 
 	return common.EnsureControllerOwnerReference(obj, ownerRef)

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -663,52 +663,59 @@ func (b *Bootstrap) addOwnerReference(
 	// split operator/services topologies are handled correctly.
 	objNs := obj.GetNamespace()
 
-	// Fast path: the reconciling instance is already the local master CR.
-	// No same-Kind takeover is needed here because the owner name already
-	// matches — only the UID may be stale (e.g. after a reinstall).
-	if instance.Name == constant.MasterCR && instance.Namespace == objNs {
-		ownerRef := metav1.OwnerReference{
-			APIVersion: constant.APIVersion,
-			Kind:       constant.KindCR,
-			Name:       instance.Name,
-			UID:        instance.UID,
-		}
-		return common.EnsureControllerOwnerReference(obj, ownerRef, false)
-	}
+	// Resolve the master CR that will be recorded as the owner.
+	// Always look up by namespace+name so that:
+	//   (a) split-namespace: op-ns/common-service reconciling svc-ns/cs-ca-certificate
+	//       finds svc-ns/common-service, not the operator instance.
+	//   (b) same-namespace upgrade: a1/common-service reconciling a1/cs-ca-certificate
+	//       that is currently owned by a1/im-common-service uses its own UID without
+	//       requiring the slow-path lookup — but still enables same-Kind takeover.
+	var masterName string
+	var masterUID types.UID
 
-	// Slow path: look up the master CR in obj's namespace.
-	master := &apiv3.CommonService{}
-	if err := b.Reader.Get(ctx, types.NamespacedName{
-		Name:      constant.MasterCR,
-		Namespace: objNs,
-	}, master); err != nil {
-		if errors.IsNotFound(err) {
-			// The cloned master CR does not exist in obj's namespace yet.
-			// PropagateDefaultCR (which runs later in the same reconcile) will
-			// create it.  Ownership will be backfilled on the next cycle.
-			klog.V(2).Infof(
-				"Skipping owner ref for %s/%s: master CR %s/%s not found yet, will retry",
-				objNs, obj.GetName(), objNs, constant.MasterCR,
+	if instance.Name == constant.MasterCR && instance.Namespace == objNs {
+		// The reconciling instance IS the local master CR; use it directly.
+		masterName = instance.Name
+		masterUID = instance.UID
+	} else {
+		// Either the reconciling instance is a secondary CR, or it lives in a
+		// different namespace from the cert.  Fetch the actual master CR.
+		master := &apiv3.CommonService{}
+		if err := b.Reader.Get(ctx, types.NamespacedName{
+			Name:      constant.MasterCR,
+			Namespace: objNs,
+		}, master); err != nil {
+			if errors.IsNotFound(err) {
+				// The cloned master CR does not exist in obj's namespace yet.
+				// PropagateDefaultCR (which runs later in the same reconcile) will
+				// create it.  Ownership will be backfilled on the next cycle.
+				klog.V(2).Infof(
+					"Skipping owner ref for %s/%s: master CR %s/%s not found yet, will retry",
+					objNs, obj.GetName(), objNs, constant.MasterCR,
+				)
+				return false, nil
+			}
+			// Propagate all other errors (Forbidden, timeout, etc.) so the
+			// reconcile loop retries.
+			return false, fmt.Errorf(
+				"failed to get master CR %s/%s for owner reference on %s/%s: %w",
+				objNs, constant.MasterCR, objNs, obj.GetName(), err,
 			)
-			return false, nil
 		}
-		// Propagate all other errors (Forbidden, timeout, etc.) so the
-		// reconcile loop retries.
-		return false, fmt.Errorf(
-			"failed to get master CR %s/%s for owner reference on %s/%s: %w",
-			objNs, constant.MasterCR, objNs, obj.GetName(), err,
-		)
+		masterName = master.Name
+		masterUID = master.UID
 	}
 
 	ownerRef := metav1.OwnerReference{
 		APIVersion: constant.APIVersion,
 		Kind:       constant.KindCR,
-		Name:       master.Name,
-		UID:        master.UID,
+		Name:       masterName,
+		UID:        masterUID,
 	}
-	// replaceExistingSameKind=true: the resolved owner is the designated master
-	// CR so it may replace a stale controller reference from another
-	// CommonService (e.g. im-common-service from a pre-upgrade install).
+	// replaceExistingSameKind=true: the resolved owner is always the designated
+	// master CR, so it may replace a stale controller reference from another
+	// CommonService CR (e.g. im-common-service from a pre-upgrade install).
+	// This applies in both the same-namespace and split-namespace cases.
 	return common.EnsureControllerOwnerReference(obj, ownerRef, true)
 }
 

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -631,25 +631,8 @@ func (b *Bootstrap) shouldAddOwnerReference(
 	return false
 }
 
-// addOwnerReference ensures that obj is controlled by the master CommonService
-// CR (named constant.MasterCR) that lives in the same namespace as obj.
-//
-// The lookup is always performed against obj.GetNamespace() so that the
-// correct CR is found regardless of whether the reconciling instance lives in
-// a different namespace (split operator/services namespace topology).  Reusing
-// the reconciling instance directly is only safe when both its name and
-// namespace already match — i.e. it IS the local master CR.
-//
-// Error handling:
-//   - NotFound: the cloned master CR has not been created in obj's namespace
-//     yet (PropagateDefaultCR runs after DeployCertManagerCR on the first
-//     reconcile).  Ownership will be backfilled on the next reconcile cycle;
-//     skip silently rather than blocking progress.
-//   - Any other error (Forbidden, transient, etc.): propagate so the reconcile
-//     loop retries instead of silently leaving ownership unset.
-//
-// It returns true when the object was changed.  The caller is responsible for
-// persisting the change and logging only after that persistence succeeds.
+// addOwnerReference uses the common-service CR in the resource's namespace.
+// The caller persists the change and logs only after the update succeeds.
 func (b *Bootstrap) addOwnerReference(
 	obj *unstructured.Unstructured,
 	instance *apiv3.CommonService,
@@ -658,65 +641,29 @@ func (b *Bootstrap) addOwnerReference(
 		return false, nil
 	}
 
-	// The owner must live in the same namespace as the object being annotated.
-	// Use obj.GetNamespace() as the authoritative lookup namespace so that
-	// split operator/services topologies are handled correctly.
-	objNs := obj.GetNamespace()
-
-	// Resolve the master CR that will be recorded as the owner.
-	// Always look up by namespace+name so that:
-	//   (a) split-namespace: op-ns/common-service reconciling svc-ns/cs-ca-certificate
-	//       finds svc-ns/common-service, not the operator instance.
-	//   (b) same-namespace upgrade: a1/common-service reconciling a1/cs-ca-certificate
-	//       that is currently owned by a1/im-common-service uses its own UID without
-	//       requiring the slow-path lookup — but still enables same-Kind takeover.
-	var masterName string
-	var masterUID types.UID
-
-	if instance.Name == constant.MasterCR && instance.Namespace == objNs {
-		// The reconciling instance IS the local master CR; use it directly.
-		masterName = instance.Name
-		masterUID = instance.UID
-	} else {
-		// Either the reconciling instance is a secondary CR, or it lives in a
-		// different namespace from the cert.  Fetch the actual master CR.
-		master := &apiv3.CommonService{}
-		if err := b.Reader.Get(ctx, types.NamespacedName{
-			Name:      constant.MasterCR,
-			Namespace: objNs,
-		}, master); err != nil {
+	owner := instance
+	if owner.Name != constant.MasterCR || owner.Namespace != obj.GetNamespace() {
+		owner = &apiv3.CommonService{}
+		key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: constant.MasterCR}
+		if err := b.Reader.Get(ctx, key, owner); err != nil {
 			if errors.IsNotFound(err) {
-				// The cloned master CR does not exist in obj's namespace yet.
-				// PropagateDefaultCR (which runs later in the same reconcile) will
-				// create it.  Ownership will be backfilled on the next cycle.
-				klog.V(2).Infof(
-					"Skipping owner ref for %s/%s: master CR %s/%s not found yet, will retry",
-					objNs, obj.GetName(), objNs, constant.MasterCR,
-				)
+				// PropagateDefaultCR creates the local clone later; its create
+				// event requeues the master CR to backfill ownership.
+				klog.V(2).Infof("Waiting for CommonService %s before adding owner reference to %s/%s",
+					key, obj.GetNamespace(), obj.GetName())
 				return false, nil
 			}
-			// Propagate all other errors (Forbidden, timeout, etc.) so the
-			// reconcile loop retries.
-			return false, fmt.Errorf(
-				"failed to get master CR %s/%s for owner reference on %s/%s: %w",
-				objNs, constant.MasterCR, objNs, obj.GetName(), err,
-			)
+			return false, fmt.Errorf("get CommonService %s for owner reference: %w", key, err)
 		}
-		masterName = master.Name
-		masterUID = master.UID
 	}
 
-	ownerRef := metav1.OwnerReference{
+	// Only the resolved local common-service CR may replace a previous CS owner.
+	return common.EnsureControllerOwnerReference(obj, metav1.OwnerReference{
 		APIVersion: constant.APIVersion,
 		Kind:       constant.KindCR,
-		Name:       masterName,
-		UID:        masterUID,
-	}
-	// replaceExistingSameKind=true: the resolved owner is always the designated
-	// master CR, so it may replace a stale controller reference from another
-	// CommonService CR (e.g. im-common-service from a pre-upgrade install).
-	// This applies in both the same-namespace and split-namespace cases.
-	return common.EnsureControllerOwnerReference(obj, ownerRef, true)
+		Name:       owner.Name,
+		UID:        owner.UID,
+	}, true)
 }
 
 func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, instance *apiv3.CommonService, alwaysUpdate ...bool) error {

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -632,10 +632,21 @@ func (b *Bootstrap) shouldAddOwnerReference(
 }
 
 // addOwnerReference ensures that obj is controlled by the master CommonService
-// CR (named constant.MasterCR).  When the reconciling instance is not the
-// master CR itself, the master CR is fetched from the API server so that its
-// UID is always used.  This guarantees that only one, well-known CR can ever
-// become the controller owner regardless of which CR triggered reconciliation.
+// CR (named constant.MasterCR) that lives in the same namespace as obj.
+//
+// The lookup is always performed against obj.GetNamespace() so that the
+// correct CR is found regardless of whether the reconciling instance lives in
+// a different namespace (split operator/services namespace topology).  Reusing
+// the reconciling instance directly is only safe when both its name and
+// namespace already match — i.e. it IS the local master CR.
+//
+// Error handling:
+//   - NotFound: the cloned master CR has not been created in obj's namespace
+//     yet (PropagateDefaultCR runs after DeployCertManagerCR on the first
+//     reconcile).  Ownership will be backfilled on the next reconcile cycle;
+//     skip silently rather than blocking progress.
+//   - Any other error (Forbidden, transient, etc.): propagate so the reconcile
+//     loop retries instead of silently leaving ownership unset.
 //
 // It returns true when the object was changed.  The caller is responsible for
 // persisting the change and logging only after that persistence succeeds.
@@ -647,47 +658,52 @@ func (b *Bootstrap) addOwnerReference(
 		return false, nil
 	}
 
-	// Resolve the master CR that will be recorded as the owner.
-	masterName := instance.Name
-	masterUID := instance.UID
-	masterNs := instance.Namespace
-	if instance.Name != constant.MasterCR {
-		master := &apiv3.CommonService{}
-		if err := b.Reader.Get(ctx, types.NamespacedName{
-			Name:      constant.MasterCR,
-			Namespace: instance.Namespace,
-		}, master); err != nil {
-			// Master CR not present yet; skip adding an owner reference rather
-			// than blocking the reconcile.
+	// The owner must live in the same namespace as the object being annotated.
+	// Use obj.GetNamespace() as the authoritative lookup namespace so that
+	// split operator/services topologies are handled correctly.
+	objNs := obj.GetNamespace()
+
+	// Fast path: the reconciling instance is already the local master CR.
+	if instance.Name == constant.MasterCR && instance.Namespace == objNs {
+		ownerRef := metav1.OwnerReference{
+			APIVersion: constant.APIVersion,
+			Kind:       constant.KindCR,
+			Name:       instance.Name,
+			UID:        instance.UID,
+		}
+		return common.EnsureControllerOwnerReference(obj, ownerRef)
+	}
+
+	// Slow path: look up the master CR in obj's namespace.
+	master := &apiv3.CommonService{}
+	if err := b.Reader.Get(ctx, types.NamespacedName{
+		Name:      constant.MasterCR,
+		Namespace: objNs,
+	}, master); err != nil {
+		if errors.IsNotFound(err) {
+			// The cloned master CR does not exist in obj's namespace yet.
+			// PropagateDefaultCR (which runs later in the same reconcile) will
+			// create it.  Ownership will be backfilled on the next cycle.
 			klog.V(2).Infof(
-				"Skipping owner ref for %s/%s: master CR %s not found in namespace %s: %v",
-				obj.GetNamespace(), obj.GetName(), constant.MasterCR, instance.Namespace, err,
+				"Skipping owner ref for %s/%s: master CR %s/%s not found yet, will retry",
+				objNs, obj.GetName(), objNs, constant.MasterCR,
 			)
 			return false, nil
 		}
-		masterName = master.Name
-		masterUID = master.UID
-		masterNs = master.Namespace
-	}
-
-	// Kubernetes does not allow cross-namespace owner references.
-	if obj.GetNamespace() != "" && obj.GetNamespace() != masterNs {
-		klog.V(2).Infof(
-			"Skipping cross-namespace owner ref for %s/%s (owner is in %s)",
-			obj.GetNamespace(),
-			obj.GetName(),
-			masterNs,
+		// Propagate all other errors (Forbidden, timeout, etc.) so the
+		// reconcile loop retries.
+		return false, fmt.Errorf(
+			"failed to get master CR %s/%s for owner reference on %s/%s: %w",
+			objNs, constant.MasterCR, objNs, obj.GetName(), err,
 		)
-		return false, nil
 	}
 
 	ownerRef := metav1.OwnerReference{
 		APIVersion: constant.APIVersion,
 		Kind:       constant.KindCR,
-		Name:       masterName,
-		UID:        masterUID,
+		Name:       master.Name,
+		UID:        master.UID,
 	}
-
 	return common.EnsureControllerOwnerReference(obj, ownerRef)
 }
 

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -664,6 +664,8 @@ func (b *Bootstrap) addOwnerReference(
 	objNs := obj.GetNamespace()
 
 	// Fast path: the reconciling instance is already the local master CR.
+	// No same-Kind takeover is needed here because the owner name already
+	// matches — only the UID may be stale (e.g. after a reinstall).
 	if instance.Name == constant.MasterCR && instance.Namespace == objNs {
 		ownerRef := metav1.OwnerReference{
 			APIVersion: constant.APIVersion,
@@ -671,7 +673,7 @@ func (b *Bootstrap) addOwnerReference(
 			Name:       instance.Name,
 			UID:        instance.UID,
 		}
-		return common.EnsureControllerOwnerReference(obj, ownerRef)
+		return common.EnsureControllerOwnerReference(obj, ownerRef, false)
 	}
 
 	// Slow path: look up the master CR in obj's namespace.
@@ -704,7 +706,10 @@ func (b *Bootstrap) addOwnerReference(
 		Name:       master.Name,
 		UID:        master.UID,
 	}
-	return common.EnsureControllerOwnerReference(obj, ownerRef)
+	// replaceExistingSameKind=true: the resolved owner is the designated master
+	// CR so it may replace a stale controller reference from another
+	// CommonService (e.g. im-common-service from a pre-upgrade install).
+	return common.EnsureControllerOwnerReference(obj, ownerRef, true)
 }
 
 func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, instance *apiv3.CommonService, alwaysUpdate ...bool) error {

--- a/internal/controller/bootstrap/init.go
+++ b/internal/controller/bootstrap/init.go
@@ -290,7 +290,7 @@ func (b *Bootstrap) InitResources(ctx context.Context, instance *apiv3.CommonSer
 	}
 
 	// Create Keycloak themes ConfigMap
-	if err := b.CreateKeycloakThemesConfigMap(instance); err != nil {
+	if err := b.CreateKeycloakThemesConfigMap(ctx, instance); err != nil {
 		klog.Errorf("Failed to create Keycloak Themes ConfigMap: %v", err)
 		return err
 	}
@@ -349,7 +349,7 @@ func (b *Bootstrap) InitResources(ctx context.Context, instance *apiv3.CommonSer
 		return err
 	} else if installODLM {
 		klog.Info("Installing ODLM Operator")
-		if err := b.renderTemplate(constant.ODLMSubscription, b.CSData, nil); err != nil {
+		if err := b.renderTemplate(ctx, constant.ODLMSubscription, b.CSData, nil); err != nil {
 			return err
 		}
 	} else {
@@ -508,14 +508,14 @@ func (b *Bootstrap) CreateCsCR() error {
 		// using `ibm-common-services` ns as ServicesNs if CS CR does not exist
 		if _, err := b.GetObject(cs); errors.IsNotFound(err) {
 			b.CSData.ServicesNs = constant.MasterNamespace
-			return b.renderTemplate(constant.CsCR, b.CSData, nil)
+			return b.renderTemplate(ctx, constant.CsCR, b.CSData, nil)
 		} else if err != nil {
 			return err
 		}
 	} else {
 		if _, err := b.GetObject(cs); errors.IsNotFound(err) { // Only if it's a fresh install
 			// Fresh Intall: No ODLM and NO CR
-			return b.renderTemplate(constant.CsCR, b.CSData, nil)
+			return b.renderTemplate(ctx, constant.CsCR, b.CSData, nil)
 		} else if err != nil {
 			return err
 		}
@@ -634,6 +634,7 @@ func (b *Bootstrap) shouldAddOwnerReference(
 // addOwnerReference uses the common-service CR in the resource's namespace.
 // The caller persists the change and logs only after the update succeeds.
 func (b *Bootstrap) addOwnerReference(
+	ctx context.Context,
 	obj *unstructured.Unstructured,
 	instance *apiv3.CommonService,
 ) (bool, error) {
@@ -663,10 +664,10 @@ func (b *Bootstrap) addOwnerReference(
 		Kind:       constant.KindCR,
 		Name:       owner.Name,
 		UID:        owner.UID,
-	}, true)
+	})
 }
 
-func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, instance *apiv3.CommonService, alwaysUpdate ...bool) error {
+func (b *Bootstrap) CreateOrUpdateFromYaml(ctx context.Context, yamlContent []byte, instance *apiv3.CommonService, alwaysUpdate ...bool) error {
 	objects, err := util.YamlToObjects(yamlContent)
 	if err != nil {
 		return err
@@ -679,7 +680,7 @@ func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, instance *apiv3.C
 
 		// Add the owner reference to the desired object so newly created resources
 		// and normal content updates include it.
-		desiredOwnerReferenceChanged, err := b.addOwnerReference(obj, instance)
+		desiredOwnerReferenceChanged, err := b.addOwnerReference(ctx, obj, instance)
 		if err != nil {
 			errMsg = err
 			continue
@@ -713,7 +714,7 @@ func (b *Bootstrap) CreateOrUpdateFromYaml(yamlContent []byte, instance *apiv3.C
 		// Backfill ownership independently from the template version. An upgrade
 		// can introduce ownership metadata while leaving the resource's version
 		// annotation unchanged.
-		ownerReferenceChanged, err := b.addOwnerReference(objInCluster, instance)
+		ownerReferenceChanged, err := b.addOwnerReference(ctx, objInCluster, instance)
 		if err != nil {
 			errMsg = err
 			continue
@@ -1141,7 +1142,7 @@ func (b *Bootstrap) InstallOrUpdateOperatorConfig(config string, forceUpdateODLM
 		}
 	}
 
-	if err := b.renderTemplate(config, b.CSData, nil, forceUpdateODLMCRs); err != nil {
+	if err := b.renderTemplate(ctx, config, b.CSData, nil, forceUpdateODLMCRs); err != nil {
 		return err
 	}
 
@@ -1151,14 +1152,14 @@ func (b *Bootstrap) InstallOrUpdateOperatorConfig(config string, forceUpdateODLM
 // CreateNsScopeConfigmap creates nss configmap for operators
 func (b *Bootstrap) CreateNsScopeConfigmap() error {
 	cmRes := constant.NamespaceScopeConfigMap
-	if err := b.renderTemplate(cmRes, b.CSData, nil, false); err != nil {
+	if err := b.renderTemplate(ctx, cmRes, b.CSData, nil, false); err != nil {
 		return err
 	}
 	return nil
 }
 
 // CreateKeycloakThemesConfigMap creates a ConfigMap contains Keycloak themes
-func (b *Bootstrap) CreateKeycloakThemesConfigMap(instance *apiv3.CommonService) error {
+func (b *Bootstrap) CreateKeycloakThemesConfigMap(ctx context.Context, instance *apiv3.CommonService) error {
 
 	klog.Info("Extracting Keycloak themes from jar file")
 	themeFile := constant.KeycloakThemesJar
@@ -1169,7 +1170,7 @@ func (b *Bootstrap) CreateKeycloakThemesConfigMap(instance *apiv3.CommonService)
 	b.CSData.CloudPakThemes = util.EncodeBase64(themeFileContent)
 
 	cmRes := constant.KeycloakThemesConfigMap
-	if err := b.renderTemplate(cmRes, b.CSData, instance, false); err != nil {
+	if err := b.renderTemplate(ctx, cmRes, b.CSData, instance, false); err != nil {
 		return err
 	}
 	return nil
@@ -1483,7 +1484,7 @@ func (b *Bootstrap) deleteSubscription(name, namespace string) error {
 	return nil
 }
 
-func (b *Bootstrap) renderTemplate(objectTemplate string, data interface{}, instance *apiv3.CommonService, alwaysUpdate ...bool) error {
+func (b *Bootstrap) renderTemplate(ctx context.Context, objectTemplate string, data interface{}, instance *apiv3.CommonService, alwaysUpdate ...bool) error {
 	var buffer bytes.Buffer
 	t := template.Must(template.New("newTemplate").Parse(objectTemplate))
 	if err := t.Execute(&buffer, data); err != nil {
@@ -1495,7 +1496,7 @@ func (b *Bootstrap) renderTemplate(objectTemplate string, data interface{}, inst
 		forceUpdate = alwaysUpdate[0]
 	}
 
-	if err := b.CreateOrUpdateFromYaml(buffer.Bytes(), instance, forceUpdate); err != nil {
+	if err := b.CreateOrUpdateFromYaml(ctx, buffer.Bytes(), instance, forceUpdate); err != nil {
 		return err
 	}
 	return nil
@@ -1836,7 +1837,7 @@ func (b *Bootstrap) updateApprovalMode() error {
 // deployResource deploys the given resource CR
 func (b *Bootstrap) DeployResource(cr, placeholder string) bool {
 	if err := utilwait.PollUntilContextCancel(ctx, time.Second*10, true, func(ctx context.Context) (done bool, err error) {
-		err = b.CreateOrUpdateFromYaml([]byte(util.Namespacelize(cr, placeholder, b.CSData.ServicesNs)), nil)
+		err = b.CreateOrUpdateFromYaml(ctx, []byte(util.Namespacelize(cr, placeholder, b.CSData.ServicesNs)), nil)
 		if err != nil {
 			return false, err
 		}
@@ -1941,7 +1942,7 @@ func (b *Bootstrap) IsBYOCert() (bool, error) {
 	}
 }
 
-func (b *Bootstrap) DeployCertManagerCR(instance *apiv3.CommonService) error {
+func (b *Bootstrap) DeployCertManagerCR(ctx context.Context, instance *apiv3.CommonService) error {
 	for _, kind := range constant.CertManagerKinds {
 		klog.Infof("Checking if resource %s CRD exsits ", kind)
 		// if the crd is not exist, skip it
@@ -2033,13 +2034,13 @@ func (b *Bootstrap) DeployCertManagerCR(instance *apiv3.CommonService) error {
 	}
 
 	for _, cr := range constant.CertManagerIssuers {
-		if err := b.CreateOrUpdateFromYaml([]byte(util.Namespacelize(cr, placeholder, b.CSData.ServicesNs)), nil); err != nil {
+		if err := b.CreateOrUpdateFromYaml(ctx, []byte(util.Namespacelize(cr, placeholder, b.CSData.ServicesNs)), nil); err != nil {
 			return err
 		}
 	}
 	if deployRootCert {
 		for _, cr := range constant.CertManagerCerts {
-			if err := b.CreateOrUpdateFromYaml([]byte(util.Namespacelize(cr, placeholder, b.CSData.ServicesNs)), instance); err != nil {
+			if err := b.CreateOrUpdateFromYaml(ctx, []byte(util.Namespacelize(cr, placeholder, b.CSData.ServicesNs)), instance); err != nil {
 				return err
 			}
 		}

--- a/internal/controller/bootstrap/init_test.go
+++ b/internal/controller/bootstrap/init_test.go
@@ -911,6 +911,71 @@ func TestAddOwnerReferenceReplacesStaleCommonServiceUID(t *testing.T) {
 	}
 }
 
+// TestAddOwnerReferenceMasterCRReplacesSecondaryOwner verifies that when
+// a1/common-service reconciles and a1/cs-ca-certificate is currently controlled
+// by a1/im-common-service, the master CR takes over ownership.  This is the
+// canonical failure case from issue #70051: the master CR reconciles first,
+// enters the fast path (name+namespace match), and must still be able to
+// displace the stale secondary-CR controller reference.
+// A second call verifies idempotency.
+func TestAddOwnerReferenceMasterCRReplacesSecondaryOwner(t *testing.T) {
+	const namespace = "a1"
+
+	cert := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]interface{}{
+				"name":      constant.CSCACertificate,
+				"namespace": namespace,
+			},
+		},
+	}
+	controller := true
+	// Pre-upgrade state: im-common-service is the controller owner.
+	cert.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: constant.APIVersion,
+		Kind:       constant.KindCR,
+		Name:       "im-common-service",
+		UID:        types.UID("uid-im"),
+		Controller: &controller,
+	}})
+
+	masterCS := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name:      constant.MasterCR,
+		Namespace: namespace,
+		UID:       types.UID("uid-master"),
+	}}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithRuntimeObjects(masterCS).
+		Build()
+	bs := &Bootstrap{
+		Client:  fakeClient,
+		Reader:  fakeClient,
+		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
+	}
+
+	// First call: master CR reconciles and takes over from im-common-service.
+	changed, err := bs.addOwnerReference(cert, masterCS)
+	assert.NoError(t, err, "master CR must take over without error")
+	assert.True(t, changed)
+	if assert.Len(t, cert.GetOwnerReferences(), 1) {
+		owner := cert.GetOwnerReferences()[0]
+		assert.Equal(t, constant.MasterCR, owner.Name, "owner must be common-service")
+		assert.Equal(t, types.UID("uid-master"), owner.UID)
+		assert.NotNil(t, owner.Controller)
+		assert.True(t, *owner.Controller)
+	}
+
+	// Second call: ownership is already correct — must be idempotent.
+	changed, err = bs.addOwnerReference(cert, masterCS)
+	assert.NoError(t, err)
+	assert.False(t, changed, "second call must be idempotent")
+	assert.Len(t, cert.GetOwnerReferences(), 1)
+}
+
 // TestAddOwnerReferenceUsesOnlyMasterCRAsOwner covers the upgrade scenario
 // from https://github.ibm.com/IBMPrivateCloud/roadmap/issues/70051:
 // When a secondary CommonService CR (e.g. im-common-service) triggers

--- a/internal/controller/bootstrap/init_test.go
+++ b/internal/controller/bootstrap/init_test.go
@@ -927,56 +927,80 @@ func ownershipTestCertificate(namespace string) *unstructured.Unstructured {
 	return cert
 }
 
+func ownershipTestConfigMap(namespace string) *unstructured.Unstructured {
+	cm := &unstructured.Unstructured{}
+	cm.SetAPIVersion("v1")
+	cm.SetKind("ConfigMap")
+	cm.SetNamespace(namespace)
+	cm.SetName(constant.CSKeycloakThemeConfigMap)
+	return cm
+}
+
+// ownershipTestResource is a constructor that builds a test Unstructured resource for a given namespace.
+type ownershipTestResource func(namespace string) *unstructured.Unstructured
+
 func TestAddOwnerReferenceUsesLocalMaster(t *testing.T) {
-	for _, tc := range []struct {
+	resources := []ownershipTestResource{ownershipTestCertificate, ownershipTestConfigMap}
+	reconcileCases := []struct {
 		name, reconcileNS, reconcileName string
 	}{
 		{"master first", "services", constant.MasterCR},
 		{"secondary first", "services", "im-common-service"},
 		{"split namespaces", "operators", constant.MasterCR},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			master := ownershipTestCR("services", constant.MasterCR, "local-master-uid")
-			instance := ownershipTestCR(tc.reconcileNS, tc.reconcileName, "other-uid")
-			if instance.Name == master.Name && instance.Namespace == master.Namespace {
-				instance = master
-			}
-			fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(master).Build()
-			bs := &Bootstrap{Reader: fc}
-			cert := ownershipTestCertificate("services")
-			controller := true
-			cert.SetOwnerReferences([]metav1.OwnerReference{{
-				APIVersion: constant.APIVersion, Kind: constant.KindCR,
-				Name: "im-common-service", UID: "im-uid", Controller: &controller,
-			}})
+	}
+	for _, res := range resources {
+		obj := res("services") // sample object to derive resource label for sub-test name
+		resourceLabel := obj.GetKind()
+		for _, tc := range reconcileCases {
+			tc, res := tc, res
+			t.Run(resourceLabel+"/"+tc.name, func(t *testing.T) {
+				master := ownershipTestCR("services", constant.MasterCR, "local-master-uid")
+				instance := ownershipTestCR(tc.reconcileNS, tc.reconcileName, "other-uid")
+				if instance.Name == master.Name && instance.Namespace == master.Namespace {
+					instance = master
+				}
+				fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(master).Build()
+				bs := &Bootstrap{Reader: fc}
+				testObj := res("services")
+				controller := true
+				testObj.SetOwnerReferences([]metav1.OwnerReference{{
+					APIVersion: constant.APIVersion, Kind: constant.KindCR,
+					Name: "im-common-service", UID: "im-uid", Controller: &controller,
+				}})
 
-			changed, err := bs.addOwnerReference(cert, instance)
-			require.NoError(t, err)
-			require.True(t, changed)
-			require.Len(t, cert.GetOwnerReferences(), 1)
-			owner := cert.GetOwnerReferences()[0]
-			assert.Equal(t, master.Name, owner.Name)
-			assert.Equal(t, master.UID, owner.UID)
-			require.NotNil(t, owner.Controller)
-			assert.True(t, *owner.Controller)
+				changed, err := bs.addOwnerReference(testObj, instance)
+				require.NoError(t, err)
+				require.True(t, changed)
+				require.Len(t, testObj.GetOwnerReferences(), 1)
+				owner := testObj.GetOwnerReferences()[0]
+				assert.Equal(t, master.Name, owner.Name)
+				assert.Equal(t, master.UID, owner.UID)
+				require.NotNil(t, owner.Controller)
+				assert.True(t, *owner.Controller)
 
-			changed, err = bs.addOwnerReference(cert, instance)
-			require.NoError(t, err)
-			assert.False(t, changed)
-			assert.Len(t, cert.GetOwnerReferences(), 1)
-		})
+				changed, err = bs.addOwnerReference(testObj, instance)
+				require.NoError(t, err)
+				assert.False(t, changed)
+				assert.Len(t, testObj.GetOwnerReferences(), 1)
+			})
+		}
 	}
 }
 
 func TestAddOwnerReferenceBackfillsAfterMasterCreated(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
-	bs := &Bootstrap{Client: fc, Reader: fc, Manager: &deploy.Manager{Client: fc, Reader: fc}}
-	instance := ownershipTestCR("operators", constant.MasterCR, "operator-uid")
-	cert := ownershipTestCertificate("services")
-	cert.SetAnnotations(map[string]string{"version": "0.0.1", "runtime": "preserve"})
-	require.NoError(t, fc.Create(context.Background(), cert))
-	// Use the production create/update path so the test checks persistence too.
-	desired := []byte(`apiVersion: cert-manager.io/v1
+	for _, res := range []ownershipTestResource{ownershipTestCertificate, ownershipTestConfigMap} {
+		sample := res("services")
+		t.Run(sample.GetKind(), func(t *testing.T) {
+			fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+			bs := &Bootstrap{Client: fc, Reader: fc, Manager: &deploy.Manager{Client: fc, Reader: fc}}
+			instance := ownershipTestCR("operators", constant.MasterCR, "operator-uid")
+			testObj := res("services")
+			testObj.SetAnnotations(map[string]string{"version": "0.0.1", "runtime": "preserve"})
+			require.NoError(t, fc.Create(context.Background(), testObj))
+
+			var desired []byte
+			if testObj.GetKind() == "Certificate" {
+				desired = []byte(`apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: cs-ca-certificate
@@ -984,41 +1008,60 @@ metadata:
   annotations:
     version: 0.0.1
 `)
-	require.NoError(t, bs.CreateOrUpdateFromYaml(desired, instance))
-	actual := ownershipTestCertificate("services")
-	key := client.ObjectKeyFromObject(actual)
-	require.NoError(t, fc.Get(context.Background(), key, actual))
-	assert.Empty(t, actual.GetOwnerReferences())
+			} else {
+				desired = []byte(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cs-keycloak-theme
+  namespace: services
+  annotations:
+    version: 0.0.1
+`)
+			}
 
-	master := ownershipTestCR("services", constant.MasterCR, "local-master-uid")
-	require.NoError(t, fc.Create(context.Background(), master))
-	// Simulate the next reconciliation triggered by the clone's create event.
-	require.NoError(t, bs.CreateOrUpdateFromYaml(desired, instance))
-	require.NoError(t, fc.Get(context.Background(), key, actual))
-	require.Len(t, actual.GetOwnerReferences(), 1)
-	assert.Equal(t, master.UID, actual.GetOwnerReferences()[0].UID)
-	assert.Equal(t, "preserve", actual.GetAnnotations()["runtime"])
+			require.NoError(t, bs.CreateOrUpdateFromYaml(desired, instance))
+			actual := res("services")
+			key := client.ObjectKeyFromObject(actual)
+			require.NoError(t, fc.Get(context.Background(), key, actual))
+			assert.Empty(t, actual.GetOwnerReferences())
+
+			master := ownershipTestCR("services", constant.MasterCR, "local-master-uid")
+			require.NoError(t, fc.Create(context.Background(), master))
+			// Simulate the next reconciliation triggered by the clone's create event.
+			require.NoError(t, bs.CreateOrUpdateFromYaml(desired, instance))
+			require.NoError(t, fc.Get(context.Background(), key, actual))
+			require.Len(t, actual.GetOwnerReferences(), 1)
+			assert.Equal(t, master.UID, actual.GetOwnerReferences()[0].UID)
+			assert.Equal(t, "preserve", actual.GetAnnotations()["runtime"])
+		})
+	}
 }
 
 func TestAddOwnerReferencePropagatesLookupErrors(t *testing.T) {
-	for _, lookupErr := range []error{
+	lookupErrors := []error{
 		k8serrors.NewForbidden(apiv3.GroupVersion.WithResource("commonservices").GroupResource(), constant.MasterCR, fmt.Errorf("denied")),
 		k8serrors.NewTimeoutError("API unavailable", 1),
-	} {
-		t.Run(lookupErr.Error(), func(t *testing.T) {
-			fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).
-				WithInterceptorFuncs(interceptor.Funcs{
-					Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
-						return lookupErr
-					},
-				}).Build()
-			cert := ownershipTestCertificate("services")
-			bs := &Bootstrap{Reader: fc}
-			changed, err := bs.addOwnerReference(cert, ownershipTestCR("services", "im-common-service", "im-uid"))
-			require.ErrorIs(t, err, lookupErr)
-			assert.False(t, changed)
-			assert.Empty(t, cert.GetOwnerReferences())
-		})
+	}
+	resources := []ownershipTestResource{ownershipTestCertificate, ownershipTestConfigMap}
+	for _, res := range resources {
+		sample := res("services")
+		for _, lookupErr := range lookupErrors {
+			res, lookupErr := res, lookupErr
+			t.Run(sample.GetKind()+"/"+lookupErr.Error(), func(t *testing.T) {
+				fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+							return lookupErr
+						},
+					}).Build()
+				testObj := res("services")
+				bs := &Bootstrap{Reader: fc}
+				changed, err := bs.addOwnerReference(testObj, ownershipTestCR("services", "im-common-service", "im-uid"))
+				require.ErrorIs(t, err, lookupErr)
+				assert.False(t, changed)
+				assert.Empty(t, testObj.GetOwnerReferences())
+			})
+		}
 	}
 }
 

--- a/internal/controller/bootstrap/init_test.go
+++ b/internal/controller/bootstrap/init_test.go
@@ -24,6 +24,7 @@ import (
 
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
 	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/constant"
@@ -912,8 +914,8 @@ func TestAddOwnerReferenceReplacesStaleCommonServiceUID(t *testing.T) {
 // TestAddOwnerReferenceUsesOnlyMasterCRAsOwner covers the upgrade scenario
 // from https://github.ibm.com/IBMPrivateCloud/roadmap/issues/70051:
 // When a secondary CommonService CR (e.g. im-common-service) triggers
-// reconciliation, addOwnerReference must look up the master CR and record it
-// as the controller owner — never the secondary CR.
+// reconciliation, addOwnerReference must look up the master CR from obj's
+// namespace and record it as the controller owner — never the secondary CR.
 func TestAddOwnerReferenceUsesOnlyMasterCRAsOwner(t *testing.T) {
 	const namespace = "test-ns"
 
@@ -961,7 +963,7 @@ func TestAddOwnerReferenceUsesOnlyMasterCRAsOwner(t *testing.T) {
 	}
 
 	// addOwnerReference is called with the secondary CR as the reconciling instance.
-	// It must fetch the master CR and use its UID, not secondaryCS.UID.
+	// It must fetch the master CR from obj's namespace and use its UID.
 	changed, err := bs.addOwnerReference(cert, secondaryCS)
 	assert.NoError(t, err)
 	assert.True(t, changed)
@@ -972,6 +974,146 @@ func TestAddOwnerReferenceUsesOnlyMasterCRAsOwner(t *testing.T) {
 		assert.NotNil(t, owner.Controller)
 		assert.True(t, *owner.Controller)
 	}
+}
+
+// TestAddOwnerReferenceSplitNamespace verifies the split operator/services
+// namespace topology.  The reconciling instance lives in the operator namespace
+// (op-ns/common-service) but cs-ca-certificate lives in the services namespace
+// (svc-ns).  addOwnerReference must look up the master CR in svc-ns, not op-ns.
+func TestAddOwnerReferenceSplitNamespace(t *testing.T) {
+	const (
+		opNs  = "op-ns"
+		svcNs = "svc-ns"
+	)
+
+	cert := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]interface{}{
+				"name":      constant.CSCACertificate,
+				"namespace": svcNs,
+			},
+		},
+	}
+
+	// Master CR cloned into the services namespace by PropagateDefaultCR.
+	masterInSvcNs := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name:      constant.MasterCR,
+		Namespace: svcNs,
+		UID:       types.UID("uid-master-svc"),
+	}}
+	// The operator-ns master (the one being reconciled).
+	masterInOpNs := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name:      constant.MasterCR,
+		Namespace: opNs,
+		UID:       types.UID("uid-master-op"),
+	}}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithRuntimeObjects(masterInSvcNs, masterInOpNs).
+		Build()
+	bs := &Bootstrap{
+		Client:  fakeClient,
+		Reader:  fakeClient,
+		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
+	}
+
+	changed, err := bs.addOwnerReference(cert, masterInOpNs)
+	assert.NoError(t, err)
+	assert.True(t, changed)
+	if assert.Len(t, cert.GetOwnerReferences(), 1) {
+		owner := cert.GetOwnerReferences()[0]
+		assert.Equal(t, constant.MasterCR, owner.Name)
+		assert.Equal(t, types.UID("uid-master-svc"), owner.UID,
+			"must use the master CR in the certificate's namespace (svc-ns), not op-ns")
+		assert.NotNil(t, owner.Controller)
+		assert.True(t, *owner.Controller)
+	}
+}
+
+// TestAddOwnerReferenceSkipsWhenMasterNotFoundYet verifies that a NotFound
+// error while looking up the master CR is handled silently — ownership will be
+// backfilled on the next reconcile after PropagateDefaultCR has run.
+func TestAddOwnerReferenceSkipsWhenMasterNotFoundYet(t *testing.T) {
+	const namespace = "test-ns"
+
+	cert := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]interface{}{
+				"name":      constant.CSCACertificate,
+				"namespace": namespace,
+			},
+		},
+	}
+	// Reconciling instance is from a different namespace; no master CR exists
+	// in the cert's namespace yet.
+	instance := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name:      constant.MasterCR,
+		Namespace: "op-ns",
+		UID:       types.UID("uid-op"),
+	}}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	bs := &Bootstrap{
+		Client:  fakeClient,
+		Reader:  fakeClient,
+		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
+	}
+
+	changed, err := bs.addOwnerReference(cert, instance)
+	assert.NoError(t, err, "NotFound must be silently skipped")
+	assert.False(t, changed, "no ownership change when master CR not yet present")
+	assert.Empty(t, cert.GetOwnerReferences())
+}
+
+// TestAddOwnerReferencePropagatesNonNotFoundError verifies that errors other
+// than NotFound (e.g. Forbidden, transient API errors) are returned so the
+// reconcile loop can retry instead of silently leaving ownership unset.
+func TestAddOwnerReferencePropagatesNonNotFoundError(t *testing.T) {
+	const namespace = "test-ns"
+
+	cert := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]interface{}{
+				"name":      constant.CSCACertificate,
+				"namespace": namespace,
+			},
+		},
+	}
+	instance := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name:      "im-common-service",
+		Namespace: namespace,
+		UID:       types.UID("uid-im"),
+	}}
+
+	forbiddenErr := k8serrors.NewForbidden(
+		apiv3.GroupVersion.WithResource("commonservices").GroupResource(),
+		constant.MasterCR,
+		fmt.Errorf("forbidden"),
+	)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return forbiddenErr
+			},
+		}).
+		Build()
+	bs := &Bootstrap{
+		Client:  fakeClient,
+		Reader:  fakeClient,
+		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
+	}
+
+	_, err := bs.addOwnerReference(cert, instance)
+	assert.Error(t, err, "non-NotFound errors must be propagated")
+	assert.Empty(t, cert.GetOwnerReferences(), "ownership must not be set on error")
 }
 
 

--- a/internal/controller/bootstrap/init_test.go
+++ b/internal/controller/bootstrap/init_test.go
@@ -909,6 +909,73 @@ func TestAddOwnerReferenceReplacesStaleCommonServiceUID(t *testing.T) {
 	}
 }
 
+// TestAddOwnerReferenceUsesOnlyMasterCRAsOwner covers the upgrade scenario
+// from https://github.ibm.com/IBMPrivateCloud/roadmap/issues/70051:
+// When a secondary CommonService CR (e.g. im-common-service) triggers
+// reconciliation, addOwnerReference must look up the master CR and record it
+// as the controller owner — never the secondary CR.
+func TestAddOwnerReferenceUsesOnlyMasterCRAsOwner(t *testing.T) {
+	const namespace = "test-ns"
+
+	// cs-ca-certificate currently owned by im-common-service (pre-upgrade state).
+	cert := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "cert-manager.io/v1",
+			"kind":       "Certificate",
+			"metadata": map[string]interface{}{
+				"name":      constant.CSCACertificate,
+				"namespace": namespace,
+			},
+		},
+	}
+	controller := true
+	cert.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion: constant.APIVersion,
+		Kind:       constant.KindCR,
+		Name:       "im-common-service",
+		UID:        types.UID("uid-im"),
+		Controller: &controller,
+	}})
+
+	// Master CR that must become the owner.
+	masterCS := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name:      constant.MasterCR,
+		Namespace: namespace,
+		UID:       types.UID("uid-master"),
+	}}
+	// Secondary CR that is being reconciled (not the master).
+	secondaryCS := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name:      "im-common-service",
+		Namespace: namespace,
+		UID:       types.UID("uid-im"),
+	}}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithRuntimeObjects(masterCS).
+		Build()
+	bs := &Bootstrap{
+		Client:  fakeClient,
+		Reader:  fakeClient,
+		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
+	}
+
+	// addOwnerReference is called with the secondary CR as the reconciling instance.
+	// It must fetch the master CR and use its UID, not secondaryCS.UID.
+	changed, err := bs.addOwnerReference(cert, secondaryCS)
+	assert.NoError(t, err)
+	assert.True(t, changed)
+	if assert.Len(t, cert.GetOwnerReferences(), 1) {
+		owner := cert.GetOwnerReferences()[0]
+		assert.Equal(t, constant.MasterCR, owner.Name, "owner name must be the master CR")
+		assert.Equal(t, types.UID("uid-master"), owner.UID, "owner UID must come from the master CR")
+		assert.NotNil(t, owner.Controller)
+		assert.True(t, *owner.Controller)
+	}
+}
+
+
+
 func TestShouldAddOwnerReferenceExcludesCSCACertificateSecret(t *testing.T) {
 	secret := &unstructured.Unstructured{Object: map[string]interface{}{ // pragma: allowlist secret
 		"apiVersion": "v1",

--- a/internal/controller/bootstrap/init_test.go
+++ b/internal/controller/bootstrap/init_test.go
@@ -24,6 +24,7 @@ import (
 
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -911,277 +912,115 @@ func TestAddOwnerReferenceReplacesStaleCommonServiceUID(t *testing.T) {
 	}
 }
 
-// TestAddOwnerReferenceMasterCRReplacesSecondaryOwner verifies that when
-// a1/common-service reconciles and a1/cs-ca-certificate is currently controlled
-// by a1/im-common-service, the master CR takes over ownership.  This is the
-// canonical failure case from issue #70051: the master CR reconciles first,
-// enters the fast path (name+namespace match), and must still be able to
-// displace the stale secondary-CR controller reference.
-// A second call verifies idempotency.
-func TestAddOwnerReferenceMasterCRReplacesSecondaryOwner(t *testing.T) {
-	const namespace = "a1"
-
-	cert := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "cert-manager.io/v1",
-			"kind":       "Certificate",
-			"metadata": map[string]interface{}{
-				"name":      constant.CSCACertificate,
-				"namespace": namespace,
-			},
-		},
-	}
-	controller := true
-	// Pre-upgrade state: im-common-service is the controller owner.
-	cert.SetOwnerReferences([]metav1.OwnerReference{{
-		APIVersion: constant.APIVersion,
-		Kind:       constant.KindCR,
-		Name:       "im-common-service",
-		UID:        types.UID("uid-im"),
-		Controller: &controller,
-	}})
-
-	masterCS := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
-		Name:      constant.MasterCR,
-		Namespace: namespace,
-		UID:       types.UID("uid-master"),
+func ownershipTestCR(namespace, name string, uid types.UID) *apiv3.CommonService {
+	return &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Namespace: namespace, Name: name, UID: uid,
 	}}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme.Scheme).
-		WithRuntimeObjects(masterCS).
-		Build()
-	bs := &Bootstrap{
-		Client:  fakeClient,
-		Reader:  fakeClient,
-		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
-	}
-
-	// First call: master CR reconciles and takes over from im-common-service.
-	changed, err := bs.addOwnerReference(cert, masterCS)
-	assert.NoError(t, err, "master CR must take over without error")
-	assert.True(t, changed)
-	if assert.Len(t, cert.GetOwnerReferences(), 1) {
-		owner := cert.GetOwnerReferences()[0]
-		assert.Equal(t, constant.MasterCR, owner.Name, "owner must be common-service")
-		assert.Equal(t, types.UID("uid-master"), owner.UID)
-		assert.NotNil(t, owner.Controller)
-		assert.True(t, *owner.Controller)
-	}
-
-	// Second call: ownership is already correct — must be idempotent.
-	changed, err = bs.addOwnerReference(cert, masterCS)
-	assert.NoError(t, err)
-	assert.False(t, changed, "second call must be idempotent")
-	assert.Len(t, cert.GetOwnerReferences(), 1)
 }
 
-// TestAddOwnerReferenceUsesOnlyMasterCRAsOwner covers the upgrade scenario
-// from https://github.ibm.com/IBMPrivateCloud/roadmap/issues/70051:
-// When a secondary CommonService CR (e.g. im-common-service) triggers
-// reconciliation, addOwnerReference must look up the master CR from obj's
-// namespace and record it as the controller owner — never the secondary CR.
-func TestAddOwnerReferenceUsesOnlyMasterCRAsOwner(t *testing.T) {
-	const namespace = "test-ns"
+func ownershipTestCertificate(namespace string) *unstructured.Unstructured {
+	cert := &unstructured.Unstructured{}
+	cert.SetAPIVersion("cert-manager.io/v1")
+	cert.SetKind("Certificate")
+	cert.SetNamespace(namespace)
+	cert.SetName(constant.CSCACertificate)
+	return cert
+}
 
-	// cs-ca-certificate currently owned by im-common-service (pre-upgrade state).
-	cert := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "cert-manager.io/v1",
-			"kind":       "Certificate",
-			"metadata": map[string]interface{}{
-				"name":      constant.CSCACertificate,
-				"namespace": namespace,
-			},
-		},
-	}
-	controller := true
-	cert.SetOwnerReferences([]metav1.OwnerReference{{
-		APIVersion: constant.APIVersion,
-		Kind:       constant.KindCR,
-		Name:       "im-common-service",
-		UID:        types.UID("uid-im"),
-		Controller: &controller,
-	}})
+func TestAddOwnerReferenceUsesLocalMaster(t *testing.T) {
+	for _, tc := range []struct {
+		name, reconcileNS, reconcileName string
+	}{
+		{"master first", "services", constant.MasterCR},
+		{"secondary first", "services", "im-common-service"},
+		{"split namespaces", "operators", constant.MasterCR},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			master := ownershipTestCR("services", constant.MasterCR, "local-master-uid")
+			instance := ownershipTestCR(tc.reconcileNS, tc.reconcileName, "other-uid")
+			if instance.Name == master.Name && instance.Namespace == master.Namespace {
+				instance = master
+			}
+			fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(master).Build()
+			bs := &Bootstrap{Reader: fc}
+			cert := ownershipTestCertificate("services")
+			controller := true
+			cert.SetOwnerReferences([]metav1.OwnerReference{{
+				APIVersion: constant.APIVersion, Kind: constant.KindCR,
+				Name: "im-common-service", UID: "im-uid", Controller: &controller,
+			}})
 
-	// Master CR that must become the owner.
-	masterCS := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
-		Name:      constant.MasterCR,
-		Namespace: namespace,
-		UID:       types.UID("uid-master"),
-	}}
-	// Secondary CR that is being reconciled (not the master).
-	secondaryCS := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
-		Name:      "im-common-service",
-		Namespace: namespace,
-		UID:       types.UID("uid-im"),
-	}}
+			changed, err := bs.addOwnerReference(cert, instance)
+			require.NoError(t, err)
+			require.True(t, changed)
+			require.Len(t, cert.GetOwnerReferences(), 1)
+			owner := cert.GetOwnerReferences()[0]
+			assert.Equal(t, master.Name, owner.Name)
+			assert.Equal(t, master.UID, owner.UID)
+			require.NotNil(t, owner.Controller)
+			assert.True(t, *owner.Controller)
 
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme.Scheme).
-		WithRuntimeObjects(masterCS).
-		Build()
-	bs := &Bootstrap{
-		Client:  fakeClient,
-		Reader:  fakeClient,
-		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
-	}
-
-	// addOwnerReference is called with the secondary CR as the reconciling instance.
-	// It must fetch the master CR from obj's namespace and use its UID.
-	changed, err := bs.addOwnerReference(cert, secondaryCS)
-	assert.NoError(t, err)
-	assert.True(t, changed)
-	if assert.Len(t, cert.GetOwnerReferences(), 1) {
-		owner := cert.GetOwnerReferences()[0]
-		assert.Equal(t, constant.MasterCR, owner.Name, "owner name must be the master CR")
-		assert.Equal(t, types.UID("uid-master"), owner.UID, "owner UID must come from the master CR")
-		assert.NotNil(t, owner.Controller)
-		assert.True(t, *owner.Controller)
+			changed, err = bs.addOwnerReference(cert, instance)
+			require.NoError(t, err)
+			assert.False(t, changed)
+			assert.Len(t, cert.GetOwnerReferences(), 1)
+		})
 	}
 }
 
-// TestAddOwnerReferenceSplitNamespace verifies the split operator/services
-// namespace topology.  The reconciling instance lives in the operator namespace
-// (op-ns/common-service) but cs-ca-certificate lives in the services namespace
-// (svc-ns).  addOwnerReference must look up the master CR in svc-ns, not op-ns.
-func TestAddOwnerReferenceSplitNamespace(t *testing.T) {
-	const (
-		opNs  = "op-ns"
-		svcNs = "svc-ns"
-	)
+func TestAddOwnerReferenceBackfillsAfterMasterCreated(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	bs := &Bootstrap{Client: fc, Reader: fc, Manager: &deploy.Manager{Client: fc, Reader: fc}}
+	instance := ownershipTestCR("operators", constant.MasterCR, "operator-uid")
+	cert := ownershipTestCertificate("services")
+	cert.SetAnnotations(map[string]string{"version": "0.0.1", "runtime": "preserve"})
+	require.NoError(t, fc.Create(context.Background(), cert))
+	// Use the production create/update path so the test checks persistence too.
+	desired := []byte(`apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cs-ca-certificate
+  namespace: services
+  annotations:
+    version: 0.0.1
+`)
+	require.NoError(t, bs.CreateOrUpdateFromYaml(desired, instance))
+	actual := ownershipTestCertificate("services")
+	key := client.ObjectKeyFromObject(actual)
+	require.NoError(t, fc.Get(context.Background(), key, actual))
+	assert.Empty(t, actual.GetOwnerReferences())
 
-	cert := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "cert-manager.io/v1",
-			"kind":       "Certificate",
-			"metadata": map[string]interface{}{
-				"name":      constant.CSCACertificate,
-				"namespace": svcNs,
-			},
-		},
-	}
-
-	// Master CR cloned into the services namespace by PropagateDefaultCR.
-	masterInSvcNs := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
-		Name:      constant.MasterCR,
-		Namespace: svcNs,
-		UID:       types.UID("uid-master-svc"),
-	}}
-	// The operator-ns master (the one being reconciled).
-	masterInOpNs := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
-		Name:      constant.MasterCR,
-		Namespace: opNs,
-		UID:       types.UID("uid-master-op"),
-	}}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme.Scheme).
-		WithRuntimeObjects(masterInSvcNs, masterInOpNs).
-		Build()
-	bs := &Bootstrap{
-		Client:  fakeClient,
-		Reader:  fakeClient,
-		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
-	}
-
-	changed, err := bs.addOwnerReference(cert, masterInOpNs)
-	assert.NoError(t, err)
-	assert.True(t, changed)
-	if assert.Len(t, cert.GetOwnerReferences(), 1) {
-		owner := cert.GetOwnerReferences()[0]
-		assert.Equal(t, constant.MasterCR, owner.Name)
-		assert.Equal(t, types.UID("uid-master-svc"), owner.UID,
-			"must use the master CR in the certificate's namespace (svc-ns), not op-ns")
-		assert.NotNil(t, owner.Controller)
-		assert.True(t, *owner.Controller)
-	}
+	master := ownershipTestCR("services", constant.MasterCR, "local-master-uid")
+	require.NoError(t, fc.Create(context.Background(), master))
+	// Simulate the next reconciliation triggered by the clone's create event.
+	require.NoError(t, bs.CreateOrUpdateFromYaml(desired, instance))
+	require.NoError(t, fc.Get(context.Background(), key, actual))
+	require.Len(t, actual.GetOwnerReferences(), 1)
+	assert.Equal(t, master.UID, actual.GetOwnerReferences()[0].UID)
+	assert.Equal(t, "preserve", actual.GetAnnotations()["runtime"])
 }
 
-// TestAddOwnerReferenceSkipsWhenMasterNotFoundYet verifies that a NotFound
-// error while looking up the master CR is handled silently — ownership will be
-// backfilled on the next reconcile after PropagateDefaultCR has run.
-func TestAddOwnerReferenceSkipsWhenMasterNotFoundYet(t *testing.T) {
-	const namespace = "test-ns"
-
-	cert := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "cert-manager.io/v1",
-			"kind":       "Certificate",
-			"metadata": map[string]interface{}{
-				"name":      constant.CSCACertificate,
-				"namespace": namespace,
-			},
-		},
+func TestAddOwnerReferencePropagatesLookupErrors(t *testing.T) {
+	for _, lookupErr := range []error{
+		k8serrors.NewForbidden(apiv3.GroupVersion.WithResource("commonservices").GroupResource(), constant.MasterCR, fmt.Errorf("denied")),
+		k8serrors.NewTimeoutError("API unavailable", 1),
+	} {
+		t.Run(lookupErr.Error(), func(t *testing.T) {
+			fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+						return lookupErr
+					},
+				}).Build()
+			cert := ownershipTestCertificate("services")
+			bs := &Bootstrap{Reader: fc}
+			changed, err := bs.addOwnerReference(cert, ownershipTestCR("services", "im-common-service", "im-uid"))
+			require.ErrorIs(t, err, lookupErr)
+			assert.False(t, changed)
+			assert.Empty(t, cert.GetOwnerReferences())
+		})
 	}
-	// Reconciling instance is from a different namespace; no master CR exists
-	// in the cert's namespace yet.
-	instance := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
-		Name:      constant.MasterCR,
-		Namespace: "op-ns",
-		UID:       types.UID("uid-op"),
-	}}
-
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).Build()
-	bs := &Bootstrap{
-		Client:  fakeClient,
-		Reader:  fakeClient,
-		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
-	}
-
-	changed, err := bs.addOwnerReference(cert, instance)
-	assert.NoError(t, err, "NotFound must be silently skipped")
-	assert.False(t, changed, "no ownership change when master CR not yet present")
-	assert.Empty(t, cert.GetOwnerReferences())
 }
-
-// TestAddOwnerReferencePropagatesNonNotFoundError verifies that errors other
-// than NotFound (e.g. Forbidden, transient API errors) are returned so the
-// reconcile loop can retry instead of silently leaving ownership unset.
-func TestAddOwnerReferencePropagatesNonNotFoundError(t *testing.T) {
-	const namespace = "test-ns"
-
-	cert := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "cert-manager.io/v1",
-			"kind":       "Certificate",
-			"metadata": map[string]interface{}{
-				"name":      constant.CSCACertificate,
-				"namespace": namespace,
-			},
-		},
-	}
-	instance := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
-		Name:      "im-common-service",
-		Namespace: namespace,
-		UID:       types.UID("uid-im"),
-	}}
-
-	forbiddenErr := k8serrors.NewForbidden(
-		apiv3.GroupVersion.WithResource("commonservices").GroupResource(),
-		constant.MasterCR,
-		fmt.Errorf("forbidden"),
-	)
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme.Scheme).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
-				return forbiddenErr
-			},
-		}).
-		Build()
-	bs := &Bootstrap{
-		Client:  fakeClient,
-		Reader:  fakeClient,
-		Manager: &deploy.Manager{Client: fakeClient, Reader: fakeClient},
-	}
-
-	_, err := bs.addOwnerReference(cert, instance)
-	assert.Error(t, err, "non-NotFound errors must be propagated")
-	assert.Empty(t, cert.GetOwnerReferences(), "ownership must not be set on error")
-}
-
-
 
 func TestShouldAddOwnerReferenceExcludesCSCACertificateSecret(t *testing.T) {
 	secret := &unstructured.Unstructured{Object: map[string]interface{}{ // pragma: allowlist secret

--- a/internal/controller/bootstrap/init_test.go
+++ b/internal/controller/bootstrap/init_test.go
@@ -800,7 +800,7 @@ spec:
   secretName: cs-ca-certificate-secret
 `)
 
-	err := bootstrap.CreateOrUpdateFromYaml(desired, instance)
+	err := bootstrap.CreateOrUpdateFromYaml(context.Background(), desired, instance)
 	assert.NoError(t, err)
 
 	actual := &unstructured.Unstructured{}
@@ -822,7 +822,7 @@ spec:
 	assert.Equal(t, "keep-me", runtimeField)
 
 	// A second reconciliation must be idempotent and must not duplicate owners.
-	err = bootstrap.CreateOrUpdateFromYaml(desired, instance)
+	err = bootstrap.CreateOrUpdateFromYaml(context.Background(), desired, instance)
 	assert.NoError(t, err)
 	err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: constant.CSCACertificate, Namespace: namespace}, actual)
 	assert.NoError(t, err)
@@ -864,7 +864,7 @@ data:
   runtime: from-template
 `)
 
-	assert.NoError(t, bootstrap.CreateOrUpdateFromYaml(desired, instance))
+	assert.NoError(t, bootstrap.CreateOrUpdateFromYaml(context.Background(), desired, instance))
 
 	actual := &unstructured.Unstructured{}
 	actual.SetAPIVersion("v1")
@@ -904,7 +904,7 @@ func TestAddOwnerReferenceReplacesStaleCommonServiceUID(t *testing.T) {
 		UID:       types.UID("new-uid"),
 	}}
 
-	changed, err := (&Bootstrap{}).addOwnerReference(obj, instance)
+	changed, err := (&Bootstrap{}).addOwnerReference(context.Background(), obj, instance)
 	assert.NoError(t, err)
 	assert.True(t, changed)
 	if assert.Len(t, obj.GetOwnerReferences(), 1) {
@@ -968,7 +968,7 @@ func TestAddOwnerReferenceUsesLocalMaster(t *testing.T) {
 					Name: "im-common-service", UID: "im-uid", Controller: &controller,
 				}})
 
-				changed, err := bs.addOwnerReference(testObj, instance)
+				changed, err := bs.addOwnerReference(context.Background(), testObj, instance)
 				require.NoError(t, err)
 				require.True(t, changed)
 				require.Len(t, testObj.GetOwnerReferences(), 1)
@@ -978,7 +978,7 @@ func TestAddOwnerReferenceUsesLocalMaster(t *testing.T) {
 				require.NotNil(t, owner.Controller)
 				assert.True(t, *owner.Controller)
 
-				changed, err = bs.addOwnerReference(testObj, instance)
+				changed, err = bs.addOwnerReference(context.Background(), testObj, instance)
 				require.NoError(t, err)
 				assert.False(t, changed)
 				assert.Len(t, testObj.GetOwnerReferences(), 1)
@@ -1019,7 +1019,7 @@ metadata:
 `)
 			}
 
-			require.NoError(t, bs.CreateOrUpdateFromYaml(desired, instance))
+			require.NoError(t, bs.CreateOrUpdateFromYaml(context.Background(), desired, instance))
 			actual := res("services")
 			key := client.ObjectKeyFromObject(actual)
 			require.NoError(t, fc.Get(context.Background(), key, actual))
@@ -1028,7 +1028,7 @@ metadata:
 			master := ownershipTestCR("services", constant.MasterCR, "local-master-uid")
 			require.NoError(t, fc.Create(context.Background(), master))
 			// Simulate the next reconciliation triggered by the clone's create event.
-			require.NoError(t, bs.CreateOrUpdateFromYaml(desired, instance))
+			require.NoError(t, bs.CreateOrUpdateFromYaml(context.Background(), desired, instance))
 			require.NoError(t, fc.Get(context.Background(), key, actual))
 			require.Len(t, actual.GetOwnerReferences(), 1)
 			assert.Equal(t, master.UID, actual.GetOwnerReferences()[0].UID)
@@ -1056,7 +1056,7 @@ func TestAddOwnerReferencePropagatesLookupErrors(t *testing.T) {
 					}).Build()
 				testObj := res("services")
 				bs := &Bootstrap{Reader: fc}
-				changed, err := bs.addOwnerReference(testObj, ownershipTestCR("services", "im-common-service", "im-uid"))
+				changed, err := bs.addOwnerReference(context.Background(), testObj, ownershipTestCR("services", "im-common-service", "im-uid"))
 				require.ErrorIs(t, err, lookupErr)
 				assert.False(t, changed)
 				assert.Empty(t, testObj.GetOwnerReferences())
@@ -1080,4 +1080,49 @@ func TestShouldAddOwnerReferenceExcludesCSCACertificateSecret(t *testing.T) {
 	}}
 
 	assert.False(t, (&Bootstrap{}).shouldAddOwnerReference(secret, instance))
+}
+
+// Check context values and cancellation through the template/update/owner path.
+func TestOwnerLookupReceivesCallerContext(t *testing.T) {
+	type traceKey struct{}
+	for _, resource := range []ownershipTestResource{ownershipTestCertificate, ownershipTestConfigMap} {
+		for _, cancelled := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/cancelled=%t", resource("services").GetKind(), cancelled), func(t *testing.T) {
+				callerCtx, cancel := context.WithCancel(context.WithValue(context.Background(), traceKey{}, "trace-value"))
+				defer cancel()
+				if cancelled {
+					cancel()
+				}
+				master := ownershipTestCR("services", constant.MasterCR, "master-uid")
+				obj := resource("services")
+				obj.SetAnnotations(map[string]string{"version": "0.0.1"})
+				lookups := 0
+				fc := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(master, obj).
+					WithInterceptorFuncs(interceptor.Funcs{
+						Get: func(gotCtx context.Context, c client.WithWatch, key client.ObjectKey, target client.Object, opts ...client.GetOption) error {
+							if _, ok := target.(*apiv3.CommonService); ok {
+								lookups++
+								require.Equal(t, callerCtx, gotCtx)
+								assert.Equal(t, "trace-value", gotCtx.Value(traceKey{}))
+								if err := gotCtx.Err(); err != nil {
+									return err
+								}
+							}
+							return c.Get(gotCtx, key, target, opts...)
+						},
+					}).Build()
+				bs := &Bootstrap{Client: fc, Reader: fc, Manager: &deploy.Manager{Client: fc, Reader: fc}}
+				template := fmt.Sprintf("apiVersion: %s\nkind: %s\nmetadata:\n  name: %s\n  namespace: services\n  annotations:\n    version: 0.0.1\n",
+					obj.GetAPIVersion(), obj.GetKind(), obj.GetName())
+				err := bs.renderTemplate(callerCtx, template, nil, ownershipTestCR("operators", constant.MasterCR, "operator-uid"))
+				if cancelled {
+					require.ErrorIs(t, err, context.Canceled)
+					assert.Equal(t, 1, lookups)
+				} else {
+					require.NoError(t, err)
+					assert.Equal(t, 2, lookups, "desired and existing objects must both use the caller context")
+				}
+			})
+		}
+	}
 }

--- a/internal/controller/common/ownerreference.go
+++ b/internal/controller/common/ownerreference.go
@@ -27,6 +27,11 @@ import (
 // EnsureControllerOwnerReference ensures that object has exactly one reference
 // to owner and that the reference is controlling. Existing non-controller owner
 // references are preserved.
+//
+// When the existing controller is a different instance of the same Kind (e.g.
+// another CommonService CR), the stale reference is replaced by owner.
+// Callers are responsible for only ever passing the designated master CR as
+// owner — see addOwnerReference which enforces this invariant.
 func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerReference) (bool, error) {
 	owner.Controller = pointer.Bool(true)
 	owner.BlockOwnerDeletion = pointer.Bool(true)
@@ -53,6 +58,14 @@ func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerRefe
 		}
 
 		if ref.Controller != nil && *ref.Controller {
+			// Allow the master CR to take over when the resource is currently
+			// controlled by a different instance of the same Kind.  This handles
+			// the upgrade path where a secondary CommonService CR (e.g.
+			// im-common-service) previously held the controller reference.
+			if ref.APIVersion == owner.APIVersion && ref.Kind == owner.Kind {
+				changed = true
+				continue
+			}
 			return false, fmt.Errorf("cannot set controller owner reference on %s/%s: object is already controlled by %s %s",
 				object.GetNamespace(), object.GetName(), ref.Kind, ref.Name)
 		}

--- a/internal/controller/common/ownerreference.go
+++ b/internal/controller/common/ownerreference.go
@@ -28,9 +28,12 @@ import (
 // to owner and that the reference is controlling. Existing non-controller owner
 // references are preserved.
 //
-// When the existing controller is a different instance of the same Kind (e.g.
-// another CommonService CR), the stale reference is replaced by owner.
-func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerReference) (bool, error) {
+// When replaceExistingSameKind is true and the object is currently controlled
+// by a different instance of the same APIVersion+Kind, that stale reference is
+// replaced by owner.  Callers should only pass true when owner is the
+// designated master CR; passing false retains the strict single-controller
+// invariant.
+func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerReference, replaceExistingSameKind bool) (bool, error) {
 	owner.Controller = pointer.Bool(true)
 	owner.BlockOwnerDeletion = pointer.Bool(true)
 
@@ -56,9 +59,10 @@ func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerRefe
 		}
 
 		if ref.Controller != nil && *ref.Controller {
-			// Allow the master CR to take over when the resource is currently
-			// controlled by a different instance of the same Kind.
-			if ref.APIVersion == owner.APIVersion && ref.Kind == owner.Kind {
+			if replaceExistingSameKind &&
+				ref.APIVersion == owner.APIVersion && ref.Kind == owner.Kind {
+				// Drop the stale same-Kind controller so owner can take over.
+				// This is only enabled for the designated master CR.
 				changed = true
 				continue
 			}

--- a/internal/controller/common/ownerreference.go
+++ b/internal/controller/common/ownerreference.go
@@ -30,8 +30,6 @@ import (
 //
 // When the existing controller is a different instance of the same Kind (e.g.
 // another CommonService CR), the stale reference is replaced by owner.
-// Callers are responsible for only ever passing the designated master CR as
-// owner — see addOwnerReference which enforces this invariant.
 func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerReference) (bool, error) {
 	owner.Controller = pointer.Bool(true)
 	owner.BlockOwnerDeletion = pointer.Bool(true)
@@ -59,9 +57,7 @@ func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerRefe
 
 		if ref.Controller != nil && *ref.Controller {
 			// Allow the master CR to take over when the resource is currently
-			// controlled by a different instance of the same Kind.  This handles
-			// the upgrade path where a secondary CommonService CR (e.g.
-			// im-common-service) previously held the controller reference.
+			// controlled by a different instance of the same Kind.
 			if ref.APIVersion == owner.APIVersion && ref.Kind == owner.Kind {
 				changed = true
 				continue

--- a/internal/controller/common/ownerreference.go
+++ b/internal/controller/common/ownerreference.go
@@ -19,6 +19,8 @@ package common
 import (
 	"fmt"
 
+	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/constant"
+
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -28,14 +30,14 @@ import (
 // to owner and that the reference is controlling. Existing non-controller owner
 // references are preserved.
 //
-// When replaceExistingSameKind is true and the object is currently controlled
-// by a different instance of the same APIVersion+Kind, that stale reference is
-// replaced by owner.  Callers should only pass true when owner is the
-// designated master CR; passing false retains the strict single-controller
-// invariant.
-func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerReference, replaceExistingSameKind bool) (bool, error) {
+// Only CommonService/common-service may replace a different CommonService
+// controller. Unrelated controller references are rejected.
+func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerReference) (bool, error) {
 	owner.Controller = pointer.Bool(true)
 	owner.BlockOwnerDeletion = pointer.Bool(true)
+
+	isMasterCommonService := owner.APIVersion == constant.APIVersion &&
+		owner.Kind == constant.KindCR && owner.Name == constant.MasterCR
 
 	existing := object.GetOwnerReferences()
 	updated := make([]metav1.OwnerReference, 0, len(existing)+1)
@@ -59,7 +61,7 @@ func EnsureControllerOwnerReference(object metav1.Object, owner metav1.OwnerRefe
 		}
 
 		if ref.Controller != nil && *ref.Controller {
-			if replaceExistingSameKind &&
+			if isMasterCommonService &&
 				ref.APIVersion == owner.APIVersion && ref.Kind == owner.Kind {
 				// Drop the stale same-Kind controller so owner can take over.
 				// This is only enabled for the designated master CR.

--- a/internal/controller/common/ownerreference_test.go
+++ b/internal/controller/common/ownerreference_test.go
@@ -49,7 +49,7 @@ func TestEnsureControllerOwnerReference_NoExisting(t *testing.T) {
 		UID:        types.UID("uid-master"),
 	}
 
-	changed, err := EnsureControllerOwnerReference(obj, owner, false)
+	changed, err := EnsureControllerOwnerReference(obj, owner)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	refs := obj.GetOwnerReferences()
@@ -79,16 +79,13 @@ func TestEnsureControllerOwnerReference_Idempotent(t *testing.T) {
 		BlockOwnerDeletion: pointer.Bool(true),
 	}})
 
-	changed, err := EnsureControllerOwnerReference(obj, owner, false)
+	changed, err := EnsureControllerOwnerReference(obj, owner)
 	require.NoError(t, err)
 	assert.False(t, changed)
 	assert.Len(t, obj.GetOwnerReferences(), 1)
 }
 
-// TestEnsureControllerOwnerReference_TakeoverFromSameKind verifies that when
-// replaceExistingSameKind is true and the object is already controlled by a
-// different instance of the same Kind, the stale reference is replaced.
-// This models the upgrade path: im-common-service → common-service.
+// Test migration from an old secondary CR to the designated common-service CR.
 func TestEnsureControllerOwnerReference_TakeoverFromSameKind(t *testing.T) {
 	obj := &unstructured.Unstructured{}
 	obj.SetNamespace("a1")
@@ -104,7 +101,7 @@ func TestEnsureControllerOwnerReference_TakeoverFromSameKind(t *testing.T) {
 		UID:        types.UID("uid-master"),
 	}
 
-	changed, err := EnsureControllerOwnerReference(obj, owner, true)
+	changed, err := EnsureControllerOwnerReference(obj, owner)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	refs := obj.GetOwnerReferences()
@@ -114,30 +111,28 @@ func TestEnsureControllerOwnerReference_TakeoverFromSameKind(t *testing.T) {
 	assert.True(t, *refs[0].Controller)
 }
 
-// TestEnsureControllerOwnerReference_TakeoverBlockedWithoutFlag verifies that
-// the same-Kind takeover is rejected when replaceExistingSameKind is false,
-// i.e. when the caller is not the designated master CR.
-func TestEnsureControllerOwnerReference_TakeoverBlockedWithoutFlag(t *testing.T) {
+// A secondary CommonService cannot take ownership from the master CR.
+func TestEnsureControllerOwnerReference_RejectsSecondaryTakeover(t *testing.T) {
 	obj := &unstructured.Unstructured{}
 	obj.SetNamespace("a1")
 	obj.SetName("cs-ca-certificate")
 	obj.SetOwnerReferences([]metav1.OwnerReference{
-		newRef("operator.ibm.com/v3", "CommonService", "im-common-service", "uid-im", true),
+		newRef("operator.ibm.com/v3", "CommonService", "common-service", "uid-master", true),
 	})
 
 	owner := metav1.OwnerReference{
 		APIVersion: "operator.ibm.com/v3",
 		Kind:       "CommonService",
-		Name:       "common-service",
-		UID:        types.UID("uid-master"),
+		Name:       "im-common-service",
+		UID:        types.UID("uid-im"),
 	}
 
-	_, err := EnsureControllerOwnerReference(obj, owner, false)
-	require.Error(t, err, "same-Kind takeover must be rejected when replaceExistingSameKind=false")
+	_, err := EnsureControllerOwnerReference(obj, owner)
+	require.Error(t, err, "secondary CommonService must not take over the master owner")
 	// Object must be unchanged.
 	refs := obj.GetOwnerReferences()
 	require.Len(t, refs, 1)
-	assert.Equal(t, "im-common-service", refs[0].Name, "stale ref must not have been removed")
+	assert.Equal(t, "common-service", refs[0].Name, "master owner must remain unchanged")
 }
 
 func TestEnsureControllerOwnerReference_RejectsUnrelatedController(t *testing.T) {
@@ -156,6 +151,26 @@ func TestEnsureControllerOwnerReference_RejectsUnrelatedController(t *testing.T)
 		UID:        types.UID("uid-master"),
 	}
 
-	_, err := EnsureControllerOwnerReference(obj, owner, true)
-	assert.Error(t, err, "unrelated-Kind controllers must always be rejected regardless of flag")
+	_, err := EnsureControllerOwnerReference(obj, owner)
+	assert.Error(t, err, "unrelated-Kind controllers must always be rejected")
+}
+
+func TestEnsureControllerOwnerReference_RejectsOtherSameKindTakeovers(t *testing.T) {
+	for _, tc := range []struct{ apiVersion, kind, name string }{
+		{"apps/v1", "Deployment", "common-service"},
+		{"example.com/v3", "CommonService", "common-service"},
+		{"operator.ibm.com/v3", "CommonService", "im-common-service"},
+	} {
+		t.Run(tc.apiVersion+"/"+tc.kind+"/"+tc.name, func(t *testing.T) {
+			obj := &unstructured.Unstructured{}
+			obj.SetName("resource")
+			obj.SetNamespace("ns")
+			oldRefs := []metav1.OwnerReference{newRef(tc.apiVersion, tc.kind, "previous-owner", "old-uid", true)}
+			obj.SetOwnerReferences(oldRefs)
+			changed, err := EnsureControllerOwnerReference(obj, newRef(tc.apiVersion, tc.kind, tc.name, "new-uid", true))
+			require.Error(t, err)
+			assert.False(t, changed)
+			assert.Equal(t, oldRefs, obj.GetOwnerReferences())
+		})
+	}
 }

--- a/internal/controller/common/ownerreference_test.go
+++ b/internal/controller/common/ownerreference_test.go
@@ -49,7 +49,7 @@ func TestEnsureControllerOwnerReference_NoExisting(t *testing.T) {
 		UID:        types.UID("uid-master"),
 	}
 
-	changed, err := EnsureControllerOwnerReference(obj, owner)
+	changed, err := EnsureControllerOwnerReference(obj, owner, false)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	refs := obj.GetOwnerReferences()
@@ -79,18 +79,16 @@ func TestEnsureControllerOwnerReference_Idempotent(t *testing.T) {
 		BlockOwnerDeletion: pointer.Bool(true),
 	}})
 
-	changed, err := EnsureControllerOwnerReference(obj, owner)
+	changed, err := EnsureControllerOwnerReference(obj, owner, false)
 	require.NoError(t, err)
 	assert.False(t, changed)
 	assert.Len(t, obj.GetOwnerReferences(), 1)
 }
 
 // TestEnsureControllerOwnerReference_TakeoverFromSameKind verifies that when
-// a resource is already controlled by a different instance of the same Kind
-// (e.g. im-common-service → common-service), the stale reference is dropped
-// and the new owner takes over without error.
-// addOwnerReference enforces that only the master CR is ever passed as owner,
-// so this takeover always moves ownership to the right place.
+// replaceExistingSameKind is true and the object is already controlled by a
+// different instance of the same Kind, the stale reference is replaced.
+// This models the upgrade path: im-common-service → common-service.
 func TestEnsureControllerOwnerReference_TakeoverFromSameKind(t *testing.T) {
 	obj := &unstructured.Unstructured{}
 	obj.SetNamespace("a1")
@@ -106,7 +104,7 @@ func TestEnsureControllerOwnerReference_TakeoverFromSameKind(t *testing.T) {
 		UID:        types.UID("uid-master"),
 	}
 
-	changed, err := EnsureControllerOwnerReference(obj, owner)
+	changed, err := EnsureControllerOwnerReference(obj, owner, true)
 	require.NoError(t, err)
 	assert.True(t, changed)
 	refs := obj.GetOwnerReferences()
@@ -114,6 +112,32 @@ func TestEnsureControllerOwnerReference_TakeoverFromSameKind(t *testing.T) {
 	assert.Equal(t, types.UID("uid-master"), refs[0].UID)
 	assert.Equal(t, "common-service", refs[0].Name)
 	assert.True(t, *refs[0].Controller)
+}
+
+// TestEnsureControllerOwnerReference_TakeoverBlockedWithoutFlag verifies that
+// the same-Kind takeover is rejected when replaceExistingSameKind is false,
+// i.e. when the caller is not the designated master CR.
+func TestEnsureControllerOwnerReference_TakeoverBlockedWithoutFlag(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetNamespace("a1")
+	obj.SetName("cs-ca-certificate")
+	obj.SetOwnerReferences([]metav1.OwnerReference{
+		newRef("operator.ibm.com/v3", "CommonService", "im-common-service", "uid-im", true),
+	})
+
+	owner := metav1.OwnerReference{
+		APIVersion: "operator.ibm.com/v3",
+		Kind:       "CommonService",
+		Name:       "common-service",
+		UID:        types.UID("uid-master"),
+	}
+
+	_, err := EnsureControllerOwnerReference(obj, owner, false)
+	require.Error(t, err, "same-Kind takeover must be rejected when replaceExistingSameKind=false")
+	// Object must be unchanged.
+	refs := obj.GetOwnerReferences()
+	require.Len(t, refs, 1)
+	assert.Equal(t, "im-common-service", refs[0].Name, "stale ref must not have been removed")
 }
 
 func TestEnsureControllerOwnerReference_RejectsUnrelatedController(t *testing.T) {
@@ -132,6 +156,6 @@ func TestEnsureControllerOwnerReference_RejectsUnrelatedController(t *testing.T)
 		UID:        types.UID("uid-master"),
 	}
 
-	_, err := EnsureControllerOwnerReference(obj, owner)
-	assert.Error(t, err, "should not allow takeover from an unrelated controller Kind")
+	_, err := EnsureControllerOwnerReference(obj, owner, true)
+	assert.Error(t, err, "unrelated-Kind controllers must always be rejected regardless of flag")
 }

--- a/internal/controller/common/ownerreference_test.go
+++ b/internal/controller/common/ownerreference_test.go
@@ -1,0 +1,137 @@
+//
+// Copyright 2026 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+)
+
+func newRef(apiVersion, kind, name string, uid types.UID, controller bool) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Name:       name,
+		UID:        uid,
+		Controller: pointer.Bool(controller),
+	}
+}
+
+func TestEnsureControllerOwnerReference_NoExisting(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetNamespace("ns")
+	obj.SetName("cert")
+
+	owner := metav1.OwnerReference{
+		APIVersion: "operator.ibm.com/v3",
+		Kind:       "CommonService",
+		Name:       "common-service",
+		UID:        types.UID("uid-master"),
+	}
+
+	changed, err := EnsureControllerOwnerReference(obj, owner)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	refs := obj.GetOwnerReferences()
+	require.Len(t, refs, 1)
+	assert.Equal(t, types.UID("uid-master"), refs[0].UID)
+	assert.True(t, *refs[0].Controller)
+}
+
+func TestEnsureControllerOwnerReference_Idempotent(t *testing.T) {
+	owner := metav1.OwnerReference{
+		APIVersion: "operator.ibm.com/v3",
+		Kind:       "CommonService",
+		Name:       "common-service",
+		UID:        types.UID("uid-master"),
+	}
+	obj := &unstructured.Unstructured{}
+	obj.SetNamespace("ns")
+	obj.SetName("cert")
+	// Pre-set with both Controller and BlockOwnerDeletion as the function would
+	// have written them on a previous reconcile.
+	obj.SetOwnerReferences([]metav1.OwnerReference{{
+		APIVersion:         "operator.ibm.com/v3",
+		Kind:               "CommonService",
+		Name:               "common-service",
+		UID:                types.UID("uid-master"),
+		Controller:         pointer.Bool(true),
+		BlockOwnerDeletion: pointer.Bool(true),
+	}})
+
+	changed, err := EnsureControllerOwnerReference(obj, owner)
+	require.NoError(t, err)
+	assert.False(t, changed)
+	assert.Len(t, obj.GetOwnerReferences(), 1)
+}
+
+// TestEnsureControllerOwnerReference_TakeoverFromSameKind verifies that when
+// a resource is already controlled by a different instance of the same Kind
+// (e.g. im-common-service → common-service), the stale reference is dropped
+// and the new owner takes over without error.
+// addOwnerReference enforces that only the master CR is ever passed as owner,
+// so this takeover always moves ownership to the right place.
+func TestEnsureControllerOwnerReference_TakeoverFromSameKind(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetNamespace("a1")
+	obj.SetName("cs-ca-certificate")
+	obj.SetOwnerReferences([]metav1.OwnerReference{
+		newRef("operator.ibm.com/v3", "CommonService", "im-common-service", "uid-im", true),
+	})
+
+	owner := metav1.OwnerReference{
+		APIVersion: "operator.ibm.com/v3",
+		Kind:       "CommonService",
+		Name:       "common-service",
+		UID:        types.UID("uid-master"),
+	}
+
+	changed, err := EnsureControllerOwnerReference(obj, owner)
+	require.NoError(t, err)
+	assert.True(t, changed)
+	refs := obj.GetOwnerReferences()
+	require.Len(t, refs, 1, "stale im-common-service ref must be removed")
+	assert.Equal(t, types.UID("uid-master"), refs[0].UID)
+	assert.Equal(t, "common-service", refs[0].Name)
+	assert.True(t, *refs[0].Controller)
+}
+
+func TestEnsureControllerOwnerReference_RejectsUnrelatedController(t *testing.T) {
+	obj := &unstructured.Unstructured{}
+	obj.SetNamespace("ns")
+	obj.SetName("cert")
+	// Owned by a completely different Kind.
+	obj.SetOwnerReferences([]metav1.OwnerReference{
+		newRef("apps/v1", "Deployment", "my-deploy", "uid-deploy", true),
+	})
+
+	owner := metav1.OwnerReference{
+		APIVersion: "operator.ibm.com/v3",
+		Kind:       "CommonService",
+		Name:       "common-service",
+		UID:        types.UID("uid-master"),
+	}
+
+	_, err := EnsureControllerOwnerReference(obj, owner)
+	assert.Error(t, err, "should not allow takeover from an unrelated controller Kind")
+}

--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -75,7 +75,7 @@ func (r *CommonServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				return ctrl.Result{}, err
 			}
 			// Generate Issuer and Certificate CR
-			if err := r.Bootstrap.DeployCertManagerCR(instance); err != nil {
+			if err := r.Bootstrap.DeployCertManagerCR(ctx, instance); err != nil {
 				return ctrl.Result{}, err
 			}
 			klog.Infof("Finished reconciling to delete CommonService: %s/%s", req.NamespacedName.Namespace, req.NamespacedName.Name)
@@ -325,7 +325,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 
 // deployCertManagerCR preserves the deployment error even if updating phase fails.
 func (r *CommonServiceReconciler) deployCertManagerCR(ctx context.Context, instance *apiv3.CommonService) error {
-	if err := r.Bootstrap.DeployCertManagerCR(instance); err != nil {
+	if err := r.Bootstrap.DeployCertManagerCR(ctx, instance); err != nil {
 		klog.Errorf("Failed to deploy cert manager CRs: %v", err)
 		if phaseErr := r.updatePhase(ctx, instance, apiv3.CRFailed); phaseErr != nil {
 			klog.Error(phaseErr)
@@ -367,7 +367,7 @@ func (r *CommonServiceReconciler) ReconcileGeneralCR(ctx context.Context, instan
 	}
 
 	// Generate Issuer and Certificate CR
-	if err := r.Bootstrap.DeployCertManagerCR(instance); err != nil {
+	if err := r.Bootstrap.DeployCertManagerCR(ctx, instance); err != nil {
 		klog.Errorf("Failed to deploy cert manager CRs: %v", err)
 		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
 			klog.Error(err)

--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -220,9 +220,10 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 	}
 
 	if !typeCorrect {
-		klog.Error("Cluster type specificed in the ibm-cpp-config isn't correct")
-		if statusErr = r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
-			klog.Error(statusErr)
+		statusErr = fmt.Errorf("cluster type specified in the ibm-cpp-config isn't correct")
+		klog.Error(statusErr)
+		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
+			klog.Error(err)
 		}
 		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		return ctrl.Result{}, statusErr
@@ -268,8 +269,8 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 	// Generate Issuer and Certificate CR
 	if statusErr = r.Bootstrap.DeployCertManagerCR(instance); statusErr != nil {
 		klog.Errorf("Failed to deploy cert manager CRs: %v", statusErr)
-		if statusErr = r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
-			klog.Error(statusErr)
+		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
+			klog.Error(err)
 		}
 		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		return ctrl.Result{}, statusErr

--- a/internal/controller/commonservice_controller.go
+++ b/internal/controller/commonservice_controller.go
@@ -267,11 +267,7 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 	}
 
 	// Generate Issuer and Certificate CR
-	if statusErr = r.Bootstrap.DeployCertManagerCR(instance); statusErr != nil {
-		klog.Errorf("Failed to deploy cert manager CRs: %v", statusErr)
-		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
-			klog.Error(err)
-		}
+	if statusErr = r.deployCertManagerCR(ctx, instance); statusErr != nil {
 		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		return ctrl.Result{}, statusErr
 	}
@@ -325,6 +321,18 @@ func (r *CommonServiceReconciler) ReconcileMasterCR(ctx context.Context, instanc
 
 	klog.Infof("Finished reconciling CommonService: %s/%s", instance.Namespace, instance.Name)
 	return ctrl.Result{}, nil
+}
+
+// deployCertManagerCR preserves the deployment error even if updating phase fails.
+func (r *CommonServiceReconciler) deployCertManagerCR(ctx context.Context, instance *apiv3.CommonService) error {
+	if err := r.Bootstrap.DeployCertManagerCR(instance); err != nil {
+		klog.Errorf("Failed to deploy cert manager CRs: %v", err)
+		if phaseErr := r.updatePhase(ctx, instance, apiv3.CRFailed); phaseErr != nil {
+			klog.Error(phaseErr)
+		}
+		return err
+	}
+	return nil
 }
 
 // ReconcileGeneralCR is for setting the OperandConfig

--- a/internal/controller/no_olm_commonservice_controller.go
+++ b/internal/controller/no_olm_commonservice_controller.go
@@ -94,9 +94,10 @@ func (r *CommonServiceReconciler) ReconcileNoOLMMasterCR(ctx context.Context, in
 	}
 
 	if !typeCorrect {
-		klog.Error("Cluster type specificed in the ibm-cpp-config isn't correct")
-		if statusErr = r.updatePhase(ctx, instance, apiv3.CRFailed); statusErr != nil {
-			klog.Error(statusErr)
+		statusErr = fmt.Errorf("cluster type specified in the ibm-cpp-config isn't correct")
+		klog.Error(statusErr)
+		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
+			klog.Error(err)
 		}
 		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, statusErr)
 		return ctrl.Result{}, statusErr

--- a/internal/controller/no_olm_commonservice_controller.go
+++ b/internal/controller/no_olm_commonservice_controller.go
@@ -171,7 +171,7 @@ func (r *CommonServiceReconciler) ReconcileNoOLMMasterCR(ctx context.Context, in
 	}
 
 	// deploy Cert Manager CR
-	if err := r.Bootstrap.DeployCertManagerCR(instance); err != nil {
+	if err := r.Bootstrap.DeployCertManagerCR(ctx, instance); err != nil {
 		klog.Errorf("Fail to reconcile %s/%s: %v", instance.Namespace, instance.Name, err)
 		return ctrl.Result{}, err
 	}
@@ -280,7 +280,7 @@ func (r *CommonServiceReconciler) ReconcileNoOLMGeneralCR(ctx context.Context, i
 	}
 
 	// Generate Issuer and Certificate CR
-	if err := r.Bootstrap.DeployCertManagerCR(instance); err != nil {
+	if err := r.Bootstrap.DeployCertManagerCR(ctx, instance); err != nil {
 		klog.Errorf("Failed to deploy cert manager CRs: %v", err)
 		if err := r.updatePhase(ctx, instance, apiv3.CRFailed); err != nil {
 			klog.Error(err)

--- a/internal/controller/statuserr_test.go
+++ b/internal/controller/statuserr_test.go
@@ -16,183 +16,118 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 
-	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/bootstrap"
+	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/constant"
+	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
-	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/bootstrap"
-	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
-func init() {
-	_ = olmv1alpha1.AddToScheme(scheme.Scheme)
-	_ = odlm.AddToScheme(scheme.Scheme)
-	_ = apiv3.AddToScheme(scheme.Scheme)
+type statusTestTransport func(*http.Request) (*http.Response, error)
+
+func (f statusTestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
-// minimalAPIServer returns a *httptest.Server that answers Kubernetes discovery
-// requests with enough structure to make the client library happy but reports
-// no API groups (so isOpenShiftCluster returns false).  All other requests
-// return 404 so that CheckCRD and similar helpers fail gracefully.
-func minimalAPIServer(t *testing.T) *httptest.Server {
+func newStatusTestReconciler(t *testing.T, transport http.RoundTripper, hooks interceptor.Funcs) (*CommonServiceReconciler, *apiv3.CommonService) {
 	t.Helper()
-	mux := http.NewServeMux()
-
-	// /api — core group version list
-	mux.HandleFunc("/api", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(metav1.APIVersions{TypeMeta: metav1.TypeMeta{
-			Kind:       "APIVersions",
-			APIVersion: "v1",
-		}, Versions: []string{"v1"}})
-	})
-	// /apis — empty group list → isOpenShiftCluster returns false
-	mux.HandleFunc("/apis", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(metav1.APIGroupList{TypeMeta: metav1.TypeMeta{
-			Kind:       "APIGroupList",
-			APIVersion: "v1",
-		}})
-	})
-	// Everything else: 404
-	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		http.NotFound(w, nil)
-	})
-
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-	return srv
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, apiv3.AddToScheme(s))
+	require.NoError(t, odlm.AddToScheme(s))
+	instance := &apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name: constant.MasterCR, Namespace: "test-ns", UID: "cs-uid",
+	}}
+	fc := fake.NewClientBuilder().WithScheme(s).WithStatusSubresource(instance).
+		WithObjects(instance, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: instance.Namespace}}).
+		WithInterceptorFuncs(hooks).Build()
+	require.NoError(t, fc.Get(context.Background(), client.ObjectKeyFromObject(instance), instance))
+	return &CommonServiceReconciler{Bootstrap: &bootstrap.Bootstrap{
+		Client: fc, Reader: fc,
+		Config: &rest.Config{Host: "https://test.invalid", Transport: transport},
+		CSData: apiv3.CSData{OperatorNs: instance.Namespace, CPFSNs: instance.Namespace, ServicesNs: instance.Namespace},
+	}}, instance
 }
 
-// newTestReconciler returns a CommonServiceReconciler backed by a fake client
-// and a minimal API server, with only the fields needed for ReconcileMasterCR
-// tests that do not require full ODLM / cert-manager infrastructure.
-func newTestReconciler(t *testing.T, srv *httptest.Server, objs ...apiv3.CommonService) *CommonServiceReconciler {
-	t.Helper()
-	builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
-	for i := range objs {
-		builder = builder.WithStatusSubresource(&objs[i]).WithRuntimeObjects(&objs[i])
-	}
-	fc := builder.Build()
-
-	cfg := &rest.Config{Host: srv.URL}
-
-	return &CommonServiceReconciler{
-		Bootstrap: &bootstrap.Bootstrap{
-			Client: fc,
-			Reader: fc,
-			Config: cfg,
-		},
+// Exercise the production certificate failure branch, including phase-update failure.
+func TestDeployCertManagerCRPreservesDeploymentError(t *testing.T) {
+	deploymentErr := errors.New("certificate discovery unavailable")
+	phaseErr := errors.New("status update unavailable")
+	for _, failPhaseUpdate := range []bool{false, true} {
+		name := "phase update succeeds"
+		if failPhaseUpdate {
+			name = "phase update fails"
+		}
+		t.Run(name, func(t *testing.T) {
+			discoveryCalled, phaseUpdateCalled := false, false
+			transport := statusTestTransport(func(*http.Request) (*http.Response, error) {
+				discoveryCalled = true
+				return nil, deploymentErr
+			})
+			hooks := interceptor.Funcs{SubResourceUpdate: func(ctx context.Context, c client.Client, subresource string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				phaseUpdateCalled = true
+				require.Equal(t, "status", subresource)
+				require.Equal(t, apiv3.CRFailed, obj.(*apiv3.CommonService).Status.Phase)
+				if failPhaseUpdate {
+					return phaseErr
+				}
+				return c.SubResource(subresource).Update(ctx, obj, opts...)
+			}}
+			r, instance := newStatusTestReconciler(t, transport, hooks)
+			err := r.deployCertManagerCR(context.Background(), instance)
+			require.ErrorIs(t, err, deploymentErr)
+			assert.True(t, discoveryCalled)
+			assert.True(t, phaseUpdateCalled)
+			if !failPhaseUpdate {
+				persisted := &apiv3.CommonService{}
+				require.NoError(t, r.Client.Get(context.Background(), client.ObjectKeyFromObject(instance), persisted))
+				assert.Equal(t, apiv3.CRFailed, persisted.Status.Phase)
+			}
+		})
 	}
 }
 
-// TestReconcileMasterCRErrorPathPreservesStatusErr is the regression test for
-// the statusErr variable-overwrite bug.
-//
-// Before the fix, the DeployCertManagerCR and !typeCorrect error paths wrote:
-//
-//	if statusErr = r.Bootstrap.DeployCertManagerCR(instance); statusErr != nil {
-//	    if statusErr = r.updatePhase(...); statusErr != nil { ... }
-//	    return ctrl.Result{}, statusErr   // returned nil when updatePhase succeeded!
-//	}
-//
-// The deferred condition-setter then saw statusErr == nil and wrote
-// type:Ready=True instead of type:Error, leaving phase:Failed but
-// conditions:Ready=True — the contradiction observed in the cluster.
-//
-// After the fix, updatePhase is called with a local `err` variable so the
-// outer statusErr always retains the original error.
-//
-// This test exercises the real ReconcileMasterCR code path. It drives the
-// reconcile into the !typeCorrect branch (which uses statusErr directly and
-// was fixed in the same commit), verifies that:
-//   - the reconcile returns the original error (not nil)
-//   - the deferred function wrote an Error condition, not Ready
-//   - the phase was set to Failed
-func TestReconcileMasterCRErrorPathPreservesStatusErr(t *testing.T) {
-	const (
-		ns   = "test-ns"
-		name = "common-service"
-	)
-
-	srv := minimalAPIServer(t)
-
-	instance := apiv3.CommonService{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       ns,
-			UID:             types.UID("uid-cs"),
-			ResourceVersion: "1",
-		},
-		Spec: apiv3.CommonServiceSpec{
-			License: apiv3.LicenseList{Accept: true},
-			// operatorNamespace == servicesNamespace: WatchNamespaces is empty,
-			// so the code checks for the servicesNamespace Namespace object.
-			// Leave it unset; the Namespace will be present in the fake store.
-		},
-	}
-
-	// The servicesNamespace Namespace must exist so the namespace-check does
-	// not short-circuit before reaching CheckClusterType.
-	svcNs := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
-
-	r := newTestReconciler(t, srv, instance)
-	// Add the Namespace to the fake store.
-	require.NoError(t, r.Client.Create(context.Background(), &svcNs))
-
-	// Point OperatorNs / ServicesNs at the test namespace so the reconcile
-	// does not try to look up unrelated objects.
-	r.Bootstrap.CSData.OperatorNs = ns
-	r.Bootstrap.CSData.ServicesNs = ns
-
-	// Fetch a live copy so resourceVersion is consistent.
-	live := &apiv3.CommonService{}
-	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, live))
-
-	// Invoke the real reconcile method.
-	result, err := r.ReconcileMasterCR(context.Background(), live)
-
-	// The reconcile must return a non-nil error.  Before the fix, updatePhase
-	// would overwrite statusErr with nil and the function returned (Result{}, nil).
-	require.Error(t, err,
-		"ReconcileMasterCR must return the original error, not nil, when it fails")
-	assert.Equal(t, result, ctrl.Result{})
-
-	// Read the persisted status.
+// Verify the real master reconcile's deferred condition handling separately.
+func TestReconcileMasterCRRecordsErrorCondition(t *testing.T) {
+	t.Setenv(constant.OperatorNamespaceEnvVar, "test-ns")
+	transport := statusTestTransport(func(req *http.Request) (*http.Response, error) {
+		body := `{"kind":"APIGroupList","apiVersion":"v1","groups":[]}`
+		if req.URL.Path == "/api" {
+			body = `{"kind":"APIVersions","apiVersion":"v1","versions":["v1"]}`
+		}
+		return &http.Response{StatusCode: http.StatusOK, Header: http.Header{"Content-Type": {"application/json"}}, Body: io.NopCloser(strings.NewReader(body)), Request: req}, nil
+	})
+	r, instance := newStatusTestReconciler(t, transport, interceptor.Funcs{})
+	// No ibm-cpp-config on a non-OCP cluster drives the cluster-type error branch.
+	_, err := r.ReconcileMasterCR(context.Background(), instance)
+	require.EqualError(t, err, "cluster type specified in the ibm-cpp-config isn't correct")
 	persisted := &apiv3.CommonService{}
-	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, persisted))
-
-	// Phase must be Failed.
-	assert.Equal(t, apiv3.CRFailed, persisted.Status.Phase,
-		"phase must be Failed after a reconcile error")
-
-	// The deferred condition-setter must have recorded an Error condition, NOT
-	// a Ready condition.  Before the fix, statusErr was nil so Ready=True was
-	// written instead.
+	require.NoError(t, r.Client.Get(context.Background(), client.ObjectKeyFromObject(instance), persisted))
+	assert.Equal(t, apiv3.CRFailed, persisted.Status.Phase)
 	var hasError, hasReady bool
 	for _, c := range persisted.Status.Conditions {
-		switch c.Type {
-		case apiv3.ConditionTypeError:
-			hasError = c.Status == corev1.ConditionTrue
-		case apiv3.ConditionTypeReady:
-			hasReady = c.Status == corev1.ConditionTrue
+		if c.Type == apiv3.ConditionTypeError && c.Status == corev1.ConditionTrue {
+			hasError = true
+			assert.Equal(t, err.Error(), c.Message)
+		}
+		if c.Type == apiv3.ConditionTypeReady && c.Status == corev1.ConditionTrue {
+			hasReady = true
 		}
 	}
-	assert.True(t, hasError,
-		"an Error condition must be set when ReconcileMasterCR returns an error")
-	assert.False(t, hasReady,
-		"Ready=True must NOT be set when ReconcileMasterCR returns an error (pre-fix bug)")
+	assert.True(t, hasError)
+	assert.False(t, hasReady)
 }

--- a/internal/controller/statuserr_test.go
+++ b/internal/controller/statuserr_test.go
@@ -16,15 +16,20 @@ package controllers
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
@@ -38,70 +43,156 @@ func init() {
 	_ = apiv3.AddToScheme(scheme.Scheme)
 }
 
-// newTestReconciler returns a CommonServiceReconciler backed by a fake client,
-// with only the fields needed for updatePhase and the status-deferred tests.
-func newTestReconciler(t *testing.T, objs ...apiv3.CommonService) *CommonServiceReconciler {
+// minimalAPIServer returns a *httptest.Server that answers Kubernetes discovery
+// requests with enough structure to make the client library happy but reports
+// no API groups (so isOpenShiftCluster returns false).  All other requests
+// return 404 so that CheckCRD and similar helpers fail gracefully.
+func minimalAPIServer(t *testing.T) *httptest.Server {
 	t.Helper()
-	runtimeObjs := make([]interface{}, len(objs))
-	for i := range objs {
-		runtimeObjs[i] = &objs[i]
-	}
+	mux := http.NewServeMux()
+
+	// /api — core group version list
+	mux.HandleFunc("/api", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(metav1.APIVersions{TypeMeta: metav1.TypeMeta{
+			Kind:       "APIVersions",
+			APIVersion: "v1",
+		}, Versions: []string{"v1"}})
+	})
+	// /apis — empty group list → isOpenShiftCluster returns false
+	mux.HandleFunc("/apis", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(metav1.APIGroupList{TypeMeta: metav1.TypeMeta{
+			Kind:       "APIGroupList",
+			APIVersion: "v1",
+		}})
+	})
+	// Everything else: 404
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newTestReconciler returns a CommonServiceReconciler backed by a fake client
+// and a minimal API server, with only the fields needed for ReconcileMasterCR
+// tests that do not require full ODLM / cert-manager infrastructure.
+func newTestReconciler(t *testing.T, srv *httptest.Server, objs ...apiv3.CommonService) *CommonServiceReconciler {
+	t.Helper()
 	builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
 	for i := range objs {
 		builder = builder.WithStatusSubresource(&objs[i]).WithRuntimeObjects(&objs[i])
 	}
 	fc := builder.Build()
+
+	cfg := &rest.Config{Host: srv.URL}
+
 	return &CommonServiceReconciler{
 		Bootstrap: &bootstrap.Bootstrap{
 			Client: fc,
 			Reader: fc,
+			Config: cfg,
 		},
 	}
 }
 
-// TestUpdatePhaseDoesNotOverwriteCallerError verifies the fix for the statusErr
-// variable overwrite bug.
+// TestReconcileMasterCRErrorPathPreservesStatusErr is the regression test for
+// the statusErr variable-overwrite bug.
 //
-// Before the fix, error paths used:
+// Before the fix, the DeployCertManagerCR and !typeCorrect error paths wrote:
 //
 //	if statusErr = r.Bootstrap.DeployCertManagerCR(instance); statusErr != nil {
 //	    if statusErr = r.updatePhase(...); statusErr != nil { ... }
-//	    return ctrl.Result{}, statusErr  // returns nil when updatePhase succeeds!
+//	    return ctrl.Result{}, statusErr   // returned nil when updatePhase succeeded!
 //	}
 //
-// The outer statusErr was overwritten by the updatePhase result, so the
-// deferred condition-setter saw nil and wrote Ready=True instead of Error.
+// The deferred condition-setter then saw statusErr == nil and wrote
+// type:Ready=True instead of type:Error, leaving phase:Failed but
+// conditions:Ready=True — the contradiction observed in the cluster.
 //
-// After the fix updatePhase is called with a local err variable so the outer
-// statusErr is never clobbered.
-func TestUpdatePhaseDoesNotOverwriteCallerError(t *testing.T) {
-	instance := apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
-		Name:            "common-service",
-		Namespace:       "test-ns",
-		UID:             types.UID("uid-cs"),
-		ResourceVersion: "1",
-	}}
+// After the fix, updatePhase is called with a local `err` variable so the
+// outer statusErr always retains the original error.
+//
+// This test exercises the real ReconcileMasterCR code path. It drives the
+// reconcile into the !typeCorrect branch (which uses statusErr directly and
+// was fixed in the same commit), verifies that:
+//   - the reconcile returns the original error (not nil)
+//   - the deferred function wrote an Error condition, not Ready
+//   - the phase was set to Failed
+func TestReconcileMasterCRErrorPathPreservesStatusErr(t *testing.T) {
+	const (
+		ns   = "test-ns"
+		name = "common-service"
+	)
 
-	r := newTestReconciler(t, instance)
-	ctx := context.Background()
+	srv := minimalAPIServer(t)
 
-	// Simulate the original (broken) pattern: statusErr is assigned by both
-	// the original failure AND the updatePhase call.
-	originalErr := errors.New("cert manager deployment failed")
-	statusErr := originalErr
+	instance := apiv3.CommonService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       ns,
+			UID:             types.UID("uid-cs"),
+			ResourceVersion: "1",
+		},
+		Spec: apiv3.CommonServiceSpec{
+			License: apiv3.LicenseList{Accept: true},
+			// operatorNamespace == servicesNamespace: WatchNamespaces is empty,
+			// so the code checks for the servicesNamespace Namespace object.
+			// Leave it unset; the Namespace will be present in the fake store.
+		},
+	}
 
-	// updatePhase writing Phase=Failed succeeds → with the old pattern this
-	// would have set statusErr = nil.
-	phaseErr := r.updatePhase(ctx, &instance, apiv3.CRFailed)
-	require.NoError(t, phaseErr, "updatePhase itself must succeed")
+	// The servicesNamespace Namespace must exist so the namespace-check does
+	// not short-circuit before reaching CheckClusterType.
+	svcNs := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
 
-	// The caller's error must be preserved — not overwritten.
-	// This is what the fix guarantees by using a local `err` variable.
-	assert.Equal(t, originalErr, statusErr,
-		"statusErr must not be overwritten when updatePhase succeeds")
+	r := newTestReconciler(t, srv, instance)
+	// Add the Namespace to the fake store.
+	require.NoError(t, r.Client.Create(context.Background(), &svcNs))
 
-	// Phase must have been persisted.
-	latest := &apiv3.CommonService{}
-	require.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: "common-service", Namespace: "test-ns"}, latest))
-	assert.Equal(t, apiv3.CRFailed, latest.Status.Phase)
+	// Point OperatorNs / ServicesNs at the test namespace so the reconcile
+	// does not try to look up unrelated objects.
+	r.Bootstrap.CSData.OperatorNs = ns
+	r.Bootstrap.CSData.ServicesNs = ns
+
+	// Fetch a live copy so resourceVersion is consistent.
+	live := &apiv3.CommonService{}
+	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, live))
+
+	// Invoke the real reconcile method.
+	result, err := r.ReconcileMasterCR(context.Background(), live)
+
+	// The reconcile must return a non-nil error.  Before the fix, updatePhase
+	// would overwrite statusErr with nil and the function returned (Result{}, nil).
+	require.Error(t, err,
+		"ReconcileMasterCR must return the original error, not nil, when it fails")
+	assert.Equal(t, result, ctrl.Result{})
+
+	// Read the persisted status.
+	persisted := &apiv3.CommonService{}
+	require.NoError(t, r.Client.Get(context.Background(), types.NamespacedName{Name: name, Namespace: ns}, persisted))
+
+	// Phase must be Failed.
+	assert.Equal(t, apiv3.CRFailed, persisted.Status.Phase,
+		"phase must be Failed after a reconcile error")
+
+	// The deferred condition-setter must have recorded an Error condition, NOT
+	// a Ready condition.  Before the fix, statusErr was nil so Ready=True was
+	// written instead.
+	var hasError, hasReady bool
+	for _, c := range persisted.Status.Conditions {
+		switch c.Type {
+		case apiv3.ConditionTypeError:
+			hasError = c.Status == corev1.ConditionTrue
+		case apiv3.ConditionTypeReady:
+			hasReady = c.Status == corev1.ConditionTrue
+		}
+	}
+	assert.True(t, hasError,
+		"an Error condition must be set when ReconcileMasterCR returns an error")
+	assert.False(t, hasReady,
+		"Ready=True must NOT be set when ReconcileMasterCR returns an error (pre-fix bug)")
 }

--- a/internal/controller/statuserr_test.go
+++ b/internal/controller/statuserr_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	apiv3 "github.com/IBM/ibm-common-service-operator/v4/api/v3"
+	"github.com/IBM/ibm-common-service-operator/v4/internal/controller/bootstrap"
+	odlm "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
+)
+
+func init() {
+	_ = olmv1alpha1.AddToScheme(scheme.Scheme)
+	_ = odlm.AddToScheme(scheme.Scheme)
+	_ = apiv3.AddToScheme(scheme.Scheme)
+}
+
+// newTestReconciler returns a CommonServiceReconciler backed by a fake client,
+// with only the fields needed for updatePhase and the status-deferred tests.
+func newTestReconciler(t *testing.T, objs ...apiv3.CommonService) *CommonServiceReconciler {
+	t.Helper()
+	runtimeObjs := make([]interface{}, len(objs))
+	for i := range objs {
+		runtimeObjs[i] = &objs[i]
+	}
+	builder := fake.NewClientBuilder().WithScheme(scheme.Scheme)
+	for i := range objs {
+		builder = builder.WithStatusSubresource(&objs[i]).WithRuntimeObjects(&objs[i])
+	}
+	fc := builder.Build()
+	return &CommonServiceReconciler{
+		Bootstrap: &bootstrap.Bootstrap{
+			Client: fc,
+			Reader: fc,
+		},
+	}
+}
+
+// TestUpdatePhaseDoesNotOverwriteCallerError verifies the fix for the statusErr
+// variable overwrite bug.
+//
+// Before the fix, error paths used:
+//
+//	if statusErr = r.Bootstrap.DeployCertManagerCR(instance); statusErr != nil {
+//	    if statusErr = r.updatePhase(...); statusErr != nil { ... }
+//	    return ctrl.Result{}, statusErr  // returns nil when updatePhase succeeds!
+//	}
+//
+// The outer statusErr was overwritten by the updatePhase result, so the
+// deferred condition-setter saw nil and wrote Ready=True instead of Error.
+//
+// After the fix updatePhase is called with a local err variable so the outer
+// statusErr is never clobbered.
+func TestUpdatePhaseDoesNotOverwriteCallerError(t *testing.T) {
+	instance := apiv3.CommonService{ObjectMeta: metav1.ObjectMeta{
+		Name:            "common-service",
+		Namespace:       "test-ns",
+		UID:             types.UID("uid-cs"),
+		ResourceVersion: "1",
+	}}
+
+	r := newTestReconciler(t, instance)
+	ctx := context.Background()
+
+	// Simulate the original (broken) pattern: statusErr is assigned by both
+	// the original failure AND the updatePhase call.
+	originalErr := errors.New("cert manager deployment failed")
+	statusErr := originalErr
+
+	// updatePhase writing Phase=Failed succeeds → with the old pattern this
+	// would have set statusErr = nil.
+	phaseErr := r.updatePhase(ctx, &instance, apiv3.CRFailed)
+	require.NoError(t, phaseErr, "updatePhase itself must succeed")
+
+	// The caller's error must be preserved — not overwritten.
+	// This is what the fix guarantees by using a local `err` variable.
+	assert.Equal(t, originalErr, statusErr,
+		"statusErr must not be overwritten when updatePhase succeeds")
+
+	// Phase must have been persisted.
+	latest := &apiv3.CommonService{}
+	require.NoError(t, r.Client.Get(ctx, types.NamespacedName{Name: "common-service", Namespace: "test-ns"}, latest))
+	assert.Equal(t, apiv3.CRFailed, latest.Status.Phase)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The fix enforces only the CommonService CR named common-service (the master CR) may ever be the controller owner of shared resources, regardless of which CR happens to be reconciling at any given moment.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/70051

**What  changed**:
1. `addOwnerReference` (init.go)
Before building the owner reference, the function now checks whether the reconciling instance is the master CR. If it is not, it fetches `common-service` from the API server and uses its `Name` and `UID` instead. This means no secondary CR can ever become an owner going forward, no matter which reconcile loop runs first. If the master CR is not found yet, ownership is silently skipped rather than blocking the reconcile.

2. `EnsureControllerOwnerReference` (ownerreference.go)
When the resource already carries im-common-service as its controller, the master CR needs to reclaim it. This function now allows the incoming owner to replace an existing controller reference when both the old and new controller are the same Kind (CommonService). 
